### PR TITLE
Create transitions df

### DIFF
--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -576,6 +576,12 @@ def create_macro_atom_df(session, chianti_species=None, chianti_short_name=None,
     macro_atom_data = np.array(macro_atom_data, dtype=macro_atom_dtype)
     macro_atom_df = pd.DataFrame(macro_atom_data)
 
+    # Set multiindex and sort to get the block for each source level
+    macro_atom_df.set_index(["atomic_number", "ion_number", "source_level_number", "target_level_number"], inplace=True)
+    macro_atom_df.sort_index(level=["atomic_number", "ion_number", "source_level_number"], inplace=True)
+
+    return macro_atom_df
+
 
 
 

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -10,6 +10,10 @@ from astropy import units as u
 from scipy import interpolate
 from tardis.util import species_string_to_tuple
 
+P_EMISSION_DOWN = -1
+P_INTERNAL_DOWN = 0
+P_INTERNAL_UP = 1
+
 
 def create_basic_atom_df(session, max_atomic_number=30):
     """
@@ -553,21 +557,21 @@ def create_macro_atom_df(session, chianti_species=None, chianti_short_name=None,
     for index, row in lines_df.iterrows():
         atomic_number, ion_number, level_number_lower, level_number_upper = index
         nu = row["nu"]
-        f_ul, f_lu =  row["f_ul"], row["f_lu"]
+        f_ul, f_lu = row["f_ul"], row["f_lu"]
         e_lower, e_upper = row["energy_lower"], row["energy_upper"]
         line_id = row["line_id"]
 
         transition_probabilities_dict = dict()  # type : probability
-        transition_probabilities_dict[-1] = 2 * nu**2 * f_ul / const.c.cgs.value**2 * (e_upper - e_lower)
-        transition_probabilities_dict[0] = 2 * nu**2 * f_ul / const.c.cgs.value**2 * e_lower
-        transition_probabilities_dict[1] = f_lu * e_lower / (const.h.cgs.value * nu)
+        transition_probabilities_dict[P_EMISSION_DOWN] = 2 * nu**2 * f_ul / const.c.cgs.value**2 * (e_upper - e_lower)
+        transition_probabilities_dict[P_INTERNAL_DOWN] = 2 * nu**2 * f_ul / const.c.cgs.value**2 * e_lower
+        transition_probabilities_dict[P_INTERNAL_UP] = f_lu * e_lower / (const.h.cgs.value * nu)
 
         macro_atom_data.append((atomic_number, ion_number, level_number_upper, level_number_lower,
-                                line_id, -1, transition_probabilities_dict[-1]))
+                                line_id, P_EMISSION_DOWN, transition_probabilities_dict[P_EMISSION_DOWN]))
         macro_atom_data.append((atomic_number, ion_number, level_number_upper, level_number_lower,
-                                line_id, 0, transition_probabilities_dict[0]))
+                                line_id, P_INTERNAL_DOWN, transition_probabilities_dict[P_INTERNAL_DOWN]))
         macro_atom_data.append((atomic_number, ion_number, level_number_lower, level_number_upper,
-                                line_id, 1, transition_probabilities_dict[1]))
+                                line_id, P_INTERNAL_UP, transition_probabilities_dict[P_INTERNAL_UP]))
 
     macro_atom_data = np.array(macro_atom_data, dtype=macro_atom_dtype)
     macro_atom_df = pd.DataFrame(macro_atom_data)

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -1,16 +1,14 @@
-from pandas import read_sql_query
-from abc import ABCMeta
-from carsus.model import Atom, AtomWeight, Ion, IonizationEnergy,\
-    Line, LineWavelength, LineGFValue, LineAValue, Level, DataSource, ECollision
-from sqlalchemy import and_, or_, tuple_, not_, union_all, literal
-from sqlalchemy.orm import aliased, joinedload, subqueryload
+import numpy as np
+import pandas as pd
+
+from carsus.model import Atom, Ion, Line, Level, DataSource, ECollision
+from sqlalchemy import and_, union_all, literal
+from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from astropy import constants as const
 from astropy import units as u
 from scipy import interpolate
 from tardis.util import species_string_to_tuple
-import numpy as np
-import pandas as pd
 
 
 def create_basic_atom_df(session, max_atomic_number=30):

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -229,7 +229,7 @@ def create_levels_df(session, chianti_species=None, chianti_short_name=None, kur
     return levels_df
 
 
-def create_lines_df(session, chianti_species=None, chianti_short_name=None, kurucz_short_name=None):
+def create_lines_df(session, chianti_species=None, chianti_short_name=None, kurucz_short_name=None, levels_df=None):
     """
         Create a DataFrame with lines data.
         Parameters
@@ -264,10 +264,10 @@ def create_lines_df(session, chianti_species=None, chianti_short_name=None, kuru
         print "Requested data sources do not exist!"
         raise
 
-    # Create levels_df to get level numbers
-    levels_df = create_levels_df(session, chianti_species=chianti_species,
-                                 chianti_short_name=chianti_short_name, kurucz_short_name=kurucz_short_name,
-                                 create_metastable_flags=False)
+    if levels_df is None:
+        # Create levels_df to get level numbers
+        levels_df = create_levels_df(session, chianti_species=chianti_species,
+                                     chianti_short_name=chianti_short_name, create_metastable_flags=False)
 
     # Set level_id as index
     levels_df.reset_index(inplace=True)
@@ -337,7 +337,7 @@ def create_lines_df(session, chianti_species=None, chianti_short_name=None, kuru
     return lines_df
 
 
-def create_collisions_df(session, chianti_species, chianti_short_name=None, temperatures=None):
+def create_collisions_df(session, chianti_species, levels_df=None, chianti_short_name=None, temperatures=None):
     """
         Create a DataFrame with lines data.
 
@@ -369,9 +369,10 @@ def create_collisions_df(session, chianti_species, chianti_short_name=None, temp
         print "Chianti data source does not exist!"
         raise
 
-    # Create levels_df to get level numbers
-    levels_df = create_levels_df(session, chianti_species=chianti_species,
-                                 chianti_short_name=chianti_short_name, create_metastable_flags=False)
+    if levels_df is None:
+        # Create levels_df to get level numbers
+        levels_df = create_levels_df(session, chianti_species=chianti_species,
+                                     chianti_short_name=chianti_short_name, create_metastable_flags=False)
 
     # Set level_id as index
     levels_df.reset_index(inplace=True)
@@ -488,3 +489,5 @@ def create_collisions_df(session, chianti_species, chianti_short_name=None, temp
     collisions_df.set_index(["atomic_number", "ion_number", "level_number_lower", "level_number_upper"], inplace=True)
 
     return collisions_df
+
+

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -481,7 +481,7 @@ def create_collisions_df(session, chianti_species, chianti_short_name=None, temp
 
     # Drop the unwanted columns
     collisions_df.drop(["lower_level_id", "upper_level_id", "btemp", "bscups",
-                        "ttype", "energy_lower", "energy_upper", "gf"],  axis=1, inplace=True)
+                        "ttype", "energy_lower", "energy_upper", "gf", "g_l", "g_u", "cups"],  axis=1, inplace=True)
 
     # Set multiindex
     collisions_df.reset_index(inplace=True)

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -1,7 +1,8 @@
 import pytest
 
 from carsus.io.output.tardis_op import create_basic_atom_df, create_ionization_df,\
-    create_levels_df
+    create_levels_df, create_lines_df
+from carsus.model import DataSource
 from numpy.testing import assert_almost_equal
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
@@ -63,3 +64,11 @@ def test_create_levels_df(levels_df, atomic_number, ion_number, level_number, ex
     energy = levels_df.loc[(atomic_number, ion_number, level_number)]["energy"]*u.eV
     energy = energy.to(u.Unit("cm-1"), equivalencies=u.spectral())
     assert_quantity_allclose(energy, exp_energy)
+
+
+@with_test_db
+def test_create_levels_df_wo_chianti_species(test_session):
+    levels_df = create_levels_df(test_session)
+    chianti_ds_id = test_session.query(DataSource.data_source_id).\
+        filter(DataSource.short_name=="chianti_v8.0.2").scalar()
+    assert all(levels_df["ds_id"]!=chianti_ds_id)

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -1,7 +1,8 @@
 import pytest
 
 from carsus.io.output.tardis_op import create_basic_atom_df, create_ionization_df,\
-    create_levels_df, create_lines_df, create_collisions_df, create_macro_atom_df
+    create_levels_df, create_lines_df, create_collisions_df, create_macro_atom_df,\
+    create_macro_atom_ref_df
 from carsus.model import DataSource
 from numpy.testing import assert_almost_equal
 from astropy import units as u
@@ -98,3 +99,8 @@ def test_create_collisions_df(test_session):
 @with_test_db
 def test_create_macro_atom_df(test_session):
     macro_atom_df = create_macro_atom_df(test_session, chianti_species=["He 2", "N 6"])
+
+
+@with_test_db
+def test_create_macro_atom_ref_df(test_session):
+    macro_atom_ref_df = create_macro_atom_ref_df(test_session, chianti_species=["He 2", "N 6"])

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -1,7 +1,7 @@
 import pytest
 
 from carsus.io.output.tardis_op import create_basic_atom_df, create_ionization_df,\
-    create_levels_df, create_lines_df
+    create_levels_df, create_lines_df, create_collisions_df
 from carsus.model import DataSource
 from numpy.testing import assert_almost_equal
 from astropy import units as u
@@ -88,3 +88,8 @@ def test_create_lines_df(lines_df, atomic_number, ion_number, level_number_lower
     wavelength = lines_df.loc[(atomic_number, ion_number,
                                level_number_lower, level_number_upper)]["wavelength"]*u.Unit("angstrom")
     assert_quantity_allclose(wavelength, exp_wavelength)
+
+
+@with_test_db
+def test_create_collisions_df(test_session):
+    collisions_df = create_collisions_df(test_session, chianti_species=["He 2", "N 6"])

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -1,7 +1,7 @@
 import pytest
 
 from carsus.io.output.tardis_op import create_basic_atom_df, create_ionization_df,\
-    create_levels_df, create_lines_df, create_collisions_df
+    create_levels_df, create_lines_df, create_collisions_df, create_macro_atom_df
 from carsus.model import DataSource
 from numpy.testing import assert_almost_equal
 from astropy import units as u
@@ -93,3 +93,8 @@ def test_create_lines_df(lines_df, atomic_number, ion_number, level_number_lower
 @with_test_db
 def test_create_collisions_df(test_session):
     collisions_df = create_collisions_df(test_session, chianti_species=["He 2", "N 6"])
+
+
+@with_test_db
+def test_create_macro_atom_df(test_session):
+    macro_atom_df = create_macro_atom_df(test_session, chianti_species=["He 2", "N 6"])

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -29,6 +29,11 @@ def levels_df(test_session):
     return create_levels_df(test_session, chianti_species=["He 2", "N 6"])
 
 
+@pytest.fixture
+def lines_df(test_session):
+    return create_lines_df(test_session, chianti_species=["He 2", "N 6"])
+
+
 @with_test_db
 @pytest.mark.parametrize("atomic_number, exp_weight", [
     (2, 4.002602),
@@ -72,3 +77,14 @@ def test_create_levels_df_wo_chianti_species(test_session):
     chianti_ds_id = test_session.query(DataSource.data_source_id).\
         filter(DataSource.short_name=="chianti_v8.0.2").scalar()
     assert all(levels_df["ds_id"]!=chianti_ds_id)
+
+
+@with_test_db
+@pytest.mark.parametrize("atomic_number, ion_number, level_number_lower, level_number_upper, exp_wavelength",[
+    (7, 6, 0, 1, 29.5343 * u.Unit("angstrom")),
+    (4, 3, 0, 3, 10.1693 * u.Unit("angstrom"))
+])
+def test_create_lines_df(lines_df, atomic_number, ion_number, level_number_lower, level_number_upper, exp_wavelength):
+    wavelength = lines_df.loc[(atomic_number, ion_number,
+                               level_number_lower, level_number_upper)]["wavelength"]*u.Unit("angstrom")
+    assert_quantity_allclose(wavelength, exp_wavelength)

--- a/carsus/tests/create_test_db.py
+++ b/carsus/tests/create_test_db.py
@@ -11,7 +11,7 @@ TEST_DB_FNAME = os.path.join(DATA_DIR, 'test.db')
 GFALL_FNAME = os.path.join(DATA_DIR, "gftest.all")
 
 
-def create_test_db(test_db_fname=None, gfall_fname=None):
+def create_test_db(test_db_fname=TEST_DB_FNAME, gfall_fname=GFALL_FNAME):
     """
     Create a database for testing
 
@@ -22,11 +22,6 @@ def create_test_db(test_db_fname=None, gfall_fname=None):
     gfall_fname : str
         Filename for the GFALL file
     """
-    if test_db_fname is None:
-        test_db_fname = TEST_DB_FNAME
-
-    if gfall_fname is None:
-        gfall_fname = GFALL_FNAME
 
     test_db_f = open(test_db_fname, "w")
     test_db_f.close()
@@ -52,9 +47,13 @@ def create_test_db(test_db_fname=None, gfall_fname=None):
     gfall_ingester.ingest(levels=True, lines=True)
     session.commit()
 
-    # Ingest chianti levels and lines
+    # Ingest chianti levels, lines and electron collisions
     chianti_ingester = ChiantiIngester(session, ions_list=["he_2", "n_6"])
-    chianti_ingester.ingest(levels=True, lines=True)
+    chianti_ingester.ingest(levels=True, lines=True, collisions=True)
     session.commit()
 
     session.close()
+
+
+if __name__ == "__main__":
+    create_test_db()


### PR DESCRIPTION
1.  Implemented `create_lines_df` ([example lines_df](https://drive.google.com/file/d/0BxXCddocl9m3SmJ1VklkVi1pN2c/view?usp=sharing)). As with levels you can select chianti ions with the `chianti_species` argument. 

2. Implemented `create_collisions_df` ([example collisions_df](https://drive.google.com/file/d/0BxXCddocl9m3ZVNSMzhNeWg3YkE/view?usp=sharing)). Calculated collisional strengths are stored as tuples in the dataframe (refer to the function `calculate_collisional_strengths`)

3. Implemented `create_macro_atom_df` ([example macro_atom_df](https://drive.google.com/file/d/0BxXCddocl9m3dlhIWFNfVXJIQXc/view?usp=sharing))

4. Implemented `create_macro_atom_ref_df` ([example macro_atom_ref_df](https://drive.google.com/file/d/0BxXCddocl9m3NkloaVBGSk45UnM/view?usp=sharing))

