### PR TITLE
AtomData to hdf

### DIFF
--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -857,7 +857,7 @@ class AtomData(object):
                 store.put("macro_atom_ref_df", self.macro_atom_ref_df_prepared)
 
             # Set the root attributes
-
+            # It seems that the only way to set the root attributes is to use `_v_attrs`
             store.root._v_attrs["database_version"] = "v0.9"
 
             print "Signing AtomData with MD5 and UUID1"

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pandas as pd
+import hashlib
+import uuid
 
 from pandas import HDFStore
 from carsus.model import Atom, Ion, Line, Level, DataSource, ECollision
@@ -853,3 +855,18 @@ class AtomData(object):
 
             if store_macro_atom_ref:
                 store["macro_atom_ref_df"] = self.macro_atom_ref_df_prepared
+
+            # Set the root attributes
+
+            store.root._v_attrs["database_version"] = "v0.9"
+
+            print "Signing AtomData with MD5 and UUID1"
+
+            md5_hash = hashlib.md5()
+            for key in store.keys():
+                md5_hash.update(store[key].values.data)
+
+            uuid1 = uuid.uuid1().hex
+
+            store.root._v_attrs['md5'] = md5_hash.hexdigest()
+            store.root._v_attrs['uuid1'] = uuid1

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 
+from pandas import HDFStore
 from carsus.model import Atom, Ion, Line, Level, DataSource, ECollision
 from sqlalchemy import and_, union_all, literal
 from sqlalchemy.orm import joinedload
@@ -796,3 +797,59 @@ class AtomData(object):
         macro_atom_ref_df.set_index(["atomic_number", "ion_number", "source_level_number"], inplace=True)
 
         return macro_atom_ref_df
+
+    def to_hdf(self, hdf5_path, store_basic_atom=True, store_ionization=True,
+               store_levels=True, store_lines=True, store_collisions=True, store_macro_atom=True,
+               store_macro_atom_ref=True):
+        """
+            Store the dataframes in an HDF5 file
+
+            Parameters
+            ------------
+            hdf5_path: str
+                The path of the HDF5 file
+            store_basic_atom: bool
+                Store the basic atom DataFrame
+                (default: True)
+            store_ionization: bool
+                Store the ionzation DataFrame
+                (default: True)
+            store_levels: bool
+                Store the levels DataFrame
+                (default: True)
+            store_lines: bool
+                Store the lines DataFrame
+                (default: True)
+            store_collisions: bool
+                Store the electron collisions DataFrame
+                (default: True)
+            store_macro_atom: bool
+                Store the macro_atom DataFrame
+                (default: True)
+            store_macro_atom_ref: bool
+                Store the macro_atom_references DataFrame
+                (default: True)
+        """
+
+        with HDFStore(hdf5_path) as store:
+
+            if store_basic_atom:
+                store["basic_atom_df"] = self.basic_atom_df_prepared
+
+            if store_ionization:
+                store["ionization_df"] = self.ionization_df_prepared
+
+            if store_levels:
+                store["levels_df"] = self.levels_df_prepared
+
+            if store_lines:
+                store["lines_df"] = self.lines_df_prepared
+
+            if store_collisions:
+                store["collisions_df"] = self.collisions_df_prepared
+
+            if store_macro_atom:
+                store["macro_atom_df"] = self.macro_atom_df_prepared
+
+            if store_macro_atom_ref:
+                store["macro_atom_ref_df"] = self.macro_atom_ref_df_prepared

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -836,25 +836,25 @@ class AtomData(object):
         with HDFStore(hdf5_path) as store:
 
             if store_basic_atom:
-                store["basic_atom_df"] = self.basic_atom_df_prepared
+                store.put("basic_atom_df", self.basic_atom_df_prepared)
 
             if store_ionization:
-                store["ionization_df"] = self.ionization_df_prepared
+                store.put("ionization_df", self.ionization_df_prepared)
 
             if store_levels:
-                store["levels_df"] = self.levels_df_prepared
+                store.put("levels_df", self.levels_df_prepared)
 
             if store_lines:
-                store["lines_df"] = self.lines_df_prepared
+                store.put("lines_df", self.lines_df_prepared)
 
             if store_collisions:
-                store["collisions_df"] = self.collisions_df_prepared
+                store.put("collisions_df", self.collisions_df_prepared)
 
             if store_macro_atom:
-                store["macro_atom_df"] = self.macro_atom_df_prepared
+                store.put("macro_atom_df", self.macro_atom_df_prepared)
 
             if store_macro_atom_ref:
-                store["macro_atom_ref_df"] = self.macro_atom_ref_df_prepared
+                store.put("macro_atom_ref_df", self.macro_atom_ref_df_prepared)
 
             # Set the root attributes
 

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -18,37 +18,40 @@ def atom_data(test_session):
     atom_data = AtomData(test_session, chianti_species=["He 2", "N 6"])
     return atom_data
 
-@pytest.fixture
-def basic_atom_df(atom_data):
-    return atom_data.prepare_basic_atom_df()
-
 
 @pytest.fixture
-def ionization_df(atom_data):
-    return atom_data.prepare_ionization_df()
+def basic_atom_df_prepared(atom_data):
+    return atom_data.basic_atom_df_prepared
 
 
 @pytest.fixture
-def levels_df(atom_data):
-    return atom_data.prepare_levels_df()
+def ionization_df_prepared(atom_data):
+    return atom_data.ionization_df_prepared
 
 
 @pytest.fixture
-def lines_df(atom_data):
-    return atom_data.prepare_lines_df()
-
-@pytest.fixture
-def collisions_df(atom_data):
-    return atom_data.prepare_collisions_df()
-
-@pytest.fixture
-def macro_atom_df(atom_data):
-    return atom_data.prepare_macro_atom_df()
+def levels_df_prepared(atom_data):
+    return atom_data.levels_df_prepared
 
 
 @pytest.fixture
-def macro_atom_ref_df(atom_data):
-    return atom_data.prepare_macro_atom_ref_df()
+def lines_df_prepared(atom_data):
+    return atom_data.lines_df_prepared
+
+
+@pytest.fixture
+def collisions_df_prepared(atom_data):
+    return atom_data.collisions_df_prepared
+
+
+@pytest.fixture
+def macro_atom_df_prepared(atom_data):
+    return atom_data.macro_atom_df_prepared
+
+
+@pytest.fixture
+def macro_atom_ref_df_prepared(atom_data):
+    return atom_data.macro_atom_ref_df_prepared
 
 
 @with_test_db
@@ -56,13 +59,15 @@ def macro_atom_ref_df(atom_data):
     (2, 4.002602),
     (11, 22.98976928)
 ])
-def test_create_basic_atom_df(basic_atom_df, atomic_number, exp_weight):
-    assert_almost_equal(basic_atom_df.loc[atomic_number]["weight"],
+def test_prepare_basic_atom_df(basic_atom_df_prepared, atomic_number, exp_weight):
+    assert_almost_equal(basic_atom_df_prepared.loc[atomic_number]["weight"],
                         exp_weight)
 
+
 @with_test_db
-def test_create_basic_atom_df_max_atomic_number(atom_data):
-    basic_atom_df = atom_data.prepare_basic_atom_df(max_atomic_number=15)
+def test_prepare_basic_atom_df_max_atomic_number(test_session):
+    atom_data = AtomData(test_session, basic_atom_max_atomic_number=15)
+    basic_atom_df = atom_data.basic_atom_df_prepared
     basic_atom_df.reset_index(inplace=True)
     assert basic_atom_df["atomic_number"].max() == 15
 
@@ -72,8 +77,8 @@ def test_create_basic_atom_df_max_atomic_number(atom_data):
     (8, 6, 138.1189),
     (11, 1,  5.1390767)
 ])
-def test_create_ionizatinon_df(ionization_df, atomic_number, ion_number, exp_ioniz_energy):
-    assert_almost_equal(ionization_df.loc[(atomic_number, ion_number)]["ionization_energy"],
+def test_prepare_ionizatinon_df(ionization_df_prepared, atomic_number, ion_number, exp_ioniz_energy):
+    assert_almost_equal(ionization_df_prepared.loc[(atomic_number, ion_number)]["ionization_energy"],
                         exp_ioniz_energy)
 
 
@@ -82,8 +87,8 @@ def test_create_ionizatinon_df(ionization_df, atomic_number, ion_number, exp_ion
     (7, 6, 7, 3991860.0 * u.Unit("cm-1")),
     (4, 3, 2, 981177.5 * u.Unit("cm-1"))
 ])
-def test_create_levels_df(levels_df, atomic_number, ion_number, level_number, exp_energy):
-    energy = levels_df.loc[(atomic_number, ion_number, level_number)]["energy"]*u.eV
+def test_prepare_levels_df(levels_df_prepared, atomic_number, ion_number, level_number, exp_energy):
+    energy = levels_df_prepared.loc[(atomic_number, ion_number, level_number)]["energy"] * u.eV
     energy = energy.to(u.Unit("cm-1"), equivalencies=u.spectral())
     assert_quantity_allclose(energy, exp_energy)
 
@@ -102,21 +107,24 @@ def test_create_levels_df_wo_chianti_species(test_session):
     (7, 6, 0, 1, 29.5343 * u.Unit("angstrom")),
     (4, 3, 0, 3, 10.1693 * u.Unit("angstrom"))
 ])
-def test_create_lines_df(lines_df, atomic_number, ion_number, level_number_lower, level_number_upper, exp_wavelength):
-    wavelength = lines_df.loc[(atomic_number, ion_number,
-                               level_number_lower, level_number_upper)]["wavelength"]*u.Unit("angstrom")
+def test_prepare_lines_df(lines_df_prepared, atomic_number, ion_number,
+                          level_number_lower, level_number_upper, exp_wavelength):
+    wavelength = lines_df_prepared.loc[(atomic_number, ion_number,
+                                        level_number_lower, level_number_upper)]["wavelength"] * u.Unit("angstrom")
     assert_quantity_allclose(wavelength, exp_wavelength)
+
 
 # ToDo: Implement real tests
 @with_test_db
-def test_create_collisions_df(collisions_df):
+def test_prepare_collisions_df(collisions_df_prepared):
     assert True
 
 
 @with_test_db
-def test_create_macro_atom_df(macro_atom_df):
+def test_prepare_macro_atom_df(macro_atom_df_prepared):
     assert True
 
+
 @with_test_db
-def test_create_macro_atom_ref_df(macro_atom_ref_df):
+def test_prepare_macro_atom_ref_df(macro_atom_ref_df_prepared):
     assert True

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 
 from carsus.io.output.tardis_op import AtomData
 from carsus.model import DataSource
@@ -52,6 +53,17 @@ def macro_atom_df_prepared(atom_data):
 @pytest.fixture
 def macro_atom_ref_df_prepared(atom_data):
     return atom_data.macro_atom_ref_df_prepared
+
+
+@pytest.fixture
+def hdf5_path(request, data_dir):
+    hdf5_path = os.path.join(data_dir, "test_hdf.hdf5")
+
+    def fin():
+      os.remove(hdf5_path)
+    request.addfinalizer(fin)
+
+    return hdf5_path
 
 
 @with_test_db
@@ -128,3 +140,8 @@ def test_prepare_macro_atom_df(macro_atom_df_prepared):
 @with_test_db
 def test_prepare_macro_atom_ref_df(macro_atom_ref_df_prepared):
     assert True
+
+
+@with_test_db
+def test_atom_data_to_hdf(atom_data, hdf5_path):
+    atom_data.to_hdf(hdf5_path)


### PR DESCRIPTION
In this PR:
 - I moved all DataFrame parameters (like `levels_metastable_loggf_threshold`  to the class initialization. The idea is to group them in `__init__` into dictionaries (like `self.levels_param` and then pass these dicts to the methods for creating DataFrames (like `self.create_levels_df`). 
 - The `prepare_*` methods don't take any arguments except `self`. They are mostly used to set muliindexes and drop the unwanted columns.
 - I created "prepared" properties for preparing dataframes so that one doesn't have to call the `prepare_*` methods (e.g `leves_df_prepared`)
 - Finally, I implemented the `to_hdf` method that stores all prepared atomic dataframes to an HDFStore. The root attribures (like `md5` or `database_version`) are also set in this method.
 