### PR TITLE
Atomic refactoring

### DIFF
--- a/carsus/base.py
+++ b/carsus/base.py
@@ -1,7 +1,7 @@
 import os
 import pandas as pd
 import carsus
-from carsus.model import Atom, setup
+from carsus.model import BasicAtom, setup
 
 
 basic_atomic_data_fname = os.path.join(carsus.__path__[0], 'data',
@@ -29,7 +29,7 @@ def init_db(url, **kwargs):
     print "Initializing the database"
     session = setup(url, **kwargs)
 
-    if session.query(Atom).count() == 0:
+    if session.query(BasicAtom).count() == 0:
         _init_empty_db(session)
 
     return session
@@ -40,6 +40,6 @@ def _init_empty_db(session):
     basic_atomic_data = pd.read_csv(basic_atomic_data_fname)
     print "Ingesting basic atomic data"
     for i, row in basic_atomic_data.iterrows():
-        session.add(Atom(atomic_number=row['atomic_number'], name=row['name'],
+        session.add(BasicAtom(atomic_number=row['atomic_number'], name=row['name'],
                           symbol=row['symbol'], group=row['group'],
                           period=row['period']))

--- a/carsus/conftest.py
+++ b/carsus/conftest.py
@@ -34,15 +34,19 @@ from sqlalchemy.orm import Session
 # except NameError:   # Needed to support Astropy <= 1.0.0
 #     pass
 
-data_dir = os.path.join(os.path.dirname(__file__), 'tests', 'data')
-if not os.path.exists(data_dir):
-    os.makedirs(data_dir)
 
-test_db_url = 'sqlite:///' + os.path.join(data_dir, 'test.db')
+@pytest.fixture(scope="session")
+def test_db_url():
+    data_dir = os.path.join(os.path.dirname(__file__), 'tests', 'data')
+    if not os.path.exists(data_dir):
+        os.makedirs(data_dir)
+    test_db_path = os.path.join(data_dir, 'test.db')
+    open(test_db_path, "w").close()
+    return 'sqlite:///' + test_db_path
 
 
 @pytest.fixture(scope="session")
-def test_engine():
+def test_engine(test_db_url):
     session = init_db(url=test_db_url)
     session.commit()
     session.close()

--- a/carsus/io/tests/test_nist_weightscomp.py
+++ b/carsus/io/tests/test_nist_weightscomp.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_almost_equal
 from astropy import units as u
 from carsus.io.nist import NISTWeightsCompIngester, NISTWeightsCompPyparser
 from carsus.io.nist.weightscomp_grammar import *
-from carsus.model import Atom, AtomicWeight, DataSource
+from carsus.model import Atom, AtomWeight, DataSource
 
 test_input = """
 Atomic Number = 35
@@ -94,45 +94,19 @@ def test_weightscomp_pyparser_prepare_atomic_df_index(atomic_df):
 def test_weightscomp_pyparser_prepare_atomic_df_(atomic_df, expected_df):
     assert_frame_equal(atomic_df, expected_df, check_names=False)
 
-
-
-@pytest.mark.parametrize("atomic_number,nom_val,std_dev", expected_tuples)
-def test_weithscomp_ingest_existing_atomic_weights(atomic_number, nom_val, std_dev, weightscomp_ingester, test_session):
-    nist = DataSource.as_unique(test_session, short_name="nist")
-    atom = test_session.query(Atom).filter(Atom.atomic_number==atomic_number).one()
-
-    atom.quantities = [
-        AtomicWeight(data_source=nist, quantity=9.9999*u.u)
-    ]
-    test_session.commit()
-
-    weightscomp_ingester.ingest(test_session)
-
-    q = test_session.query(Atom, AtomicWeight).\
-        join(Atom.quantities.of_type(AtomicWeight)).\
-        filter(AtomicWeight.data_source==nist).\
-        filter(Atom.atomic_number==atomic_number).one()
-
-    assert q.AtomicWeight.atomic_number == atomic_number
-    assert_almost_equal(q.AtomicWeight.quantity.value, nom_val)
-    assert_almost_equal(q.AtomicWeight.std_dev, std_dev)
-
-
-@pytest.mark.parametrize("atomic_number,nom_val,std_dev", expected_tuples)
-def test_weightscomp_ingest_nonexisting_atomic_weights(atomic_number, nom_val, std_dev, weightscomp_ingester, test_session):
+@pytest.mark.parametrize("atomic_number,value,uncert", expected_tuples)
+def test_weightscomp_ingest_atomic_weights(atomic_number, value, uncert, weightscomp_ingester, test_session):
     weightscomp_ingester.ingest(test_session)
     nist = DataSource.as_unique(test_session, short_name="nist")
-    aw = test_session.query(AtomicWeight).\
-        filter(AtomicWeight.atomic_number==atomic_number).\
-        filter(AtomicWeight.data_source==nist).one()
-    assert_almost_equal(aw.quantity.value, nom_val)
-    assert_almost_equal(aw.std_dev, std_dev)
+    atom = Atom.as_unique(test_session, atomic_number=atomic_number, data_source=nist)
+    aw = test_session.query(AtomWeight).\
+        filter(AtomWeight.atom==atom).one()
+    assert_almost_equal(aw.quantity.value, value)
+    assert_almost_equal(aw.uncert, uncert)
 
 
 @pytest.mark.remote_data
 def test_weightscomp_ingest_default_count(weightscomp_ingester, test_session):
     weightscomp_ingester.download()
     weightscomp_ingester.ingest(test_session)
-    nist = DataSource.as_unique(test_session, short_name="nist")
-    assert test_session.query(AtomicWeight).\
-               filter(AtomicWeight.data_source==nist).count() == 94
+    assert test_session.query(AtomWeight).count() == 94

--- a/carsus/model/__init__.py
+++ b/carsus/model/__init__.py
@@ -1,2 +1,2 @@
-from .atomic import Atom, AtomicQuantity, AtomicWeight, DataSource
+from .atomic import Atom, BasicAtom, AtomQuantity, AtomWeight, DataSource
 from .meta import Base, setup

--- a/carsus/model/atomic.py
+++ b/carsus/model/atomic.py
@@ -1,4 +1,4 @@
-from .meta import Base, UniqueMixin, DBQuantity
+from .meta import Base, UniqueMixin, QuantityMixin
 
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.exc import NoResultFound
@@ -7,75 +7,64 @@ from sqlalchemy import Column, Integer, String, Float, ForeignKey, UniqueConstra
 from astropy import units as u
 
 
-class Atom(Base):
+class Atom(UniqueMixin, Base):
     __tablename__ = "atom"
+
+    @classmethod
+    def unique_hash(cls, atomic_number, data_source, *args, **kwargs):
+        return "atom:{0}_{1}".format(atomic_number, data_source.short_name)
+
+    @classmethod
+    def unique_filter(cls, query, atomic_number, data_source, *args, **kwargs):
+        return query.filter(and_(Atom.atomic_number == atomic_number,
+                                 Atom.data_source == data_source))
+
+    atom_id = Column(Integer, primary_key=True)
+    atomic_number = Column(Integer, ForeignKey('basic_atom.atomic_number'), nullable=False)
+    data_source_id = Column(Integer, ForeignKey('data_source.data_source_id'), nullable=False)
+
+    weights = relationship("AtomWeight", back_populates='atom')
+    data_source = relationship("DataSource", back_populates='atoms')
+
+    basic_atom = relationship("BasicAtom")
+
+    __table_args__ = (UniqueConstraint('atomic_number', 'data_source_id'),)
+
+    def __repr__(self):
+        return "<Atom Z={0}>".format(self.atomic_number)
+
+
+class BasicAtom(Base):
+    __tablename__ = "basic_atom"
+
     atomic_number = Column(Integer, primary_key=True)
-    symbol = Column(String(5), nullable=False)
-    name = Column(String(150))
+    symbol = Column(String(3), nullable=False)
+    name = Column(String(25))
     group = Column(Integer)
     period = Column(Integer)
-    quantities = relationship("AtomicQuantity",
-                    backref='atom',
-                    cascade='all, delete-orphan')
-
-    def __repr__(self):
-        return "<Atom {0}, Z={1}>".format(self.symbol, self.atomic_number)
-
-    def merge_quantity(self, session, source_qty):
-        """ Updates an existing quantity or creates a new one"""
-        qty_cls = source_qty.__class__
-        try:
-            target_qty = session.query(qty_cls).\
-                         filter(and_(qty_cls.atom==self,
-                                     qty_cls.data_source==source_qty.data_source)).one()
-            target_qty.quantity = source_qty.quantity
-            target_qty.std_dev = source_qty.std_dev
-
-        except NoResultFound:
-
-            self.quantities.append(source_qty)
 
 
-class AtomicQuantity(Base):
+class AtomQuantity(QuantityMixin, Base):
     __tablename__ = "atomic_quantity"
 
-    id = Column(Integer, primary_key=True)
+    atom_qty_id = Column(Integer, primary_key=True)
+    atom_id = Column(Integer, ForeignKey("atom.atom_id"), nullable=False)
     type = Column(String(20))
-    atomic_number = Column(Integer, ForeignKey('atom.atomic_number'), nullable=False)
-    data_source_id = Column(Integer, ForeignKey('data_source.id'), nullable=False)
 
-    _value = Column(Float, nullable=False)
-    unit = u.Unit("")
-
-    # Public interface for value is via the Quantity object
-    @hybrid_property
-    def quantity(self):
-        return DBQuantity(self._value, self.unit)
-
-    @quantity.setter
-    def quantity(self, qty):
-        self._value = qty.to(self.unit).value
-
-    std_dev = Column(Float)
-
-    data_source = relationship("DataSource")
-
-    __table_args__ = (UniqueConstraint('type', 'atomic_number', 'data_source_id'),)
+    __table_args__ = (UniqueConstraint('type', 'atom_id'),)
     __mapper_args__ = {
-        'polymorphic_on':type,
-        'polymorphic_identity':'atomic_quantity',
-        'with_polymorphic' : '*'
+        'polymorphic_on': type,
+        'polymorphic_identity': 'qty'
     }
 
-    def __repr__(self):
-        return "<Quantity: {0}, value: {1}>".format(self.type, self._value)
 
-
-class AtomicWeight(AtomicQuantity):
+class AtomWeight(AtomQuantity):
     unit = u.u
 
+    atom = relationship("Atom", back_populates='weights')
+
     __mapper_args__ = {
-        'polymorphic_identity':'atomic_weight'
+        'polymorphic_identity': 'weight'
     }
 
 
@@ -90,11 +79,13 @@ class DataSource(UniqueMixin, Base):
     def unique_filter(cls, query, short_name, *args, **kwargs):
         return query.filter(DataSource.short_name == short_name)
 
-    id = Column(Integer, primary_key=True)
+    data_source_id = Column(Integer, primary_key=True)
     short_name = Column(String(20), unique=True, nullable=False)
     name = Column(String(120))
     description = Column(String(800))
     data_source_quality = Column(Integer)
+
+    atoms = relationship("Atom", back_populates="data_source")
 
     def __repr__(self):
         return "<Data Source: {}>".format(self.short_name)

--- a/carsus/model/meta/__init__.py
+++ b/carsus/model/meta/__init__.py
@@ -1,3 +1,4 @@
 from .types import DBQuantity
 from .orm import UniqueMixin
+from .schema import QuantityMixin
 from .base import Base, setup

--- a/carsus/model/meta/schema.py
+++ b/carsus/model/meta/schema.py
@@ -1,0 +1,38 @@
+""" Database schema generation/definition helpers """
+
+from sqlalchemy import Column, Integer, Float, String
+from sqlalchemy.ext.hybrid import hybrid_property
+from ..meta.types import DBQuantity
+from astropy.units import dimensionless_unscaled, UnitsError, set_enabled_equivalencies
+
+
+class QuantityMixin(object):
+
+    _value = Column(Float, nullable=False)
+    uncert = Column(Float)
+    method = Column(String(15))
+    reference = Column(String(50))
+
+    unit = dimensionless_unscaled
+    equivalencies = None
+
+    # Public interface for value is via `.quantity` accessor
+    @hybrid_property
+    def quantity(self):
+        return DBQuantity(self._value, self.unit)
+
+    @quantity.setter
+    def quantity(self, qty):
+        try:
+            with set_enabled_equivalencies(self.equivalencies):
+                self._value = qty.to(self.unit).value
+        except AttributeError:
+            if self.unit is dimensionless_unscaled or qty == 0:
+                self._value = qty
+            else:
+                raise UnitsError("Can only assign dimensionless values "
+                                 "to dimensionless quantities "
+                                 "(unless the value is 0)")
+
+    def __repr__(self):
+        return "<Quantity: {0} {1}>".format(self._value, self.unit)

--- a/carsus/model/tests/conftest.py
+++ b/carsus/model/tests/conftest.py
@@ -3,81 +3,49 @@ import pytest
 import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
-from carsus.model import Base, Atom, DataSource, AtomicWeight
+from carsus.model import Base, Atom, DataSource, AtomWeight, BasicAtom
 from astropy import units as u
-
-data_dir = os.path.join(os.path.dirname(__file__), 'data')
-if not os.path.exists(data_dir):
-    os.makedirs(data_dir)
-
-foo_db_url = 'sqlite:///' + os.path.join(data_dir, 'foo.db')
 
 
 @pytest.fixture
-def memory_session():
+def memory_engine():
     engine = create_engine("sqlite://")
     Base.metadata.create_all(engine)
-    session = Session(bind=engine)
+    return engine
+
+
+@pytest.fixture
+def empty_session(memory_engine):
+    session = Session(bind=memory_engine)
     return session
 
 
-@pytest.fixture(scope="session")
-def foo_engine():
-    engine = create_engine(foo_db_url)
-    Base.metadata.drop_all(engine)
-    Base.metadata.create_all(engine)
-    session = Session(bind=engine)
+@pytest.fixture
+def atom_session(empty_session):
 
-    # atoms
-    H = Atom(atomic_number=1, symbol='H')
-    O = Atom(atomic_number=8, symbol='O')
+    # basic atoms
+    basic_h = BasicAtom(atomic_number=1, symbol='H')
+    basic_o = BasicAtom(atomic_number=8, symbol='O')
 
     # data sources
     nist = DataSource(short_name='nist')
     ku = DataSource(short_name='ku')
 
-    # atomic weights
-    H.quantities = [
-        AtomicWeight(quantity=1.00784*u.u, data_source=nist, std_dev=4e-3),
-        AtomicWeight(quantity=1.00811*u.u, data_source=ku, std_dev=4e-3),
-    ]
+    # atoms
+    h_nist = Atom(atomic_number=1,
+             data_source=nist,
+             weights=[
+                 AtomWeight(quantity=1.00784 * u.u, uncert=4e-3)
+             ])
 
-    session.add_all([H, O, nist, ku])
-    session.commit()
-    session.close()
-    return engine
+    h_ku = Atom(atomic_number=1,
+              data_source=ku,
+              weights=[
+                  AtomWeight(quantity=1.00811*u.u, uncert=4e-3)
+              ])
 
+    o = Atom(atomic_number=8, data_source=nist)
 
-@pytest.fixture
-def foo_session(foo_engine, request):
-    # connect to the database
-    connection = foo_engine.connect()
-
-    # begin a non-ORM transaction
-    trans = connection.begin()
-
-    # bind an individual Session to the connection
-    session = Session(bind=connection)
-
-    def fin():
-        session.close()
-        # rollback - everything that happened with the
-        # Session above (including calls to commit())
-        # is rolled back.
-        trans.rollback()
-        # return connection to the Engine
-        connection.close()
-
-    request.addfinalizer(fin)
-
-    return session
-
-
-@pytest.fixture
-def H(foo_session):
-    return foo_session.query(Atom).filter(Atom.atomic_number==1).one()
-
-
-@pytest.fixture
-def nist(foo_session):
-    return DataSource.as_unique(foo_session, short_name="nist")
+    empty_session.add_all([basic_h, basic_o, h_nist, h_ku, o, nist, ku])
+    empty_session.commit()
+    return empty_session

--- a/carsus/model/tests/test_atomic.py
+++ b/carsus/model/tests/test_atomic.py
@@ -1,121 +1,76 @@
 import pytest
-from carsus.model import Atom, AtomicWeight, DataSource
+from carsus.model import Atom, BasicAtom, AtomWeight, DataSource
 from astropy import units as u
 from astropy.units import UnitsError, UnitConversionError
 from sqlalchemy import and_
 from sqlalchemy.exc import IntegrityError
 from numpy.testing import assert_allclose, assert_almost_equal
-
-def test_atom_count(foo_session):
-    assert foo_session.query(Atom).count() == 2
+from astropy.tests.helper import assert_quantity_allclose
 
 
-def test_atom_query_atom(foo_session):
-    H = foo_session.query(Atom).\
-        filter(Atom.symbol=="H").one()
-    assert H.atomic_number == 1
+def test_basic_atom_count(atom_session):
+    assert atom_session.query(BasicAtom).count() == 2
 
 
-def test_atom_unique_constraint(foo_session):
-    fake = Atom(atomic_number=1, symbol="Fk")
-    foo_session.add(fake)
-    with pytest.raises(IntegrityError):
-        foo_session.commit()
-
-
-def test_data_source_as_unique(memory_session):
-    nist = DataSource.as_unique(memory_session, short_name="nist",
+def test_data_source_as_unique(empty_session):
+    nist = DataSource.as_unique(empty_session, short_name="nist",
                                 name="National Institute of Standards and Technology")
-    nist2 = DataSource.as_unique(memory_session, short_name="nist")
+    nist2 = DataSource.as_unique(empty_session, short_name="nist",
+                                 name="National Institute of Standards and Technology")
     assert nist is nist2
 
 
-def test_data_sources_count(foo_session):
-    assert foo_session.query(DataSource).count() == 2
+def test_atom_as_unique(empty_session):
+    nist = DataSource.as_unique(empty_session, short_name="nist")
+    h_nist1 = Atom.as_unique(empty_session, atomic_number=1, data_source=nist)
+    h_nist2 = Atom.as_unique(empty_session, atomic_number=1, data_source=nist)
+    assert h_nist1 is h_nist2
 
 
-def test_data_sources_unique_constraint(foo_session):
+def test_data_source_count(atom_session):
+    assert atom_session.query(DataSource).count() == 2
+
+
+def test_data_source_unique_constraint(atom_session):
     duplicate = DataSource(short_name="nist")
-    foo_session.add(duplicate)
+    atom_session.add(duplicate)
     with pytest.raises(IntegrityError):
-        foo_session.commit()
+        atom_session.commit()
 
 
-def test_atomic_weights_values(foo_session):
-    q = foo_session.query(AtomicWeight.quantity.value).\
-        filter(AtomicWeight.atomic_number==1).\
-        order_by(AtomicWeight.quantity.value)
-    values = [_[0] for _ in q]
-    assert_allclose(values, [1.00784, 1.00811])
+def test_atom_relationship_basic_atom(atom_session):
+    ku = DataSource.as_unique(atom_session, short_name="ku")
+    h_ku = Atom.as_unique(atom_session, atomic_number=1, data_source=ku)
+    assert h_ku.basic_atom.symbol == "H"
 
 
-def test_atomic_weights_atom_relationship(foo_session, nist):
-    q = foo_session.query(Atom, AtomicWeight).\
-        join(Atom.quantities.of_type(AtomicWeight)).\
-        filter(AtomicWeight.data_source == nist).first()
-
-    assert_almost_equal(q.AtomicWeight.quantity.value, 1.00784)
-
-
-def test_atomic_weights_convert_to(foo_session):
-    q = foo_session.query(AtomicWeight.quantity.to(u.solMass).value)
-    values = [_[0] for _ in q]
-    assert_allclose(values, [8.41364096027349e-58, 8.415894971881755e-58])
-
-
-def test_atomic_weights_add_same_units(foo_session):
-    q = foo_session.query((AtomicWeight.quantity + 1*u.u).value)
-    values = [_[0] for _ in q]
-    assert_allclose(values, [2.00784, 2.00811])
-
-
-def test_atomic_weights_unique_constraint(foo_session, H, nist):
-    H.quantities.append(
-        AtomicWeight(data_source=nist, quantity=666*u.u)
-    )
+def test_atom_unique_constraint(atom_session):
+    ku = DataSource.as_unique(atom_session, short_name="ku")
+    duplicate_h_ku = Atom(atomic_number=1, data_source=ku)
+    atom_session.add(duplicate_h_ku)
     with pytest.raises(IntegrityError):
-        foo_session.commit()
+        atom_session.commit()
 
 
-def test_atom_merge_new_quantity(foo_session, H):
-    cr = DataSource.as_unique(foo_session, short_name="cr")
-    H.merge_quantity(foo_session, AtomicWeight(data_source=cr, quantity=1.00754*u.u, std_dev=3e-5,))
-    foo_session.commit()
-    res = foo_session.query(AtomicWeight).filter(and_(AtomicWeight.atom==H,
-                                                    AtomicWeight.data_source==cr)).one()
-    assert_almost_equal(res.quantity.value, 1.00754)
+@pytest.mark.parametrize("atomic_number, ds_short_name, expected_weight",[
+    (1, "ku", 1.00811*u.u),
+    (1, "nist", 1.00784*u.u)
+])
+def test_atomic_weights_values(atom_session, atomic_number, ds_short_name, expected_weight):
+    ds = DataSource.as_unique(atom_session, short_name=ds_short_name)
+    atom = Atom.as_unique(atom_session, atomic_number=atomic_number, data_source=ds)
+    aw = atom_session.query(AtomWeight).\
+        filter(AtomWeight.atom==atom).one()
+    assert_quantity_allclose([aw.quantity], expected_weight)
 
 
-def test_atom_merge_existing_quantity(foo_session, H, nist):
-    H.merge_quantity(foo_session,  AtomicWeight(data_source=nist, quantity=1.00654*u.u, std_dev=4e-5,))
-    foo_session.commit()
-    res = foo_session.query(AtomicWeight).filter(and_(AtomicWeight.atom==H,
-                                                    AtomicWeight.data_source==nist)).one()
-    assert_almost_equal(res.quantity.value, 1.00654)
-
-
-def test_atomic_quantity_convert_to(foo_session, H, nist):
-    res = foo_session.query(AtomicWeight.quantity.to(u.ng).value).filter(and_(AtomicWeight.atom==H,
-                                                    AtomicWeight.data_source==nist)).scalar()
-    assert_almost_equal(res, 1.6735573234079996e-15)
-
-
-def test_atomic_quantity_compare(foo_session):
-    res = foo_session.query(AtomicWeight).filter(AtomicWeight.quantity > 1.008*u.u).count()
-    assert res == 1
-
-
-def test_atomic_quantity_compare_diff_units(foo_session):
-    res = foo_session.query(AtomicWeight).\
-        filter(AtomicWeight.quantity > 1.6738230095999998e-27*u.kg).count()
-    assert res == 1
-
-
-def test_atomic_quantity_compare_uncompatible_units(foo_session):
-    with pytest.raises(UnitConversionError):
-        res = foo_session.query(AtomicWeight).filter(AtomicWeight.quantity > 1.008*u.m)
-
-
-def test_atomic_quantity_compare_with_zero(foo_session):
-    res = foo_session.query(AtomicWeight).filter(AtomicWeight.quantity > 0).count()
-    assert res == 2
+@pytest.mark.parametrize("atomic_number, ds_short_name, expected_weight_value",[
+    (1, "ku", 8.41364096027349e-58),
+    (1, "nist", 8.415894971881755e-58)
+])
+def test_atomic_weights_convert_to(atom_session, atomic_number, ds_short_name, expected_weight_value):
+    ds = DataSource.as_unique(atom_session, short_name=ds_short_name)
+    atom = Atom.as_unique(atom_session, atomic_number=atomic_number, data_source=ds)
+    atom_weight_value = atom_session.query(AtomWeight.quantity.to(u.solMass).value). \
+                        filter(AtomWeight.atom == atom).scalar()
+    assert_almost_equal(atom_weight_value, expected_weight_value)

--- a/carsus/tests/test_base.py
+++ b/carsus/tests/test_base.py
@@ -1,10 +1,10 @@
 import pytest
 from numpy.testing import assert_almost_equal
-from carsus.model import Atom
+from carsus.model import BasicAtom
 
 
 def test_init_db(test_session):
-    assert test_session.query(Atom).count() == 118
+    assert test_session.query(BasicAtom).count() == 118
 
 
 @pytest.mark.parametrize("atomic_number,expected",[
@@ -12,7 +12,7 @@ def test_init_db(test_session):
     (19, {'atomic_number':19, 'symbol':'K', 'name':'Potassium', 'group': 1.0, 'period':4})
 ])
 def test_atomic_database_test_atoms(atomic_number, expected, test_session):
-    atom = test_session.query(Atom).filter_by(atomic_number=atomic_number).one()
+    atom = test_session.query(BasicAtom).get(atomic_number)
     assert atom.atomic_number == expected['atomic_number']
     assert atom.symbol == expected['symbol']
     assert atom.name == expected['name']


### PR DESCRIPTION
New schema:
===========
![atoms2](https://cloud.githubusercontent.com/assets/8950027/15716300/cf8126fa-2832-11e6-8970-ea145bf1428d.png)


Old schema:
==========
![atomic](https://cloud.githubusercontent.com/assets/8950027/15715955/84ebe932-2831-11e6-89dd-db60f0c5a2b1.png)

What's different:
=============

- General information about atoms is now stored in `BasicAtom`. 
- `Atom` has a many-to-one relationship with `DataSource`.
- `AtomQuantity` does not have a relationship with `DataSource` any more. Instead, it is has the `reference` field and a relationship with `Atom`. One can find `AtomQuantity`'s data source from its `Atom` (or Ion, Level, Transition for other quantities)
