### PR TITLE
Level mapping classes

### DIFF
--- a/carsus/model/__init__.py
+++ b/carsus/model/__init__.py
@@ -1,3 +1,3 @@
 from .atomic import Atom, AtomQuantity, AtomWeight, DataSource,\
-    Ion, IonQuantity, IonizationEnergy
+    Ion, IonQuantity, IonizationEnergy, LevelEnergy, Level, LevelQuantity
 from .meta import Base, setup

--- a/carsus/model/atomic.py
+++ b/carsus/model/atomic.py
@@ -99,13 +99,13 @@ class Level(Base):
     __tablename__ = "level"
 
     level_id = Column(Integer, primary_key=True)
-    level_index = Column(Integer, nullable=False)  # Index of this level from the data source
+
     # Ion CFK
     atomic_number = Column(Integer, nullable=False)
     ion_charge = Column(Integer, nullable=False)
 
     data_source_id = Column(Integer, ForeignKey('data_source.data_source_id'), nullable=False)
-
+    level_index = Column(Integer)  # Index of this level from its data source
     configuration = Column(String(50))
     L = Column(String(2))  # total orbital angular momentum
     J = Column(Float)  # total angular momentum
@@ -118,10 +118,8 @@ class Level(Base):
     ion = relationship("Ion", back_populates="levels")
     data_source = relationship("DataSource", back_populates="levels")
 
-    __table_args__ = (UniqueConstraint('level_index', 'atomic_number', 'ion_charge', 'data_source_id'),
-                      ForeignKeyConstraint(['atomic_number', 'ion_charge'],
-                                           ['ion.atomic_number', 'ion.ion_charge'])
-                      )
+    __table_args__ = (ForeignKeyConstraint(['atomic_number', 'ion_charge'],
+                                           ['ion.atomic_number', 'ion.ion_charge']),)
 
 
 class LevelQuantity(QuantityMixin, Base):

--- a/carsus/model/tests/conftest.py
+++ b/carsus/model/tests/conftest.py
@@ -4,7 +4,7 @@ import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from carsus.model import Base, Atom, DataSource, AtomWeight,\
-    Ion, IonizationEnergy
+    Ion, IonizationEnergy, Level, LevelEnergy
 from astropy import units as u
 
 data_dir = os.path.join(os.path.dirname(__file__), 'data')
@@ -36,6 +36,7 @@ def foo_engine():
     # data sources
     nist = DataSource(short_name='nist')
     ku = DataSource(short_name='ku')
+    ch = DataSource(short_name="chianti")
 
     # atomic weights
     h.weights = [
@@ -44,14 +45,14 @@ def foo_engine():
     ]
 
     # ions
-    h_o = Ion(
+    h0 = Ion(
         atomic_number=1,
         ion_charge=0,
         ionization_energies=[
             IonizationEnergy(quantity=13.5984*u.eV, data_source=nist, method="th")
         ])
 
-    ne_1 = Ion(
+    ne1 = Ion(
         atomic_number=10,
         ion_charge=1,
         ionization_energies=[
@@ -60,7 +61,40 @@ def foo_engine():
         ]
     )
 
-    session.add_all([h, ne, h_o, ne_1, nist, ku])
+    ne2 = Ion(
+        atomic_number=10,
+        ion_charge=2,
+        ionization_energies=[
+            IonizationEnergy(quantity=48.839 * u.eV, data_source=nist, method="th")
+        ]
+    )
+
+    # levels
+    ne2_lvl0_ku = Level(
+        ion=ne2, data_source=ku, level_index=1,
+        configuration="2s2.2p5", term="2P1.5", L="P", J=1.5, spin_multiplicity=2, parity=1,
+        energies=[
+            LevelEnergy(quantity=0, data_source=ku, method="m"),
+            LevelEnergy(quantity=0, data_source=ku, method="th")
+        ])
+
+    ne2_lvl1_ku = Level(
+        ion=ne2, data_source=ku, level_index=2,
+        configuration="2s2.2p5", term="2P0.5", L="P", J=0.5, spin_multiplicity=2, parity=1,
+        energies=[
+            LevelEnergy(quantity=780.4*u.Unit("cm-1"), data_source=ku, method="m"),
+            LevelEnergy(quantity=780.0*u.Unit("cm-1"), data_source=ku, method="th")
+        ])
+
+    ne2_lvl1_ch = Level(
+        ion=ne2, data_source=ch, level_index=2,
+        configuration="2s2.2p5", term="2P0.5", L="P", J=0.5, spin_multiplicity=2, parity=1,
+        energies=[
+            LevelEnergy(quantity=780.2*u.Unit("cm-1"), data_source=ch, method="m")
+        ])
+
+    session.add_all([h, ne, nist, ku, ch, h0, ne1,
+                     ne2_lvl1_ch, ne2_lvl0_ku, ne2_lvl1_ku])
     session.commit()
     session.close()
     return engine


### PR DESCRIPTION
Tables:
=======
![pr_level_mapping_classes](https://cloud.githubusercontent.com/assets/8950027/15974280/b5826214-2f58-11e6-9f26-447501479408.png)

Note that all Quantities tables have a relationship with `DataSource` and `Level` has a relationship with `DataSource`. Currently levels are identified by their data source, ion, and index from the source, that is not very good  but I don't see another way now.

Legend
-----------
Colours:
 - lightblue - tables
 - lightgrey - subset tables, they subclass tables and have all their columns and relationships
 - lightpink - mixin classes, gives every table their columns and relationships

Abbreviations:
- PK - primary key
- CPK - composite primary key
- FK - foreign key
- CFK - composite foreign key

