### PR TITLE
Travis cache (NOT to merge)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,12 @@ python:
 virtualenv:
   system_site_packages: true
 
-cache:
-  apt: true
-
 sudo: false
 
+cache:
+  apt: true
+  directories:
+  - $HOME/chianti
 
 env:
     global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ before_install:
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH=$HOME/miniconda/bin:$PATH
     # install the CHIANTI database
-    - mkdir $HOME/chianti
     - wget $CHIANTI_DATA_URL -O $HOME/chianti/CHIANTI_8.0.2_data.tar.gz
     - tar -zxvf $HOME/chianti/CHIANTI_8.0.2_data.tar.gz -C $HOME/chianti
     - export XUVTOP=$HOME/chianti

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,8 @@ before_install:
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH=$HOME/miniconda/bin:$PATH
     # install the CHIANTI database
-    - wget $CHIANTI_DATA_URL -O $HOME/chianti/CHIANTI_8.0.2_data.tar.gz
-    - tar -zxvf $HOME/chianti/CHIANTI_8.0.2_data.tar.gz -C $HOME/chianti
+    #- wget $CHIANTI_DATA_URL -O $HOME/chianti/CHIANTI_8.0.2_data.tar.gz
+    #- tar -zxvf $HOME/chianti/CHIANTI_8.0.2_data.tar.gz -C $HOME/chianti
     - export XUVTOP=$HOME/chianti
     - hash -r
     - conda update --yes conda


### PR DESCRIPTION
So in the first commit https://github.com/tardis-sn/carsus/commit/0c36fa3d4fa1b6816a9be1d587ec23c8f2965a24 I added $HOME/chianti to cache
In `script` the database was downloaded and installed and saved in the cache.
Then I commented out the lines in `script` https://github.com/tardis-sn/carsus/commit/19bac5e98bd2b29c844ff8e8a0024ca6bdbd9ca7 and it worked. 
But that is strange. How am I supposed to put things in cache?
