### PR TITLE
Electron Collisional Rates

### DIFF
--- a/carsus/conftest.py
+++ b/carsus/conftest.py
@@ -34,16 +34,20 @@ from sqlalchemy.orm import Session
 # except NameError:   # Needed to support Astropy <= 1.0.0
 #     pass
 
-# data_dir = os.path.join(os.path.dirname(__file__), 'tests', 'data')
-# if not os.path.exists(data_dir):
-#     os.makedirs(data_dir)
-#
-# test_db_url = 'sqlite:///' + os.path.join(data_dir, 'test.db')
+
+@pytest.fixture(scope="session")
+def test_db_url():
+    data_dir = os.path.join(os.path.dirname(__file__), 'tests', 'data')
+    if not os.path.exists(data_dir):
+        os.makedirs(data_dir)
+    test_db_path = os.path.join(data_dir, 'test.db')
+    open(test_db_path, "w").close()
+    return 'sqlite:///' + test_db_path
 
 
 @pytest.fixture(scope="session")
-def test_engine():
-    session = init_db("sqlite://")
+def test_engine(test_db_url):
+    session = init_db(test_db_url)
     session.commit()
     session.close()
     return session.get_bind()

--- a/carsus/conftest.py
+++ b/carsus/conftest.py
@@ -34,16 +34,16 @@ from sqlalchemy.orm import Session
 # except NameError:   # Needed to support Astropy <= 1.0.0
 #     pass
 
-data_dir = os.path.join(os.path.dirname(__file__), 'tests', 'data')
-if not os.path.exists(data_dir):
-    os.makedirs(data_dir)
-
-test_db_url = 'sqlite:///' + os.path.join(data_dir, 'test.db')
+# data_dir = os.path.join(os.path.dirname(__file__), 'tests', 'data')
+# if not os.path.exists(data_dir):
+#     os.makedirs(data_dir)
+#
+# test_db_url = 'sqlite:///' + os.path.join(data_dir, 'test.db')
 
 
 @pytest.fixture(scope="session")
 def test_engine():
-    session = init_db(url=test_db_url)
+    session = init_db("sqlite://")
     session.commit()
     session.close()
     return session.get_bind()

--- a/carsus/io/chianti_.py
+++ b/carsus/io/chianti_.py
@@ -6,7 +6,11 @@ import os
 import re
 from numpy.testing import assert_almost_equal
 from astropy import units as u
-from carsus.model import DataSource, Ion, ChiantiLevel, LevelEnergy
+from sqlalchemy import and_
+from sqlalchemy.orm.exc import NoResultFound
+from carsus.io.base import IngesterError
+from carsus.model import DataSource, Ion, ChiantiLevel, LevelEnergy, \
+    Line, LineWavelength, LineAValue, LineGFValue
 
 if os.getenv('XUVTOP'):
     masterlist_ions_path = os.path.join(
@@ -41,19 +45,29 @@ class ChiantiReader(object):
 
     masterlist_ions = masterlist_ions
 
-    elvlc_dict = {'lvl': 'level_index',
-                  'ecm': 'energy',  # cm-1
-                  'ecmth': 'energy_theoretical',  # cm-1
-                  'j': 'J',
-                  'spd': 'L',
-                  'spin': 'spin_multiplicity',
-                  'pretty': 'pretty',  # configuration + term
-                  'label': 'label'}
+    elvlc_dict = {
+        'lvl': 'level_index',
+        'ecm': 'energy',  # cm-1
+        'ecmth': 'energy_theoretical',  # cm-1
+        'j': 'J',
+        'spd': 'L',
+        'spin': 'spin_multiplicity',
+        'pretty': 'pretty',  # configuration + term
+        'label': 'label'
+    }
+
+    wgfa_dict = {
+        'avalue': 'a_value',
+        'gf': 'gf_value',
+        'lvl1': 'source_level_index',
+        'lvl2': 'target_level_index',
+        'wvl': 'wavelength'
+    }
 
     def _read_ion_levels(self, ion):
 
         if not hasattr(ion, 'Elvlc'):
-            print("No energy data is available for ion {}".format(ion))
+            print("No levels data is available for ion {}".format(ion))
             return None
 
         levels_dict = {}
@@ -82,10 +96,46 @@ class ChiantiReader(object):
         levels_df.set_index(["atomic_number", "ion_charge", "level_index"], inplace=True)
 
         # Keep only bound levels ?
-        # ip = u.eV.to(u.Unit("cm-1", value=ion.Ip, equivalencies=u.spectral())
+        # ip = u.eV.to(u.Unit("cm-1"), value=ion.Ip, equivalencies=u.spectral())
         # levels_df = levels_df[levels_df['energy'] < ion.Ip]
 
         return levels_df
+
+    def _read_ion_lines(self, ion):
+
+        if not hasattr(ion, 'Wgfa'):
+            print("No lines data is available for ion {}".format(ion))
+            return None
+
+        lines_dict = {}
+
+        for key, col_name in self.wgfa_dict.iteritems():
+            lines_dict[col_name] = ion.Wgfa.get(key)
+
+        lines_df = pd.DataFrame(lines_dict)
+
+        # two-photon transitions are given a zero wavelength and we ignore them for now
+        lines_df = lines_df.loc[~(lines_df["wavelength"] == 0)]
+
+        # theoretical wavelengths have negative values
+        def parse_wavelength(row):
+            if row["wavelength"] < 0:
+                wvl = -row["wavelength"]
+                method = "th"
+            else:
+                wvl = row["wavelength"]
+                method = "m"
+            return pd.Series([wvl, method])
+
+        lines_df[["wavelength", "method"]] = lines_df.apply(parse_wavelength, axis=1)
+
+        lines_df["atomic_number"] = ion.Z
+        lines_df["ion_charge"] = ion.Ion - 1
+
+        lines_df.set_index(["atomic_number", "ion_charge",
+                            "source_level_index", "target_level_index"], inplace=True)
+
+        return lines_df
 
     def read_levels(self):
         levels_df = pd.DataFrame()
@@ -93,6 +143,13 @@ class ChiantiReader(object):
             df = self._read_ion_levels(ion)
             levels_df = levels_df.append(df)  # None is treated as an empty dataframe
         return levels_df
+
+    def read_lines(self):
+        lines_df = pd.DataFrame()
+        for ion in self.ions:
+            df = self._read_ion_lines(ion)
+            lines_df = lines_df.append(df)  # None is treated as an empty dataframe
+        return lines_df
 
 
 class ChiantiIngester(object):
@@ -104,9 +161,9 @@ class ChiantiIngester(object):
 
     def _ingest_levels(self, levels_df):
 
-        for index, ion_df in levels_df.groupby(level=["atomic_number", "ion_charge"]):
+        for ion_index, ion_df in levels_df.groupby(level=["atomic_number", "ion_charge"]):
 
-            atomic_number, ion_charge = index
+            atomic_number, ion_charge = ion_index
             ion = Ion.as_unique(self.session, atomic_number=atomic_number, ion_charge=ion_charge)
 
             # ToDo: Determine parity from configuration
@@ -127,8 +184,59 @@ class ChiantiIngester(object):
                         )
                 self.session.add(level)
 
-    def ingest(self, levels=True):
+    def _ingest_lines(self, lines_df):
+
+        for ion_index, ion_df in lines_df.groupby(level=["atomic_number", "ion_charge"]):
+            atomic_number, ion_charge = ion_index
+            ion = Ion.as_unique(self.session, atomic_number=atomic_number, ion_charge=ion_charge)
+
+            # ToDo: Check which lines from this source already exist and update them
+
+            for index, row in ion_df.iterrows():
+
+                # index: (atomic_number, ion_charge, source_level_index, target_level_index)
+                source_level_index, target_level_index = index[2:]
+
+                try:
+                    source_level = self.session.query(ChiantiLevel).\
+                        filter(and_(ChiantiLevel.ion == ion,
+                                    ChiantiLevel.data_source == self.ds,
+                                    ChiantiLevel.ch_index == source_level_index)).one()
+                    target_level = self.session.query(ChiantiLevel). \
+                        filter(and_(ChiantiLevel.ion == ion,
+                                    ChiantiLevel.data_source == self.ds,
+                                    ChiantiLevel.ch_index == target_level_index)).one()
+                except NoResultFound:
+                    raise IngesterError("Levels from this source have not been found."
+                                        "You must ingest levels before transitions")
+
+                # Create a new line
+                line = Line(
+                    ion=ion,
+                    source_level=source_level,
+                    target_level=target_level,
+                    data_source=self.ds,
+                    wavelengths=[
+                        LineWavelength(quantity=row["wavelength"]*u.AA, method=row["method"])
+                    ],
+                    a_values=[
+                        LineAValue(quantity=row["a_value"]*u.Unit("s**-1"))
+                    ],
+                    gf_values=[
+                        LineGFValue(quantity=row["gf_value"])
+                    ]
+                )
+
+                self.session.add(line)
+
+    def ingest(self, levels=True, lines=True):
 
         if levels:
             levels_df = self.reader.read_levels()
             self._ingest_levels(levels_df)
+        self.session.commit()
+
+        if lines:
+            lines_df = self.reader.read_lines()
+            self._ingest_lines(lines_df)
+        self.session.commit()

--- a/carsus/io/chianti_.py
+++ b/carsus/io/chianti_.py
@@ -1,0 +1,136 @@
+import chianti.core as ch
+import pandas as pd
+import numpy as np
+import pickle
+import os
+import re
+from numpy.testing import assert_almost_equal
+from astropy import units as u
+from carsus.model import DataSource, Ion, ChiantiLevel, LevelEnergy
+
+if os.getenv('XUVTOP'):
+    masterlist_ions_path = os.path.join(
+        os.getenv('XUVTOP'), "masterlist", "masterlist_ions.pkl"
+    )
+
+    masterlist_ions_file = open(masterlist_ions_path, 'rb')
+    masterlist_ions = pickle.load(masterlist_ions_file).keys()
+    # Exclude the "d" ions for now
+    masterlist_ions = [_ for _ in masterlist_ions
+                       if re.match("[a-z]+_\d+", _)]
+
+else:
+    print "Chianti database is not installed!"
+    masterlist_ions = list()
+
+
+class ChiantiReader(object):
+
+    def __init__(self, ions_list):
+        # ToDo write a parser for Spectral Notation
+        self.ions_list = list()
+        for ion in ions_list:
+            if ion in self.masterlist_ions:
+                self.ions_list.append(ion)
+            else:
+                print("Ion {0} is not available".format(ion))
+
+    @property
+    def ions(self):
+        return [ch.ion(_) for _ in self.ions_list]
+
+    masterlist_ions = masterlist_ions
+
+    elvlc_dict = {'lvl': 'level_index',
+                  'ecm': 'energy',  # cm-1
+                  'ecmth': 'energy_theoretical',  # cm-1
+                  'j': 'J',
+                  'spd': 'L',
+                  'spin': 'spin_multiplicity',
+                  'pretty': 'pretty',  # configuration + term
+                  'label': 'label'}
+
+    def _read_ion_levels(self, ion):
+
+        if not hasattr(ion, 'Elvlc'):
+            print("No energy data is available for ion {}".format(ion))
+            return None
+
+        levels_dict = {}
+
+        for key, col_name in self.elvlc_dict.iteritems():
+            levels_dict[col_name] = ion.Elvlc.get(key)
+
+        # Check that ground level energy is 0
+        try:
+            for key in ['energy', 'energy_theoretical']:
+                assert_almost_equal(levels_dict[key][0], 0)
+        except AssertionError:
+            raise ValueError('Level 0 energy is not 0.0')
+
+        levels_df = pd.DataFrame(levels_dict)
+
+        # Replace empty labels with NaN
+        levels_df["label"].replace(r'\s+', np.nan, regex=True, inplace=True)
+
+        # Extract configuration and term from the "pretty" column
+        term_conf_df = levels_df["pretty"].str.\
+            extract("(?P<configuration>(\d[a-z]\d?[\s,.]?)+)\s(?P<term>\d+[A-Z][\d,.]+)")
+        levels_df[["term", "configuration"]] = term_conf_df[["term", "configuration"]]
+        levels_df.drop("pretty", axis=1, inplace=True)
+
+        levels_df["atomic_number"] = ion.Z
+        levels_df["ion_charge"] = ion.Ion - 1
+        levels_df.set_index(["atomic_number", "ion_charge", "level_index"], inplace=True)
+
+        # Keep only bound levels ?
+        # ip = u.eV.to(u.Unit("cm-1", value=ion.Ip, equivalencies=u.spectral())
+        # levels_df = levels_df[levels_df['energy'] < ion.Ip]
+
+        return levels_df
+
+    def read_levels(self):
+        levels_df = pd.DataFrame()
+        for ion in self.ions:
+            df = self._read_ion_levels(ion)
+            levels_df = levels_df.append(df)  # None is treated as an empty dataframe
+        return levels_df
+
+
+class ChiantiIngester(object):
+
+    def __init__(self, session, ions_list=masterlist_ions, ds_short_name="chianti_v8.0.2"):
+        self.session = session
+        self.reader = ChiantiReader(ions_list=ions_list)
+        self.ds = DataSource.as_unique(self.session, short_name=ds_short_name)
+
+    def _ingest_levels(self, levels_df):
+
+        for index, ion_df in levels_df.groupby(level=["atomic_number", "ion_charge"]):
+
+            atomic_number, ion_charge = index
+            ion = Ion.as_unique(self.session, atomic_number=atomic_number, ion_charge=ion_charge)
+
+            # ToDo: Determine parity from configuration
+            # ToDo: Check if the level from this source already exists and update it then
+
+            for index, row in ion_df.iterrows():
+
+                ch_index = index[2]  # (atomic_number, ion_charge, chianti_index)
+                level = ChiantiLevel(ion=ion, data_source=self.ds, ch_index=ch_index, ch_label=row["label"],
+                                     configuration=row["configuration"], term=row["term"],
+                                     L=row["L"], J=row["J"], spin_multiplicity=row["spin_multiplicity"])
+
+                level.energies = []
+                for column, method in [('energy', 'm'), ('energy_theoretical', 'th')]:
+                    if row[column] != -1:  # check if the value exists
+                        level.energies.append(
+                            LevelEnergy(quantity=row[column] * u.Unit("cm-1"), method=method),
+                        )
+                self.session.add(level)
+
+    def ingest(self, levels=True):
+
+        if levels:
+            levels_df = self.reader.read_levels()
+            self._ingest_levels(levels_df)

--- a/carsus/io/chianti_.py
+++ b/carsus/io/chianti_.py
@@ -74,9 +74,7 @@ class ChiantiReader(object):
         levels_df["label"].replace(r'\s+', np.nan, regex=True, inplace=True)
 
         # Extract configuration and term from the "pretty" column
-        term_conf_df = levels_df["pretty"].str.\
-            extract("(?P<configuration>(\d[a-z]\d?[\s,.]?)+)\s(?P<term>\d+[A-Z][\d,.]+)")
-        levels_df[["term", "configuration"]] = term_conf_df[["term", "configuration"]]
+        levels_df[["term", "configuration"]] = levels_df["pretty"].str.rsplit(' ', expand=True, n=1)
         levels_df.drop("pretty", axis=1, inplace=True)
 
         levels_df["atomic_number"] = ion.Z

--- a/carsus/io/tests/test_chianti.py
+++ b/carsus/io/tests/test_chianti.py
@@ -1,0 +1,41 @@
+import pytest
+from ..chianti_ import ChiantiReader, ChiantiIngester, masterlist_ions
+from carsus.model import Level, LevelEnergy, Ion
+from numpy.testing import assert_almost_equal
+
+
+@pytest.fixture
+def chianti_reader():
+    ions = ['ne_2', 'cl_4', 'ne_6']
+    return ChiantiReader(ions)
+
+@pytest.fixture
+def chianti_ingester(test_session):
+    ions_list = masterlist_ions[:3]  # ['ne_2', 'cl_4', 'ne_6']
+    ingester = ChiantiIngester(test_session, ions_list=ions_list)
+    return ingester
+
+def test_chianti_reader_init(chianti_reader):
+    assert len(chianti_reader.ions) == 3
+
+
+def test_chianti_reader_init_w_bad_ions():
+    chianti_rdr = ChiantiReader(['ne_2', 'cl_4', 'ne_6', 'au_1'])
+    assert len(chianti_rdr.ions) == 3
+
+
+def test_chianti_reader_read_levels(chianti_reader):
+    levels_df = chianti_reader.read_levels()
+    assert_almost_equal(levels_df.loc[10,1,1]['energy'], 0)
+
+
+@pytest.mark.parametrize("atomic_number, ion_charge, count",[
+    (10, 1, 138),
+    (10, 5, 204),
+    (17, 3, 5)
+])
+def test_chianti_ingest_levels_count(test_session, chianti_ingester, atomic_number, ion_charge, count):
+    chianti_ingester.ingest()
+    test_session.commit()
+    ne_1 = Ion.as_unique(test_session, atomic_number=atomic_number, ion_charge=ion_charge)
+    assert len(ne_1.levels) == count

--- a/carsus/io/tests/test_chianti.py
+++ b/carsus/io/tests/test_chianti.py
@@ -1,77 +1,73 @@
 import pytest
-from ..chianti_ import ChiantiReader, ChiantiIngester, masterlist_ions
-from carsus.model import Level, LevelEnergy, Ion
+from ..chianti_ import ChiantiIonReader, ChiantiIngester
+from carsus.model import Level, LevelEnergy, Ion, ChiantiLevel,\
+    Line, LineWavelength, LineAValue, LineGFValue, \
+    ECollision, ECollisionTemp, ECollisionStrength, \
+    ECollisionGFValue, ECollisionTempStrength, ECollisionEnergy
 from numpy.testing import assert_almost_equal
 
 
 @pytest.fixture(scope="module")
-def chianti_reader():
-    ions = ['ne_2', 'cl_4', 'ne_6']
-    return ChiantiReader(ions)
-
-
-@pytest.fixture(scope="module")
-def levels_df(chianti_reader):
-    return chianti_reader.read_levels()
-
-
-@pytest.fixture(scope="module")
-def lines_df(chianti_reader):
-    return chianti_reader.read_lines()
+def ch_ion_reader():
+    return ChiantiIonReader("ne_6")
 
 
 @pytest.fixture
-def chianti_ingester(test_session):
+def ch_ingester(test_session):
     ions_list = ['ne_2', 'cl_4', 'ne_6']
     ingester = ChiantiIngester(test_session, ions_list=ions_list)
     return ingester
 
 
-def test_chianti_reader_init(chianti_reader):
-    assert len(chianti_reader.ions) == 3
-
-
-def test_chianti_reader_init_w_bad_ions():
-    chianti_rdr = ChiantiReader(['ne_2', 'cl_4', 'ne_6', 'au_1'])
-    assert len(chianti_rdr.ions) == 3
-
-
-@pytest.mark.parametrize("index, energy, energy_theoretical",[
-    ((10, 5, 1), 0, 0),
-    ((10, 5, 20), 816294.000, 815133.312),
+@pytest.mark.parametrize("level_index, energy, energy_theoretical",[
+    (1, 0, 0),
+    (20, 816294.000, 815133.312),
 ])
-def test_chianti_reader_read_levels(levels_df, index, energy, energy_theoretical):
-    row = levels_df.loc[index]
+def test_chianti_reader_read_levels(ch_ion_reader, level_index, energy, energy_theoretical):
+    row = ch_ion_reader.levels_df.loc[level_index]
     assert_almost_equal(row['energy'], energy)
     assert_almost_equal(row['energy_theoretical'], energy_theoretical)
 
 
-@pytest.mark.parametrize("index, wavelength, method",[
-    ((10, 5, 10, 13), 913.195, "m"),
-    ((10, 5, 74, 204), 4.091, "th"),
+@pytest.mark.parametrize("level_index, wavelength, method",[
+    ((10, 13), 913.195, "m"),
+    ((74, 204), 4.091, "th"),
 ])
-def test_chianti_reader_read_lines(lines_df, index, wavelength, method):
-    row = lines_df.loc[index]
+def test_chianti_reader_read_lines(ch_ion_reader, level_index, wavelength, method):
+    row = ch_ion_reader.lines_df.loc[level_index]
     assert_almost_equal(row['wavelength'], wavelength)
     assert row['method'] == method
 
 
-@pytest.mark.parametrize("atomic_number, ion_charge, count",[
-    (10, 1, 138),
-    (10, 5, 204),
-    (17, 3, 5)
-])
-def test_chianti_ingest_levels_count(test_session, chianti_ingester, atomic_number, ion_charge, count):
-    chianti_ingester.ingest(levels=True, lines=False)
-    test_session.commit()
-    ne_1 = Ion.as_unique(test_session, atomic_number=atomic_number, ion_charge=ion_charge)
-    assert len(ne_1.levels) == count
+# @pytest.mark.parametrize("atomic_number, ion_charge, levels_count",[
+#     (10, 1, 138),
+#     (10, 5, 204),
+#     (17, 3, 5)
+# ])
+# def test_chianti_ingest_levels_count(test_session, ch_ingester, atomic_number, ion_charge, levels_count):
+#     ch_ingester.ingest(levels=True, lines=False)
+#     test_session.commit()
+#     ne_1 = Ion.as_unique(test_session, atomic_number=atomic_number, ion_charge=ion_charge)
+#     assert len(ne_1.levels) == levels_count
+#
+#
+# @pytest.mark.parametrize("atomic_number, ion_charge, lines_count",[
+#     (10, 1, 1999)
+# ])
+# def test_chianti_ingest_lines_count(test_session, ch_ingester, atomic_number, ion_charge, lines_count):
+#     ch_ingester.ingest(levels=True, lines=True)
+#     ne_1 = Ion.as_unique(test_session, atomic_number=atomic_number, ion_charge=ion_charge)
+#     cnt = test_session.query(Level).filter(Level.ion == ne_1).\
+#         join(Level.source_transitions.of_type(Line)).count()
+#     assert cnt == lines_count
 
 
-@pytest.mark.parametrize("atomic_number, ion_charge, lines_count",[
-    (10, 1, 1999)
+@pytest.mark.parametrize("atomic_number, ion_charge, e_col_count",[
+    (10, 1, 9453)
 ])
-def test_chianti_ingest_lines_count(test_session, chianti_ingester, atomic_number, ion_charge, lines_count):
-    chianti_ingester.ingest(levels=True, lines=True)
+def test_chianti_ingest_e_col_count(test_session, ch_ingester, atomic_number, ion_charge, e_col_count):
+    ch_ingester.ingest(levels=True, collisions=True)
     ne_1 = Ion.as_unique(test_session, atomic_number=atomic_number, ion_charge=ion_charge)
-    assert len(ne_1.lines) == lines_count
+    cnt = test_session.query(Level).filter(Level.ion == ne_1).\
+        join(Level.source_transitions.of_type(ECollision)).count()
+    assert cnt == e_col_count

--- a/carsus/io/tests/test_chianti.py
+++ b/carsus/io/tests/test_chianti.py
@@ -4,16 +4,28 @@ from carsus.model import Level, LevelEnergy, Ion
 from numpy.testing import assert_almost_equal
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def chianti_reader():
     ions = ['ne_2', 'cl_4', 'ne_6']
     return ChiantiReader(ions)
 
+
+@pytest.fixture(scope="module")
+def levels_df(chianti_reader):
+    return chianti_reader.read_levels()
+
+
+@pytest.fixture(scope="module")
+def lines_df(chianti_reader):
+    return chianti_reader.read_lines()
+
+
 @pytest.fixture
 def chianti_ingester(test_session):
-    ions_list = masterlist_ions[:3]  # ['ne_2', 'cl_4', 'ne_6']
+    ions_list = ['ne_2', 'cl_4', 'ne_6']
     ingester = ChiantiIngester(test_session, ions_list=ions_list)
     return ingester
+
 
 def test_chianti_reader_init(chianti_reader):
     assert len(chianti_reader.ions) == 3
@@ -24,9 +36,24 @@ def test_chianti_reader_init_w_bad_ions():
     assert len(chianti_rdr.ions) == 3
 
 
-def test_chianti_reader_read_levels(chianti_reader):
-    levels_df = chianti_reader.read_levels()
-    assert_almost_equal(levels_df.loc[10,1,1]['energy'], 0)
+@pytest.mark.parametrize("index, energy, energy_theoretical",[
+    ((10, 5, 1), 0, 0),
+    ((10, 5, 20), 816294.000, 815133.312),
+])
+def test_chianti_reader_read_levels(levels_df, index, energy, energy_theoretical):
+    row = levels_df.loc[index]
+    assert_almost_equal(row['energy'], energy)
+    assert_almost_equal(row['energy_theoretical'], energy_theoretical)
+
+
+@pytest.mark.parametrize("index, wavelength, method",[
+    ((10, 5, 10, 13), 913.195, "m"),
+    ((10, 5, 74, 204), 4.091, "th"),
+])
+def test_chianti_reader_read_lines(lines_df, index, wavelength, method):
+    row = lines_df.loc[index]
+    assert_almost_equal(row['wavelength'], wavelength)
+    assert row['method'] == method
 
 
 @pytest.mark.parametrize("atomic_number, ion_charge, count",[
@@ -35,7 +62,16 @@ def test_chianti_reader_read_levels(chianti_reader):
     (17, 3, 5)
 ])
 def test_chianti_ingest_levels_count(test_session, chianti_ingester, atomic_number, ion_charge, count):
-    chianti_ingester.ingest()
+    chianti_ingester.ingest(levels=True, lines=False)
     test_session.commit()
     ne_1 = Ion.as_unique(test_session, atomic_number=atomic_number, ion_charge=ion_charge)
     assert len(ne_1.levels) == count
+
+
+@pytest.mark.parametrize("atomic_number, ion_charge, lines_count",[
+    (10, 1, 1999)
+])
+def test_chianti_ingest_lines_count(test_session, chianti_ingester, atomic_number, ion_charge, lines_count):
+    chianti_ingester.ingest(levels=True, lines=True)
+    ne_1 = Ion.as_unique(test_session, atomic_number=atomic_number, ion_charge=ion_charge)
+    assert len(ne_1.lines) == lines_count

--- a/carsus/io/tests/test_chianti.py
+++ b/carsus/io/tests/test_chianti.py
@@ -2,19 +2,18 @@ import pytest
 from ..chianti_ import ChiantiIonReader, ChiantiIngester
 from carsus.model import Level, LevelEnergy, Ion, ChiantiLevel,\
     Line, LineWavelength, LineAValue, LineGFValue, \
-    ECollision, ECollisionTemp, ECollisionStrength, \
-    ECollisionGFValue, ECollisionTempStrength, ECollisionEnergy
+    ECollision,ECollisionGFValue, ECollisionTempStrength, ECollisionEnergy
 from numpy.testing import assert_almost_equal
 
 
 @pytest.fixture(scope="module")
 def ch_ion_reader():
-    return ChiantiIonReader("ne_6")
+    return ChiantiIonReader("ne_2")
 
 
 @pytest.fixture
 def ch_ingester(test_session):
-    ions_list = ['ne_2', 'cl_4', 'ne_6']
+    ions_list = ['ne_2']
     ingester = ChiantiIngester(test_session, ions_list=ions_list)
     return ingester
 
@@ -39,27 +38,27 @@ def test_chianti_reader_read_lines(ch_ion_reader, level_index, wavelength, metho
     assert row['method'] == method
 
 
-# @pytest.mark.parametrize("atomic_number, ion_charge, levels_count",[
-#     (10, 1, 138),
-#     (10, 5, 204),
-#     (17, 3, 5)
-# ])
-# def test_chianti_ingest_levels_count(test_session, ch_ingester, atomic_number, ion_charge, levels_count):
-#     ch_ingester.ingest(levels=True, lines=False)
-#     test_session.commit()
-#     ne_1 = Ion.as_unique(test_session, atomic_number=atomic_number, ion_charge=ion_charge)
-#     assert len(ne_1.levels) == levels_count
-#
-#
-# @pytest.mark.parametrize("atomic_number, ion_charge, lines_count",[
-#     (10, 1, 1999)
-# ])
-# def test_chianti_ingest_lines_count(test_session, ch_ingester, atomic_number, ion_charge, lines_count):
-#     ch_ingester.ingest(levels=True, lines=True)
-#     ne_1 = Ion.as_unique(test_session, atomic_number=atomic_number, ion_charge=ion_charge)
-#     cnt = test_session.query(Level).filter(Level.ion == ne_1).\
-#         join(Level.source_transitions.of_type(Line)).count()
-#     assert cnt == lines_count
+@pytest.mark.parametrize("atomic_number, ion_charge, levels_count",[
+    (10, 1, 138),
+    (10, 5, 204),
+    (17, 3, 5)
+])
+def test_chianti_ingest_levels_count(test_session, ch_ingester, atomic_number, ion_charge, levels_count):
+    ch_ingester.ingest(levels=True, lines=False)
+    test_session.commit()
+    ne_1 = Ion.as_unique(test_session, atomic_number=atomic_number, ion_charge=ion_charge)
+    assert len(ne_1.levels) == levels_count
+
+
+@pytest.mark.parametrize("atomic_number, ion_charge, lines_count",[
+    (10, 1, 1999)
+])
+def test_chianti_ingest_lines_count(test_session, ch_ingester, atomic_number, ion_charge, lines_count):
+    ch_ingester.ingest(levels=True, lines=True)
+    ne_1 = Ion.as_unique(test_session, atomic_number=atomic_number, ion_charge=ion_charge)
+    cnt = test_session.query(Level).filter(Level.ion == ne_1).\
+        join(Level.source_transitions.of_type(Line)).count()
+    assert cnt == lines_count
 
 
 @pytest.mark.parametrize("atomic_number, ion_charge, e_col_count",[

--- a/carsus/model/__init__.py
+++ b/carsus/model/__init__.py
@@ -1,2 +1,3 @@
-from .atomic import Atom, AtomicQuantity, AtomicWeight, DataSource, Ion, Level, LevelEnergy, ChiantiLevel
+from .atomic import Atom, AtomicQuantity, AtomicWeight, DataSource, Ion, Level, LevelEnergy, ChiantiLevel,\
+    Line, LineAValue, LineGFValue, LineWavelength
 from .meta import Base, setup

--- a/carsus/model/__init__.py
+++ b/carsus/model/__init__.py
@@ -1,4 +1,4 @@
 from .atomic import Atom, AtomicQuantity, AtomicWeight, DataSource, Ion, Level, LevelEnergy, ChiantiLevel,\
-    Line, LineAValue, LineGFValue, LineWavelength, ECollision, ECollisionTemp, ECollisionStrength, \
+    Line, LineAValue, LineGFValue, LineWavelength, ECollision, \
     ECollisionGFValue, ECollisionTempStrength, ECollisionEnergy
 from .meta import Base, setup

--- a/carsus/model/__init__.py
+++ b/carsus/model/__init__.py
@@ -1,3 +1,4 @@
 from .atomic import Atom, AtomicQuantity, AtomicWeight, DataSource, Ion, Level, LevelEnergy, ChiantiLevel,\
-    Line, LineAValue, LineGFValue, LineWavelength
+    Line, LineAValue, LineGFValue, LineWavelength, ECollision, ECollisionTemp, ECollisionStrength, \
+    ECollisionGFValue, ECollisionTempStrength, ECollisionEnergy
 from .meta import Base, setup

--- a/carsus/model/__init__.py
+++ b/carsus/model/__init__.py
@@ -1,2 +1,2 @@
-from .atomic import Atom, AtomicQuantity, AtomicWeight, DataSource
+from .atomic import Atom, AtomicQuantity, AtomicWeight, DataSource, Ion, Level, LevelEnergy, ChiantiLevel
 from .meta import Base, setup

--- a/carsus/model/atomic.py
+++ b/carsus/model/atomic.py
@@ -126,7 +126,8 @@ class Level(Base):
                             backref="level",
                             cascade="all, delete-orphan")
 
-    data_source = relationship("DataSource", backref="level_data")
+    data_source = relationship("DataSource", backref="levels")
+    ion = relationship("Ion", backref="ion")
 
     __table_args__ = (UniqueConstraint('id', 'ion_id', 'data_source_id'),)
 

--- a/carsus/model/atomic.py
+++ b/carsus/model/atomic.py
@@ -167,9 +167,11 @@ class Transition(Base):
     data_source_id = Column(Integer, ForeignKey('data_source.id'), nullable=False)
 
     source_level = relationship("Level",
-                                primaryjoin=(Level.id == source_level_id))
+                                primaryjoin=(Level.id == source_level_id),
+                                backref="source_transitions")
     target_level = relationship("Level",
-                                primaryjoin=(Level.id == target_level_id))
+                                primaryjoin=(Level.id == target_level_id),
+                                backref="target_transitions")
 
 
     data_source = relationship("DataSource", backref="transitions")

--- a/carsus/model/atomic.py
+++ b/carsus/model/atomic.py
@@ -18,6 +18,8 @@ class Atom(Base):
                     backref='atom',
                     cascade='all, delete-orphan')
 
+    ions = relationship("Ion", back_populates="atom")
+
     def __repr__(self):
         return "<Atom {0}, Z={1}>".format(self.symbol, self.atomic_number)
 
@@ -95,11 +97,8 @@ class Ion(UniqueMixin, Base):
     atomic_number = Column(Integer, ForeignKey('atom.atomic_number'), nullable=False)
     ion_charge = Column(Integer, nullable=False)
 
-    levels = relationship("Level",
-                          backref='ion',
-                          cascade="all, delete-orphan")
-
-    atom = relationship("Atom", backref='ions')
+    levels = relationship("Level", back_populates='ion')
+    atom = relationship("Atom", back_populates='ions')
 
     __table_args__ = (UniqueConstraint('atomic_number', 'ion_charge'),)
 
@@ -122,13 +121,11 @@ class Level(Base):
     # ToDo I think that term column can be derived from L, S, parity and configuration
     term = Column(String(20))
 
-    energies = relationship("LevelEnergy",
-                            backref="level",
-                            cascade="all, delete-orphan")
+    energies = relationship("LevelEnergy", back_populates="level")
+    ion = relationship("Ion", back_populates="levels")
 
     data_source = relationship("DataSource", backref="levels")
-    ion = relationship("Ion", backref="ion")
-
+    
     __table_args__ = (UniqueConstraint('id', 'ion_id', 'data_source_id'),)
 
     __mapper_args__ = {
@@ -155,6 +152,8 @@ class LevelEnergy(QuantityMixin, Base):
     level_id = Column(Integer, ForeignKey('level.id'), nullable=False)
     unit = u.eV
     equivalencies = u.spectral()
+
+    level = relationship("Level", back_populates="energies")
 
 class DataSource(UniqueMixin, Base):
     __tablename__ = "data_source"

--- a/carsus/model/atomic.py
+++ b/carsus/model/atomic.py
@@ -276,25 +276,6 @@ class ECollisionEnergy(ECollisionQuantity):
         'polymorphic_identity': 'energy'
     }
 
-
-class ECollisionTemp(ECollisionQuantity):
-
-    unit = u.dimensionless_unscaled
-
-    __mapper_args__ = {
-        'polymorphic_identity': 'temp'
-    }
-
-
-class ECollisionStrength(ECollisionQuantity):  # Scaled effective collision strengths
-
-    unit = u.dimensionless_unscaled
-
-    __mapper_args__ = {
-        'polymorphic_identity': 'strength'
-    }
-
-
 class ECollisionGFValue(ECollisionQuantity):
 
     unit = u.dimensionless_unscaled
@@ -307,19 +288,17 @@ class ECollisionGFValue(ECollisionQuantity):
 class ECollisionTempStrength(Base):
     __tablename__ = "e_collision_temp_strength"
 
-    temp_id = Column(Integer, ForeignKey("e_collision_qty.id"), primary_key=True)
-    strength_id = Column(Integer, ForeignKey("e_collision_qty.id"), primary_key=True)
+    temp_strength_id = Column(Integer, primary_key=True)
+    temp = Column(Float)
+    strength = Column(Float)
     e_collision_id = Column(Integer, ForeignKey("e_collision.id"))
-
-    temp = relationship("ECollisionTemp", foreign_keys=[temp_id])
-    strength = relationship("ECollisionStrength", foreign_keys=[strength_id])
-
-    def __init__(self, tup):
-        self.temp, self.strength = tup
 
     @property
     def as_tuple(self):
         return self.temp, self.strength
+
+    def __repr__(self):
+        return "<Temp: {}, Strength: {}>".format(self.temp, self.strength)
 
 
 class DataSource(UniqueMixin, Base):

--- a/carsus/model/meta/__init__.py
+++ b/carsus/model/meta/__init__.py
@@ -1,3 +1,4 @@
 from .types import DBQuantity
 from .orm import UniqueMixin
 from .base import Base, setup
+from .schema import QuantityMixin

--- a/carsus/model/meta/schema.py
+++ b/carsus/model/meta/schema.py
@@ -1,0 +1,37 @@
+from sqlalchemy import Column, Integer, Float, String
+from sqlalchemy.ext.hybrid import hybrid_property
+from ..meta.types import DBQuantity
+from astropy.units import dimensionless_unscaled, UnitsError, set_enabled_equivalencies
+
+
+class QuantityMixin(object):
+
+    id = Column(Integer, primary_key=True)
+
+    _value = Column(Float, nullable=False)
+    uncert = Column(Float)
+    method = Column(String(15))
+
+    unit = dimensionless_unscaled
+    equivalencies = None
+
+    # Public interface for value is via `.quantity` accessor
+    @hybrid_property
+    def quantity(self):
+        return DBQuantity(self._value, self.unit)
+
+    @quantity.setter
+    def quantity(self, qty):
+        try:
+            with set_enabled_equivalencies(self.equivalencies):
+                self._value = qty.to(self.unit).value
+        except AttributeError:
+            if self.unit is dimensionless_unscaled or qty == 0:
+                self._value = qty
+            else:
+                raise UnitsError("Can only assign dimensionless values "
+                                 "to dimensionless quantities "
+                                 "(unless the value is 0)")
+
+    def __repr__(self):
+        return "<Quantity: {0} {1}>".format(self._value, self.unit)

--- a/carsus/model/meta/schema.py
+++ b/carsus/model/meta/schema.py
@@ -11,6 +11,7 @@ class QuantityMixin(object):
     _value = Column(Float, nullable=False)
     uncert = Column(Float)
     method = Column(String(15))
+    reference = Column(String(50))
 
     unit = dimensionless_unscaled
     equivalencies = None

--- a/carsus/model/tests/conftest.py
+++ b/carsus/model/tests/conftest.py
@@ -3,7 +3,8 @@ import pytest
 import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
-from carsus.model import Base, Atom, DataSource, AtomicWeight, Ion, LevelEnergy, ChiantiLevel
+from carsus.model import Base, Atom, DataSource, AtomicWeight, Ion, \
+    LevelEnergy, ChiantiLevel, Line, LineWavelength, LineAValue, LineGFValue
 from astropy import units as u
 
 # data_dir = os.path.join(os.path.dirname(__file__), 'data')
@@ -66,8 +67,44 @@ def foo_engine():
                                  LevelEnergy(quantity=780.4*u.Unit("cm-1"), method="m"),
                                  LevelEnergy(quantity=780.0*u.Unit("cm-1"), method="th")
                              ])
+    # 2s2p6 2S0.5
+    ne_1_lvl2 = ChiantiLevel(ion=ne_1, data_source=ch,
+                             configuration="2s2p6", term="2S0.5", L="S", J=0.5,
+                             spin_multiplicity=2, parity=0, ch_index=3,
+                             energies=[
+                                 LevelEnergy(quantity=217047.594*u.Unit("cm-1"), method="m"),
+                                 LevelEnergy(quantity=217048*u.Unit("cm-1"), method="th")
+                             ])
 
-    session.add_all([ne_1, ne_0, ne_1_lvl0, ne_1_lvl1])
+    # lines
+    ne_1_line0 = Line(
+        ion=ne_1,
+        source_level=ne_1_lvl0,
+        target_level=ne_1_lvl1,
+        data_source=ch,
+        wavelengths=[
+            LineWavelength(quantity=1*u.AA)
+        ],
+        a_values=[
+            LineAValue(quantity=48*u.Unit("s-1"))
+        ],
+        gf_values=[
+            LineGFValue(quantity=23)
+        ]
+    )
+
+    ne_1_line1 = Line(
+        ion=ne_1,
+        source_level=ne_1_lvl0,
+        target_level=ne_1_lvl2,
+        data_source=ch)
+
+    lw1 = LineWavelength(quantity=10*u.AA,
+                         line=ne_1_line1)
+
+    session.add_all([ne_1, ne_0,
+                     ne_1_lvl0, ne_1_lvl1, ne_1_lvl2,
+                     ne_1_line0, ne_1_lvl1])
     session.commit()
     session.close()
     return engine

--- a/carsus/model/tests/conftest.py
+++ b/carsus/model/tests/conftest.py
@@ -4,7 +4,9 @@ import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from carsus.model import Base, Atom, DataSource, AtomicWeight, Ion, \
-    LevelEnergy, ChiantiLevel, Line, LineWavelength, LineAValue, LineGFValue
+    LevelEnergy, ChiantiLevel, Line, LineWavelength, LineAValue, LineGFValue, \
+    ECollision, ECollisionTemp, ECollisionStrength, \
+    ECollisionGFValue, ECollisionTempStrength, ECollisionEnergy
 from astropy import units as u
 
 # data_dir = os.path.join(os.path.dirname(__file__), 'data')
@@ -78,7 +80,6 @@ def foo_engine():
 
     # lines
     ne_1_line0 = Line(
-        ion=ne_1,
         source_level=ne_1_lvl0,
         target_level=ne_1_lvl1,
         data_source=ch,
@@ -94,7 +95,6 @@ def foo_engine():
     )
 
     ne_1_line1 = Line(
-        ion=ne_1,
         source_level=ne_1_lvl0,
         target_level=ne_1_lvl2,
         data_source=ch)
@@ -102,9 +102,25 @@ def foo_engine():
     lw1 = LineWavelength(quantity=10*u.AA,
                          line=ne_1_line1)
 
+    # electron collisions
+    ne_1_col = ECollision(
+        source_level=ne_1_lvl0,
+        target_level=ne_1_lvl1,
+        data_source=ch,
+        bt92_ttype=2,
+        bt92_cups=11.16,
+        energies=[
+            ECollisionEnergy(quantity=0.007108*u.rydberg)
+        ],
+        temp_strengths_tuple=[
+            (ECollisionTemp(quantity=0.0), ECollisionStrength(quantity=0.255)),
+            (ECollisionTemp(quantity=0.07394), ECollisionStrength(quantity=0.266))
+        ]
+    )
+
     session.add_all([ne_1, ne_0,
                      ne_1_lvl0, ne_1_lvl1, ne_1_lvl2,
-                     ne_1_line0, ne_1_lvl1])
+                     ne_1_line0, ne_1_lvl1, ne_1_col])
     session.commit()
     session.close()
     return engine

--- a/carsus/model/tests/conftest.py
+++ b/carsus/model/tests/conftest.py
@@ -5,8 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from carsus.model import Base, Atom, DataSource, AtomicWeight, Ion, \
     LevelEnergy, ChiantiLevel, Line, LineWavelength, LineAValue, LineGFValue, \
-    ECollision, ECollisionTemp, ECollisionStrength, \
-    ECollisionGFValue, ECollisionTempStrength, ECollisionEnergy
+    ECollision, ECollisionGFValue, ECollisionTempStrength, ECollisionEnergy
 from astropy import units as u
 
 # data_dir = os.path.join(os.path.dirname(__file__), 'data')
@@ -112,9 +111,9 @@ def foo_engine():
         energies=[
             ECollisionEnergy(quantity=0.007108*u.rydberg)
         ],
-        temp_strengths_tuple=[
-            (ECollisionTemp(quantity=0.0), ECollisionStrength(quantity=0.255)),
-            (ECollisionTemp(quantity=0.07394), ECollisionStrength(quantity=0.266))
+        temp_strengths=[
+            (ECollisionTempStrength(temp=0.0, strength=0.255)),
+            (ECollisionTempStrength(temp=0.07394, strength=0.266))
         ]
     )
 

--- a/carsus/model/tests/test_atomic.py
+++ b/carsus/model/tests/test_atomic.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
-from carsus.model import Atom, AtomicWeight, DataSource, Ion, LevelEnergy, Level
+from carsus.model import Atom, AtomicWeight, DataSource, Ion, LevelEnergy,\
+    Level, Line, LineGFValue, LineWavelength, LineAValue
 from astropy import units as u
 from astropy.units import UnitsError, UnitConversionError
 from sqlalchemy import and_
@@ -134,13 +135,18 @@ def test_ions_count(foo_session):
 ])
 def test_levels_measured_energies(foo_session, method, expected):
     levels_w_eth = foo_session.query(Level, LevelEnergy).\
-        join(Level.energies).filter(LevelEnergy.method == method).all()
+        join(Level.energies).filter(LevelEnergy.method == method).limit(2)
     energies = [en.quantity for lvl, en in levels_w_eth]
     with u.set_enabled_equivalencies(u.spectral()):
         assert_quantity_allclose(energies, expected)
 
 
 def test_levels_chianiti_index(foo_session):
-    levels = foo_session.query(Level).all()
+    levels = foo_session.query(Level).limit(2)
     indices = {lvl.ch_index for lvl in levels}
     assert indices == set([1, 2])
+
+
+def test_lines_chianti(foo_session):
+    line0, line1 = foo_session.query(Line).all()
+    import pdb; pdb.set_trace()

--- a/carsus/model/tests/test_atomic.py
+++ b/carsus/model/tests/test_atomic.py
@@ -2,7 +2,6 @@ import pytest
 import numpy as np
 from carsus.model import Atom, AtomicWeight, DataSource, Ion, LevelEnergy,\
     Level, Line, LineGFValue, LineWavelength, LineAValue, ECollision,\
-    ECollisionTemp, ECollisionStrength, \
     ECollisionGFValue, ECollisionTempStrength, ECollisionEnergy
 from astropy import units as u
 from astropy.units import UnitsError, UnitConversionError
@@ -160,7 +159,4 @@ def test_lines_chianti(foo_session):
 def test_e_collisions_chianti(foo_session, tuple_index, expected_temp_strength):
     e_col = foo_session.query(ECollision).first()
     temp, strength = e_col.temp_strengths_tuple[tuple_index]
-    assert_quantity_allclose(
-        [temp.quantity, strength.quantity],
-        expected_temp_strength
-    )
+    assert_allclose([temp, strength], expected_temp_strength)

--- a/carsus/model/tests/test_atomic.py
+++ b/carsus/model/tests/test_atomic.py
@@ -1,10 +1,12 @@
 import pytest
-from carsus.model import Atom, AtomicWeight, DataSource
+import numpy as np
+from carsus.model import Atom, AtomicWeight, DataSource, Ion, LevelEnergy, Level
 from astropy import units as u
 from astropy.units import UnitsError, UnitConversionError
 from sqlalchemy import and_
 from sqlalchemy.exc import IntegrityError
 from numpy.testing import assert_allclose, assert_almost_equal
+from astropy.tests.helper import assert_quantity_allclose
 
 def test_atom_count(foo_session):
     assert foo_session.query(Atom).count() == 2
@@ -31,7 +33,7 @@ def test_data_source_as_unique(memory_session):
 
 
 def test_data_sources_count(foo_session):
-    assert foo_session.query(DataSource).count() == 2
+    assert foo_session.query(DataSource).count() == 3
 
 
 def test_data_sources_unique_constraint(foo_session):
@@ -119,3 +121,26 @@ def test_atomic_quantity_compare_uncompatible_units(foo_session):
 def test_atomic_quantity_compare_with_zero(foo_session):
     res = foo_session.query(AtomicWeight).filter(AtomicWeight.quantity > 0).count()
     assert res == 2
+
+
+def test_ions_count(foo_session):
+    res = foo_session.query(Ion).count()
+    assert res == 2
+
+
+@pytest.mark.parametrize("method, expected",[
+    ("th", [0, 780.0]*u.Unit("cm-1")),
+    ("m", [0, 780.4]*u.Unit("cm-1"))
+])
+def test_levels_measured_energies(foo_session, method, expected):
+    levels_w_eth = foo_session.query(Level, LevelEnergy).\
+        join(Level.energies).filter(LevelEnergy.method == method).all()
+    energies = [en.quantity for lvl, en in levels_w_eth]
+    with u.set_enabled_equivalencies(u.spectral()):
+        assert_quantity_allclose(energies, expected)
+
+
+def test_levels_chianiti_index(foo_session):
+    levels = foo_session.query(Level).all()
+    indices = {lvl.ch_index for lvl in levels}
+    assert indices == set([1, 2])

--- a/carsus/model/tests/test_atomic.py
+++ b/carsus/model/tests/test_atomic.py
@@ -1,7 +1,9 @@
 import pytest
 import numpy as np
 from carsus.model import Atom, AtomicWeight, DataSource, Ion, LevelEnergy,\
-    Level, Line, LineGFValue, LineWavelength, LineAValue
+    Level, Line, LineGFValue, LineWavelength, LineAValue, ECollision,\
+    ECollisionTemp, ECollisionStrength, \
+    ECollisionGFValue, ECollisionTempStrength, ECollisionEnergy
 from astropy import units as u
 from astropy.units import UnitsError, UnitConversionError
 from sqlalchemy import and_
@@ -149,4 +151,16 @@ def test_levels_chianiti_index(foo_session):
 
 def test_lines_chianti(foo_session):
     line0, line1 = foo_session.query(Line).all()
-    import pdb; pdb.set_trace()
+
+
+@pytest.mark.parametrize("tuple_index, expected_temp_strength",[
+    (0, [0.0, 0.255]),
+    (1, [0.07394, 0.266])
+])
+def test_e_collisions_chianti(foo_session, tuple_index, expected_temp_strength):
+    e_col = foo_session.query(ECollision).first()
+    temp, strength = e_col.temp_strengths_tuple[tuple_index]
+    assert_quantity_allclose(
+        [temp.quantity, strength.quantity],
+        expected_temp_strength
+    )


### PR DESCRIPTION
Tables
========

![collisions](https://cloud.githubusercontent.com/assets/8950027/15681735/8a8a206e-276b-11e6-9aa8-0c687ffcf796.png)

- The `ECollision` table is a subset table of `Transition`, similarly to the `Lines` table.
-  `ECollisionTempStrength` is an association table that relates scaled temperatures (`ECollisionTemp`) to scaled effective collision strengths (`ECollisionStrength`). 

Mapping Classes
==============

To understand the purpose of the `ECollisionTempStrength` table lets look at the `ECollision` class:

```
class ECollision(Transition):
    __tablename__ = "e_collision"

    id = Column(Integer, ForeignKey('transition.id'), primary_key=True)
    bt92_ttype = Column(Integer)  # BT92 Transition type
    bt92_cups = Column(Float)  # BT92 Scaling parameter

    energies = relationship("ECollisionEnergy",
                            backref="e_collision")
    gf_values = relationship("ECollisionGFValue",
                            backref="e_collision")
    temp_strengths = relationship("ECollisionTempStrength",
                            backref="e_collision")

    temp_strengths_tuple = association_proxy("temp_strengths", "as_tuple")

    __mapper_args__ = {
        'polymorphic_identity': 'e_collision'
    }
``` 

Using the `temp_strength_tuple` attribute we can set temperatures and collisions as a list of tuples:
 ```
 e_col = ECollision(
        source_level=ne_1_lvl0,
        target_level=ne_1_lvl1,
        data_source=ch,
        bt92_ttype=2,
        bt92_cups=11.16,
        energies=[
            ECollisionEnergy(quantity=0.007108*u.rydberg)
        ],
        temp_strengths_tuple=[
            (ECollisionTemp(quantity=0.0), ECollisionStrength(quantity=0.255)),
            (ECollisionTemp(quantity=0.07394), ECollisionStrength(quantity=0.266))
        ]
    )
```
