### PR TITLE
Chianti levels (not to merge)

### DIFF
--- a/carsus/io/chiantidb.py
+++ b/carsus/io/chiantidb.py
@@ -1,0 +1,123 @@
+import chianti.core as ch
+import pandas as pd
+import numpy as np
+import pickle
+import os
+import re
+from numpy.testing import assert_almost_equal
+from astropy import units as u
+from carsus.model import DataSource, Ion, Level, LevelChiantiData, LevelEnergy
+
+if os.getenv('XUVTOP'):
+    masterlist_ions_path = os.path.join(
+        os.getenv('XUVTOP'), "masterlist", "masterlist_ions.pkl"
+    )
+
+    masterlist_ions_file = open(masterlist_ions_path, 'rb')
+    masterlist_ions = pickle.load(masterlist_ions_file).keys()
+    # Exclude the "d" ions for now
+    masterlist_ions = [_ for _ in masterlist_ions
+                       if re.match("[a-z]+_\d+", _)]
+
+else:
+    print "Chianti database is not installed!"
+    masterlist_ions = list()
+
+
+class ChiantiReader(object):
+
+    def __init__(self, ions_list):
+        # ToDo write a parser for Spectral Notation
+        self.ions_list = list()
+        for ion in ions_list:
+            if ion in self.masterlist_ions:
+                self.ions_list.append(ion)
+            else:
+                print("Ion {0} is not available".format(ion))
+
+    @property
+    def ions(self):
+        return [ch.ion(_) for _ in self.ions_list]
+
+    masterlist_ions = masterlist_ions
+
+    elvlc_dict = {'lvl': 'level_index',
+                  'ecm': 'energy',
+                  'ecmth': 'energy_theoretical',
+                  'j': 'J',
+                  'spd': 'L',
+                  'spin': 'spin_mult',
+                  'term': 'configuration',
+                  'label': 'label'}
+
+    def _read_ion_levels(self, ion):
+
+        if not hasattr(ion, 'Elvlc'):
+            return None
+
+        levels_dict = {}
+
+        for key, col_name in self.elvlc_dict.iteritems():
+            levels_dict[col_name] = ion.Elvlc.get(key)
+
+        # Convert energies from cm**-1 to eV
+        for key in ['energy', 'energy_theoretical']:
+            levels_dict[key] = u.Unit('cm-1').to('eV', levels_dict[key], equivalencies=u.spectral())
+
+        # Check that ground level energy is 0
+        try:
+            for key in ['energy', 'energy_theoretical']:
+                assert_almost_equal(levels_dict[key][0], 0)
+        except AssertionError:
+            raise ValueError('Level 0 energy is not 0.0')
+
+        levels_df = pd.DataFrame(levels_dict)
+        levels_df.replace(r'\s+', np.nan, regex=True, inplace=True)  # Replace space with NaN
+        levels_df["atomic_number"] = ion.Z
+        levels_df["ionization_stage"] = ion.Ion
+        levels_df.set_index(["atomic_number", "ionization_stage", "level_index"], inplace=True)
+
+        # Keep only bound levels
+        levels_df = levels_df[levels_df['energy'] < ion.Ip]
+
+        return levels_df
+
+    def read_levels(self):
+        levels_df = pd.DataFrame()
+        for ion in self.ions:
+            df = self._read_ion_levels(ion)
+            levels_df = levels_df.append(df)  # None is treated as an empty dataframe
+        return levels_df
+
+
+def get_level_term(spin_mult, L, conf):
+    # ToDo: determine parity from configuration
+    term = str(spin_mult) + L;
+    return term
+
+
+class ChiantiIngestor(object):
+
+    def __init__(self, session, ds_short_name="ch_v8.0"):
+        self.session = session
+        self.ds = DataSource.as_unique(self.session, short_name=ds_short_name)
+
+    def ingest_levels(self, levels_df):
+
+        for index, row in levels_df.iterrows():
+            atomic_number, ioniz_stage, level_index = index
+            ion = Ion.as_unique(self.session, atomic_number=atomic_number, ion_charge=ioniz_stage-1)
+            self.session.commit()
+            term = get_level_term(row["spin_mult"], row["L"], row["configuration"])
+            level = Level.as_unique(self.session, ion=ion, configuration=row["configuration"],
+                                        term=term, J=row["J"])
+            self.session.commit()
+            # ToDo: check if data from this source already exists; update it in this case
+            level_data = LevelChiantiData(
+                level=level, data_source=self.ds, ch_index=level_index, ch_label=row["label"],
+                energies=[
+                    LevelEnergy(quantity=row["energy"]*u.eV, method="m"),
+                    LevelEnergy(quantity=row["energy_theoretical"]*u.eV, method="th")
+                ]
+            )
+            self.session.add(level_data)

--- a/carsus/io/tests/test_chiantidb.py
+++ b/carsus/io/tests/test_chiantidb.py
@@ -1,5 +1,5 @@
 import pytest
-from ..chiantidb import ChiantiReader, ChiantiIngestor, masterlist_ions
+from ..chiantidb import ChiantiReader, ChiantiIngester, masterlist_ions
 from carsus.model import Level, LevelEnergy, Ion
 from numpy.testing import assert_almost_equal
 
@@ -27,5 +27,5 @@ def test_chianti_ingest(test_session):
     ions = masterlist_ions[:3]  # ['ne_2', 'cl_4', 'ne_6']
     rdr = ChiantiReader(ions)
     levels_df = rdr.read_levels()
-    ingester = ChiantiIngestor(test_session)
+    ingester = ChiantiIngester(test_session)
     ingester.ingest_levels(levels_df)

--- a/carsus/io/tests/test_chiantidb.py
+++ b/carsus/io/tests/test_chiantidb.py
@@ -1,0 +1,31 @@
+import pytest
+from ..chiantidb import ChiantiReader, ChiantiIngestor, masterlist_ions
+from carsus.model import Level, LevelEnergy, Ion
+from numpy.testing import assert_almost_equal
+
+
+@pytest.fixture
+def chianti_rdr():
+    return ChiantiReader(["si_2", "si_3"])
+
+
+def test_chianti_reader_init(chianti_rdr):
+    assert len(chianti_rdr.ions) == 2
+
+
+def test_chianti_reader_init_w_bad_ions():
+    chianti_rdr = ChiantiReader(["si_2", "si_3", "au_1"])
+    assert len(chianti_rdr.ions) == 2
+
+
+def test_chianti_reader_read_levels(chianti_rdr):
+    levels_df = chianti_rdr.read_levels()
+    assert_almost_equal(levels_df.loc[14,3,1]['energy'], 0)
+
+
+def test_chianti_ingest(test_session):
+    ions = masterlist_ions[:3]  # ['ne_2', 'cl_4', 'ne_6']
+    rdr = ChiantiReader(ions)
+    levels_df = rdr.read_levels()
+    ingester = ChiantiIngestor(test_session)
+    ingester.ingest_levels(levels_df)

--- a/carsus/model/__init__.py
+++ b/carsus/model/__init__.py
@@ -1,2 +1,3 @@
-from .atomic import Atom, AtomicQuantity, AtomicWeight, DataSource
+from .atomic import Atom, AtomicQuantity, AtomicWeight, DataSource,\
+    Ion, Level, LevelEnergy,  LevelData, LevelChiantiData
 from .meta import Base, setup

--- a/carsus/model/atomic.py
+++ b/carsus/model/atomic.py
@@ -1,9 +1,10 @@
-from .meta import Base, UniqueMixin, DBQuantity
-
+from .meta import Base, UniqueMixin, DBQuantity, Decimal10, QuantityMixin
+import re
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy import Column, Integer, String, Float, ForeignKey, UniqueConstraint, and_
+from sqlalchemy import Column, Integer, String, Float, ForeignKey,\
+    UniqueConstraint, ForeignKeyConstraint, and_, cast, case
 from astropy import units as u
 
 
@@ -78,6 +79,140 @@ class AtomicWeight(AtomicQuantity):
         'polymorphic_identity':'atomic_weight'
     }
 
+
+class Ion(UniqueMixin, Base):
+    __tablename__ = "ion"
+
+    @classmethod
+    def unique_hash(cls, atomic_number, ion_charge, *args, **kwargs):
+        return "ion:{0},{1}".format(atomic_number, ion_charge)
+
+    @classmethod
+    def unique_filter(cls, query, atomic_number, ion_charge, *args, **kwargs):
+        return query.filter(and_(Ion.atomic_number == atomic_number,
+                                 Ion.ion_charge == ion_charge))
+
+    id = Column(Integer, primary_key=True)
+    atomic_number = Column(Integer, ForeignKey('atom.atomic_number'), nullable=False)
+    ion_charge = Column(Integer, nullable=False)
+
+    # ground_level_id = Column(Integer, ForeignKey('level.id'))
+
+    # ionization_energies = relationship("IonizationEnergy",
+    #                                    backref='ion',
+    #                                    cascade="all, delete-orphan")
+
+    levels = relationship("Level",
+                          backref='ion',
+                          cascade="all, delete-orphan")
+
+    atom = relationship("Atom", backref='ions')
+
+    __table_args__ = (UniqueConstraint('atomic_number', 'ion_charge'),)
+
+    def __repr__(self):
+        return "<Ion {0} +{1}>".format(self.atom.symbol, self.ion_charge)
+
+
+class Level(UniqueMixin, Base):
+    __tablename__ = "level"
+
+    id = Column(Integer, primary_key=True)
+    ion_id = Column(Integer, ForeignKey('ion.id'), nullable=False)
+    configuration = Column(String(50))
+    L = Column(String(2))
+    J = Column(Decimal10)
+    parity = Column(Integer)
+    spin_mult = Column(Integer)  # 2*S + 1
+
+    @classmethod
+    def unique_hash(cls, configuration, term, *args, **kwargs):
+        return "lvl:{0},{1}".format(configuration, term)
+
+    @classmethod
+    def unique_filter(cls, query, ion, configuration, term, J, *args, **kwargs):
+        return query.filter(and_(Level.ion == ion,
+                                 Level.configuration == configuration,
+                                 Level.term == term,
+                                 Level.J == J))
+
+    @hybrid_property
+    def term(self):
+        if self.parity == 0:
+            return str(self.spin_mult) + self.L
+        else:
+            return str(self.spin_mult) + self.L + '*'
+
+    @term.setter
+    def term(self, value):
+        value_dict = re.match(r"(?P<spin_mult>\d+)(?P<L>[A-Z]+)(?P<parity>[*])?", value).groupdict()
+        self.spin_mult = value_dict["spin_mult"]
+        self.L = value_dict["L"]
+        self.parity = 1 if value_dict["parity"] else 0
+
+
+    @term.expression
+    def term(cls):
+        return case([
+            (cls.parity == 0, cast(cls.spin_mult, String) + cls.L),
+        ], else_=(cast(cls.spin_mult, String) + cls.L + '*'))
+
+    @hybrid_property
+    def g(self):
+        return int(2*self.J + 1)
+
+    @g.expression
+    def g(cls):
+        return (2*cast(cls.J, Integer) + 10)/10
+
+    __table_args__ = (
+        UniqueConstraint('ion_id', 'configuration', 'L', 'J', 'spin_mult'),
+    )
+
+
+class LevelData(Base):
+    __tablename__ = "level_data"
+
+    id = Column(Integer, primary_key=True)
+    level_id = Column(Integer, ForeignKey('level.id'))
+    data_source_id = Column(Integer, ForeignKey('data_source.id'))
+    type = Column(String(20))
+
+    energies = relationship("LevelEnergy")
+    level = relationship("Level", backref="level_data")
+    data_source = relationship("DataSource", backref="level_data")
+
+    __mapper_args__ = {
+        'polymorphic_identity': 'data',
+        'polymorphic_on': type
+    }
+
+
+class LevelChiantiData(LevelData):
+    __tablename__ = "level_chianti_data"
+
+    id = Column(Integer, ForeignKey('level_data.id'), primary_key=True)
+    ch_index = Column(Integer)
+    ch_label = Column(String(10))
+
+    __mapper_args__ = {
+        'polymorphic_identity': 'chianti'
+    }
+
+
+class LevelEnergy(QuantityMixin, Base):
+    __tablename__ = "level_energy"
+
+    level_id = Column(Integer)
+    data_source_id = Column(Integer)
+
+    unit = u.eV
+
+    __table_args__ = (
+        ForeignKeyConstraint(['level_id', 'data_source_id'],
+            ['level_data.level_id', 'level_data.data_source_id']),)
+
+# UniqueConstraint('level_id', 'data_source_id', 'method')
 
 class DataSource(UniqueMixin, Base):
     __tablename__ = "data_source"

--- a/carsus/model/meta/__init__.py
+++ b/carsus/model/meta/__init__.py
@@ -1,3 +1,4 @@
-from .types import DBQuantity
+from .types import DBQuantity, Decimal10
 from .orm import UniqueMixin
 from .base import Base, setup
+from .schema import QuantityMixin

--- a/carsus/model/meta/schema.py
+++ b/carsus/model/meta/schema.py
@@ -1,0 +1,28 @@
+from sqlalchemy import Column, Integer, Float, String
+from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.orm import relationship
+from ..meta.types import DBQuantity
+
+
+class QuantityMixin(object):
+
+    id = Column(Integer, primary_key=True)
+
+    _value = Column(Float, nullable=False)
+    uncert = Column(Float)
+    method = Column(String(15))
+
+    unit = None
+
+    # Public interface for value is via `.quantity` accessor
+    @hybrid_property
+    def quantity(self):
+        return DBQuantity(self._value, self.unit)
+
+    @quantity.setter
+    def quantity(self, qty):
+        self._value = qty.to(self.unit).value
+
+    def __repr__(self):
+        return "<Quantity: {0} {1}>".format(self._value, self.unit)

--- a/carsus/model/meta/types.py
+++ b/carsus/model/meta/types.py
@@ -1,10 +1,22 @@
 """Types and SQL constructs specific to carsus"""
 
+import numpy as np
 from sqlalchemy.sql.expression import ClauseElement
+from sqlalchemy.types import Integer, TypeDecorator
 from sqlalchemy.orm.attributes import QueryableAttribute
 from astropy.units import Quantity, Unit, dimensionless_unscaled, UnitsError
 from astropy.units.quantity_helper import helper_twoarg_comparison, UFUNC_HELPERS
-import numpy as np
+from decimal import Decimal
+
+
+class Decimal10(TypeDecorator):
+    impl = Integer
+
+    def process_bind_param(self, value, dialect):
+        return int(value*10)
+
+    def process_result_value(self, value, dialect):
+        return Decimal(value)/Decimal('10')
 
 
 class DBQuantity(Quantity):

--- a/carsus/model/tests/conftest.py
+++ b/carsus/model/tests/conftest.py
@@ -3,7 +3,8 @@ import pytest
 import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
-from carsus.model import Base, Atom, DataSource, AtomicWeight
+from carsus.model import Base, Atom, DataSource, AtomicWeight,\
+    Ion,  Level, LevelEnergy, LevelData, LevelChiantiData
 from astropy import units as u
 
 data_dir = os.path.join(os.path.dirname(__file__), 'data')
@@ -30,11 +31,12 @@ def foo_engine():
 
     # atoms
     H = Atom(atomic_number=1, symbol='H')
-    O = Atom(atomic_number=8, symbol='O')
+    Si = Atom(atomic_number=14, symbol='Si')
 
     # data sources
     nist = DataSource(short_name='nist')
-    ku = DataSource(short_name='ku')
+    ku = DataSource(short_name='kurucz')
+    ch = DataSource(short_name='chianti')
 
     # atomic weights
     H.quantities = [
@@ -42,7 +44,36 @@ def foo_engine():
         AtomicWeight(quantity=1.00811*u.u, data_source=ku, std_dev=4e-3),
     ]
 
-    session.add_all([H, O, nist, ku])
+    # ions
+    H_1 = Ion(atom=H, ion_charge=0)
+    Si_1 = Ion(atom=Si, ion_charge=0)
+    Si_2 = Ion(atom=Si, ion_charge=1)
+
+
+    # levels
+    Si_2_lvl0 = Level(ion=Si_2, L="P", J=0.5, parity=1, spin_mult=2, configuration="3s2.3p")
+    Si_2_lvl1 = Level(ion=Si_2, L="P", J=1.5, parity=1, spin_mult=2, configuration="3s2.3p")
+    Si_2_lvl2 = Level(ion=Si_2, L="P", J=0.5, parity=1, spin_mult=4, configuration="3s.3p2")
+
+    # Chianti level data:
+    ch_si_2_lvl0 = LevelChiantiData(
+        level=Si_2_lvl0, data_source=ch, ch_index=1, energies=[
+            LevelEnergy(quantity=0*u.eV, method='m'),
+            LevelEnergy(quantity=0*u.eV, method='th')
+        ]
+    )
+
+    ch_si_2_lvl1 = LevelChiantiData(
+        level=Si_2_lvl1, data_source=ch, ch_index=2, energies=[
+            LevelEnergy(quantity=287.24*u.eV, method='m'),
+            LevelEnergy(quantity=287.512*u.eV, method='th')
+        ]
+    )
+
+    session.add_all([H, Si, Si_1, Si_2,
+                     Si_2_lvl0, Si_2_lvl1, Si_2_lvl2,
+                     ch_si_2_lvl0, ch_si_2_lvl1,
+                     nist, ku, ch])
     session.commit()
     session.close()
     return engine

--- a/carsus/model/tests/test_atomic.py
+++ b/carsus/model/tests/test_atomic.py
@@ -1,5 +1,5 @@
 import pytest
-from carsus.model import Atom, AtomicWeight, DataSource
+from carsus.model import Atom, AtomicWeight, DataSource, Ion, Level, LevelEnergy, LevelData
 from astropy import units as u
 from astropy.units import UnitsError, UnitConversionError
 from sqlalchemy import and_
@@ -31,7 +31,7 @@ def test_data_source_as_unique(memory_session):
 
 
 def test_data_sources_count(foo_session):
-    assert foo_session.query(DataSource).count() == 2
+    assert foo_session.query(DataSource).count() == 3
 
 
 def test_data_sources_unique_constraint(foo_session):
@@ -119,3 +119,32 @@ def test_atomic_quantity_compare_uncompatible_units(foo_session):
 def test_atomic_quantity_compare_with_zero(foo_session):
     res = foo_session.query(AtomicWeight).filter(AtomicWeight.quantity > 0).count()
     assert res == 2
+
+
+def test_levels_count(foo_session):
+    res = foo_session.query(Level).count()
+    assert res == 3
+
+
+def test_levels_count(foo_session):
+    res = foo_session.query(Level).count()
+    assert res == 3
+
+
+def test_levels_as_unique_existing(foo_session):
+    si_2 = Ion.as_unique(foo_session, atomic_number=14, ion_charge=1)
+    si_2_lvl0_1 = foo_session.query(Level).filter(and_(
+                                Level.ion == si_2,
+                                Level.configuration == "3s2.3p",
+                                Level.term == "2P*",
+                                Level.J == 0.5)).one()
+    si_2_lvl0_2 = Level.as_unique(foo_session, ion=si_2, configuration="3s2.3p", term="2P*", J=0.5)
+    assert si_2_lvl0_1 is si_2_lvl0_2
+
+
+def test_levels_as_unique_new(foo_session):
+    si_2 = Ion.as_unique(foo_session, atomic_number=14, ion_charge=1)
+    si_2_lvl3 = Level.as_unique(foo_session, ion=si_2, configuration="3s.3p2", term="2P*", J=1.5)
+    res = foo_session.query(Level).count()
+    import pdb; pdb.set_trace()
+    assert res == 4


### PR DESCRIPTION
Unfortunately, the schema below does not work:

![chianti_levels](https://cloud.githubusercontent.com/assets/8950027/15510076/01465612-21e7-11e6-99f5-17b3e9a98e11.png)

My idea was to store theoretical interpretation of levels in the `Level` table and then associate levels from different data sources with these theoretical levels. The `LevelData` table is basically an association table between the `Level` and `DataSource` tables (many-to-many relationship), but it also contains additional columns. Level energies are stored in a separate table, because there are situations when different values are available for the same level from the same data source. For example, measured and theoretical values are available for many CHIANTI levels. The `LevelChiantiData` table inherits from the `LevelData` table and contains fields specific to CHIANTI. 

The implementation of the mapping classes for these tables is in the [carsus/model/atomic.py](https://github.com/mishinma/carsus/blob/f42d70da49a75cbe7fdfa92ffef15e9ca275f4e4/carsus/model/atomic.py) module. 

The proposed implementation fails because some levels present in CHIANTI are indistinguishable. For example these [levels for Ne II](https://drive.google.com/file/d/0BxXCddocl9m3SlE2QVlHM2t1YTg/view?usp=sharing). Three of them have absolutely identical configuration, term and J value. I can't see how to relate them to "theoretical levels" from the `Level` table. 

So I intend to merge `Level` and `LevelData` tables and leave this problem for later.  