### PR TITLE
Chianti ingest transitions

### DIFF
--- a/carsus/io/tests/test_chianti_io.py
+++ b/carsus/io/tests/test_chianti_io.py
@@ -1,6 +1,6 @@
 import pytest
 from ..chianti_io import ChiantiIonReader, ChiantiIngester
-from carsus.model import Level, LevelEnergy, Ion
+from carsus.model import Level, LevelEnergy, Ion, Line, ECollision
 from numpy.testing import assert_almost_equal
 
 
@@ -34,3 +34,23 @@ def test_chianti_ingest_levels_count(test_session, ch_ingester, atomic_number, i
     ch_ingester.ingest(levels=True)
     ion = Ion.as_unique(test_session, atomic_number=atomic_number, ion_charge=ion_charge)
     assert len(ion.levels) == levels_count
+
+
+@pytest.mark.parametrize("atomic_number, ion_charge, lines_count",[
+    (10, 1, 1999)
+])
+def test_chianti_ingest_lines_count(test_session, ch_ingester, atomic_number, ion_charge, lines_count):
+    ch_ingester.ingest(levels=True, lines=True)
+    ion = Ion.as_unique(test_session, atomic_number=atomic_number, ion_charge=ion_charge)
+    cnt = test_session.query(Line).join(Line.lower_level).filter(Level.ion==ion).count()
+    assert cnt == lines_count
+
+
+@pytest.mark.parametrize("atomic_number, ion_charge, e_col_count",[
+    (10, 1, 9453)
+])
+def test_chianti_ingest_e_col_count(test_session, ch_ingester, atomic_number, ion_charge, e_col_count):
+    ch_ingester.ingest(levels=True, collisions=True)
+    ion = Ion.as_unique(test_session, atomic_number=atomic_number, ion_charge=ion_charge)
+    cnt = test_session.query(ECollision).join(ECollision.lower_level).filter(Level.ion==ion).count()
+    assert cnt == e_col_count


### PR DESCRIPTION
Implemented two methods for ingesting lines and electron collisions from the CHIANTI database:
- `ingest_lines`
- `ingest_collisions`
