### PR TITLE
add QuantityMixin

### DIFF
--- a/carsus/model/meta/schema.py
+++ b/carsus/model/meta/schema.py
@@ -1,0 +1,38 @@
+""" Database schema generation/definition helpers """
+
+from sqlalchemy import Column, Integer, Float, String
+from sqlalchemy.ext.hybrid import hybrid_property
+from ..meta.types import DBQuantity
+from astropy.units import dimensionless_unscaled, UnitsError, set_enabled_equivalencies
+
+
+class QuantityMixin(object):
+
+    _value = Column(Float, nullable=False)
+    uncert = Column(Float)
+    method = Column(String(15))
+    reference = Column(String(50))
+
+    unit = dimensionless_unscaled
+    equivalencies = None
+
+    # Public interface for value is via `.quantity` accessor
+    @hybrid_property
+    def quantity(self):
+        return DBQuantity(self._value, self.unit)
+
+    @quantity.setter
+    def quantity(self, qty):
+        try:
+            with set_enabled_equivalencies(self.equivalencies):
+                self._value = qty.to(self.unit).value
+        except AttributeError:
+            if self.unit is dimensionless_unscaled or qty == 0:
+                self._value = qty
+            else:
+                raise UnitsError("Can only assign dimensionless values "
+                                 "to dimensionless quantities "
+                                 "(unless the value is 0)")
+
+    def __repr__(self):
+        return "<Quantity: {0} {1}>".format(self._value, self.unit)


### PR DESCRIPTION
A mixin class for quantities that adds to mapping class the following set of columns:
 - _value
 - uncert
 - method
 - reference

The mixin class also provides a public accessor `.quantity` for converting `_value` to different units in queries and converting values to the base unit of the quantity when setting `_value`.