### PR TITLE
Ionization

### DIFF
--- a/carsus/io/nist/ionization.py
+++ b/carsus/io/nist/ionization.py
@@ -1,0 +1,210 @@
+"""
+Input module for the NIST Ionization Energies database
+http://physics.nist.gov/PhysRefData/ASD/ionEnergy.html
+"""
+
+import requests
+import pandas as pd
+from bs4 import BeautifulSoup
+from StringIO import StringIO
+from astropy import units as u
+from uncertainties import ufloat_fromstr
+from carsus.model import DataSource, Ion, IonizationEnergy
+from carsus.io.base import BaseParser, BaseIngester
+
+IONIZATION_ENERGIES_URL = 'http://physics.nist.gov/cgi-bin/ASD/ie.pl'
+
+
+def download_ionization_energies(spectra='h-uuh', e_out=0, e_unit=1, format_=1, at_num_out=True, sp_name_out=False,
+                                 ion_charge_out=True, el_name_out=False, seq_out=False, shells_out=True,
+                                 conf_out=False, level_out=True, ion_conf_out=False, unc_out=True, biblio=False):
+    """
+        Downloader function for the Ionization Energies Data from the NIST Atomic Spectra Database
+
+
+        Parameters
+        ----------
+        spectra: str
+            (default value = 'h-uuh')
+
+        Returns
+        -------
+        str
+            Preformatted text data
+
+        """
+    data = {'spectra': spectra, 'units': e_unit,
+            'format': format_, 'at_num_out': at_num_out, 'sp_name_out': sp_name_out,
+            'ion_charge_out': ion_charge_out, 'el_name_out': el_name_out,
+            'seq_out': seq_out, 'shells_out': shells_out, 'conf_out': conf_out,
+            'level_out': level_out, 'ion_conf_out': ion_conf_out, 'e_out': e_out,
+            'unc_out': unc_out, 'biblio': biblio}
+
+    data = {k: v for k, v in data.iteritems() if v is not False}
+
+    print "Downloading ionization energies data from http://physics.nist.gov/PhysRefData/ASD/ionEnergy.html"
+    r = requests.post(IONIZATION_ENERGIES_URL, data=data)
+    return r.text
+
+
+class NISTIonizationEnergiesParser(BaseParser):
+    """
+        Class for parsers for the Ionization Energies Data from the NIST Atomic Spectra Database
+
+        Attributes
+        ----------
+        base_df : pandas.DataFrame
+
+        grammar : pyparsing.ParseElement
+            (default value = isotope)
+
+        columns : list of str
+            (default value = COLUMNS)
+
+        Methods
+        -------
+        load(input_data)
+            Parses the input data and stores the results in the `base_df` attribute
+
+        prepare_ion_energies_df()
+            Returns a new dataframe created from `base_df` that contains ionization energies data
+
+    """
+
+    def load(self, input_data):
+        soup = BeautifulSoup(input_data, 'html5lib')
+        pre_tag = soup.pre
+        for a in pre_tag.find_all("a"):
+            a = a.sting
+        text_data = pre_tag.get_text()
+        column_names = ['atomic_number', 'ion_charge', 'ground_shells', 'ground_level', 'ionization_energy_str']
+        base_df = pd.read_csv(StringIO(text_data), sep='|', header=None,
+                         usecols=range(5), names=column_names, skiprows=3, skipfooter=1)
+        for column in ['ground_shells', 'ground_level', 'ionization_energy_str']:
+                base_df[column] = base_df[column].map(lambda x: x.strip())
+        self.base_df = base_df
+
+    def prepare_ion_energies_df(self):
+        """ Returns a new dataframe created from `base_df` that contains ionization energies data """
+        ion_energies_df = self.base_df.copy()
+
+        def parse_ion_energy_str(row):
+            ion_energy_str = row['ionization_energy_str']
+            if ion_energy_str == '':
+                return None
+            if ion_energy_str.startswith('('):
+                method = 'theoretical'
+                ion_energy_str = ion_energy_str.strip('(').replace('))', ')')
+            elif ion_energy_str.startswith('['):
+                method = 'interpolated'
+                ion_energy_str = ion_energy_str.strip('[]')
+            else:
+                method = 'measured'
+            # ToDo: Some value are given without uncertainty. How to be with them?
+            ion_energy = ufloat_fromstr(ion_energy_str)
+            return pd.Series([ion_energy.nominal_value, ion_energy.std_dev, method])
+
+        ion_energies_df[['ionization_energy_value', 'ionization_energy_uncert',
+                      'ionization_energy_method']] = ion_energies_df.apply(parse_ion_energy_str, axis=1)
+        ion_energies_df.drop('ionization_energy_str', axis=1, inplace=True)
+        ion_energies_df.set_index(['atomic_number', 'ion_charge'], inplace=True)
+        return ion_energies_df
+
+
+class NISTIonizationEnergiesIngester(BaseIngester):
+    """
+        Class for ingesters for the Ionization Energies Data from the NIST Atomic Spectra Database
+
+        Attributes
+        ----------
+        parser : BaseParser instance
+            (default value = NISTIonizationEnergiesParser())
+
+        downloader : function
+            (default value = download_ionization_energies)
+
+        ds_short_name : str
+            (default value = "nist-asd-ionenergy")
+
+        Methods
+        -------
+        download()
+            Downloads the data with the 'downloader' and loads the `parser` with it
+
+        ingest(session)
+            Persists the downloaded data into the database
+
+        """
+    ds_short_name = "nist-asd-ionenergy"
+
+    def __init__(self, downloader=download_ionization_energies, parser=None):
+        if parser is None:
+            parser = NISTIonizationEnergiesParser()
+        super(NISTIonizationEnergiesIngester, self). \
+            __init__(parser=parser,
+                     downloader=downloader)
+
+    def download(self, spectra='h-uuh'):
+        data = self.downloader(spectra=spectra)
+        self.parser(data)
+
+    def ingest(self, session):
+        """ *Only* ingests ions and ionization energies *for now* """
+        print "Ingesting ionization energies data"
+        ion_energies_df = self.parser.prepare_ion_energies_df()
+        data_source = DataSource.as_unique(session, short_name=self.ds_short_name)
+
+        #  Select existing ions and ionization energies
+        ion_energies_subq = session.query(IonizationEnergy).\
+            filter(IonizationEnergy.data_source == data_source).subquery()
+        exist_ions = session.query(Ion).\
+            outerjoin(ion_energies_subq, Ion.ionization_energies).all()
+        exist_ions_indices = list()
+
+        for ion in exist_ions:
+
+            #  Locate the corresponding row in the dataframe and update ion
+            index = (ion.atomic_number, ion.ion_charge)
+            row = ion_energies_df.loc[index]
+            ion.ground_shells = row['ground_shells']
+            ion.ground_level = row['ground_level']
+
+            # If the ionization energy value for this ion is present in the dataframe
+            # than update it as well
+            if pd.notnull(row['ionization_energy_value']):
+
+                # Create a new instance
+                if not ion.ionization_energies:
+                    ion.ionization_energies = [
+                        IonizationEnergy(quantity=row['ionization_energy_value']*u.eV,
+                                         data_source=data_source,
+                                         std_dev=row['ionization_energy_uncert'],
+                                         method=row['ionization_energy_method'])
+                    ]
+                # Or update the old one
+                else:
+                    ion_energy = ion.ionization_energies[0]  # there can be at most 1 quantity here
+                    ion_energy.quantity = row['ionization_energy_value']*u.eV
+                    ion_energy.std_dev = row['ionization_energy_uncert']
+                    ion_energy.method = row['ionization_energy_method']
+
+            exist_ions_indices.append(index)
+
+        nonexist_ion_energies_df = ion_energies_df.iloc[
+            ~ion_energies_df.index.isin(exist_ions_indices)
+        ]
+
+        # Create new instances for ions that were not present in the database
+        for index, row in nonexist_ion_energies_df.iterrows():
+            atomic_number, ion_charge = index
+            new_ion = Ion(atomic_number=atomic_number, ion_charge=ion_charge,
+                          ground_shells=row['ground_shells'],
+                          ground_level=row['ground_level'])
+            if pd.notnull(row['ionization_energy_value']):
+                new_ion.ionization_energies = [
+                    IonizationEnergy(quantity=row['ionization_energy_value']*u.eV,
+                                     data_source=data_source,
+                                     std_dev=row['ionization_energy_uncert'],
+                                     method=row['ionization_energy_method'])
+                ]
+            session.add(new_ion)

--- a/carsus/io/tests/test_nist_ionization.py
+++ b/carsus/io/tests/test_nist_ionization.py
@@ -1,0 +1,117 @@
+import pytest
+import pandas as pd
+from pandas.util.testing import assert_series_equal
+from astropy import units as u
+from numpy.testing import assert_almost_equal
+from sqlalchemy import and_
+from sqlalchemy.orm import joinedload
+from carsus.model import Ion, Atom, DataSource, IonizationEnergy
+from carsus.io.nist.ionization import download_ionization_energies, NISTIonizationEnergiesParser,\
+    NISTIonizationEnergiesIngester
+
+
+test_data = """
+<h2> Be specta </h2>
+<pre>
+--------------------------------------------------------------------------------------------
+At. num | Ion Charge | Ground Shells | Ground Level |      Ionization Energy (a) (eV)      |
+--------|------------|---------------|--------------|--------------------------------------|
+      4 |          0 | 1s2.2s2       | 1S0          |                 9.3226990(70)        |
+      4 |         +1 | 1s2.2s        | 2S<1/2>      |                18.211153(40)         |
+      4 |         +2 | 1s2           | 1S0          |   <a class=bal>[</a>153.8961980(40)<a class=bal>]</a>       |
+      4 |         +3 | 1s            | 2S<1/2>      |   <a class=bal>(</a>217.7185766(10)<a class=bal>)</a>       |
+--------------------------------------------------------------------------------------------
+</pre>
+"""
+
+expected_at_num = [4, 4, 4, 4]
+
+expected_ion_charge = [0, 1, 2, 3]
+
+expected_indices = zip(expected_at_num, expected_ion_charge)
+
+expected_ground_shells = ('ground_shells',
+                          ['1s2.2s2', '1s2.2s', '1s2', '1s']
+                          )
+
+expected_ground_level = ('ground_level',
+                         ['1S0', '2S<1/2>', '1S0', '2S<1/2>']
+                         )
+
+expected_ion_energy_value = ('ionization_energy_value',
+                            [9.3226990, 18.211153, 153.8961980, 217.7185766]
+                            )
+
+expected_ion_energy_uncert = ('ionization_energy_uncert',
+                             [7e-6, 4e-5, 4e-6, 1e-6]
+                             )
+
+expected_ion_energy_method = ('ionization_energy_method',
+                             ['measured', 'measured', 'interpolated', 'theoretical']
+                             )
+
+
+@pytest.fixture
+def ion_energies_parser():
+    parser = NISTIonizationEnergiesParser(input_data=test_data)
+    return parser
+
+
+@pytest.fixture
+def ion_energies_df(ion_energies_parser):
+    return ion_energies_parser.prepare_ion_energies_df()
+
+
+@pytest.fixture
+def ion_energies_ingester():
+    ingester = NISTIonizationEnergiesIngester()
+    ingester.parser(test_data)
+    return ingester
+
+@pytest.fixture(params=[expected_ground_shells,
+                        expected_ground_level, expected_ion_energy_value,
+                        expected_ion_energy_uncert, expected_ion_energy_method])
+def expected_series(request):
+    index = pd.MultiIndex.from_tuples(tuples=expected_indices,
+                                       names=['atomic_number', 'ion_charge'])
+    name, data = request.param
+    return pd.Series(data=data, name=name, index=index)
+
+
+def test_prepare_ion_energies_df(ion_energies_df, expected_series):
+    series = ion_energies_df[expected_series.name]
+    assert_series_equal(series, expected_series)
+
+
+@pytest.mark.parametrize("index, value, uncert",
+                         zip(expected_indices,
+                             expected_ion_energy_value[1],
+                             expected_ion_energy_uncert[1]))
+def test_ingest_test_data(index, value, uncert, test_session, ion_energies_ingester):
+    ds = DataSource.as_unique(test_session, short_name="nist-asd-ionenergy")
+    Be = test_session.query(Atom).get(4)
+    Be_0 = Ion(atom=Be, ion_charge=0)
+    Be_1 = Ion(atom=Be, ion_charge=1)
+    Be_0.ionization_energies = [
+        IonizationEnergy(quantity=13.6180540 * u.eV, data_source=ds, std_dev=6e-6)
+    ]
+
+    test_session.add_all([ds, Be_0, Be_1])
+
+    ion_energies_ingester.ingest(test_session)
+
+    atomic_number, ion_charge = index
+    q = test_session.query(Ion).options(joinedload('ionization_energies')).\
+            filter(and_(Ion.atomic_number==atomic_number,
+                        Ion.ion_charge==ion_charge))
+    for ion in q:
+        ion_energy = ion.ionization_energies[0]
+        assert_almost_equal(ion_energy.quantity.value, value)
+        assert_almost_equal(ion_energy.std_dev, uncert)
+
+
+@pytest.mark.remote_data
+def test_ingest_nist_asd_ion_data(test_session):
+    ingester = NISTIonizationEnergiesIngester()
+    ingester.download()
+    ingester.ingest(test_session)

--- a/carsus/model/__init__.py
+++ b/carsus/model/__init__.py
@@ -1,2 +1,2 @@
-from .atomic import Atom, AtomicQuantity, AtomicWeight, DataSource
+from .atomic import Atom, AtomicQuantity, AtomicWeight, DataSource, Ion, IonizationEnergy
 from .meta import Base, setup

--- a/carsus/model/meta/__init__.py
+++ b/carsus/model/meta/__init__.py
@@ -1,3 +1,4 @@
 from .types import DBQuantity
 from .orm import UniqueMixin
 from .base import Base, setup
+from .schema import QuantityMixin

--- a/carsus/model/meta/schema.py
+++ b/carsus/model/meta/schema.py
@@ -1,0 +1,35 @@
+from sqlalchemy import Column, Integer, Float, ForeignKey
+from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.orm import relationship
+from ..meta.types import DBQuantity
+
+
+class QuantityMixin(object):
+
+    id = Column(Integer, primary_key=True)
+
+    _value = Column(Float, nullable=False)
+    std_dev = Column(Float)
+
+    unit = None
+
+    # Public interface for value is via `.quantity` accessor
+    @hybrid_property
+    def quantity(self):
+        return DBQuantity(self._value, self.unit)
+
+    @quantity.setter
+    def quantity(self, qty):
+        self._value = qty.to(self.unit).value
+
+    @declared_attr
+    def data_source_id(cls):
+        return Column(Integer, ForeignKey('data_source.id'), nullable=False)
+
+    @declared_attr
+    def data_source(cls):
+        return relationship("DataSource")
+
+    def __repr__(self):
+        return "<Quantity: {0} {1}>".format(self._value, self.unit)


### PR DESCRIPTION
SQLAlchemy model
=============
- Proposed schema:
![ionization](https://cloud.githubusercontent.com/assets/8950027/15328867/9251353a-1c67-11e6-85ec-a8ee228f4592.png)

- I used a little different approach for `IonizationEnergy` . Instead of subclassing it from some base class, I used a mixin class to give it the 'quantity' functionality. `QuantityMixin` is defined in [carsus/model/meta/schema.py](https://github.com/tardis-sn/carsus/blob/3fedc42f565fcb3f2c2a071d82de6ffb0372627c/carsus/model/meta/schema.py):
```
class IonizationEnergy(QuantityMixin, Base):
    __tablename__ = "ionization_energy"

    ion_id = Column(Integer, ForeignKey('ion.id'), nullable=False)
    unit = u.eV
    method = Column(String(15))

    __table_args__ = (UniqueConstraint('ion_id', 'data_source_id'),)
```

- Also I think it is more practical to have a direct relationship to `ionization_energies` in ions:
```
    ionization_energies = relationship("IonizationEnergy",
                                       backref='ion',
                                       cascade="all, delete-orphan")
```
rather than to all quantities, like it is now in `Atom`
```
   quantities = relationship("AtomicQuantity",
                    backref='atom',
                    cascade='all, delete-orphan')
```
- The `Ion` class inherits from `UniqueMixin`, so one can easily get an existing ion or create a new one:
```
Ion.as_unique(foo_session, atomic_number=8, ion_charge=1)
```

Downloader, parser and ingester
=========================
Are defined in `carsus/io/nist/ionization.py`.
Everything is similar to the previous case and some ideas are taken from `tardisatomic`.
Special care was taken to insert and update ions and ionization energies properly in the `ingest` method.







