### PR TITLE
Window ranged lines q

### DIFF
--- a/carsus/model/meta/__init__.py
+++ b/carsus/model/meta/__init__.py
@@ -1,4 +1,4 @@
 from .types import DBQuantity
-from .orm import UniqueMixin
+from .orm import UniqueMixin, yield_limit
 from .base import Base, setup
 from .schema import QuantityMixin, DataSourceMixin


### PR DESCRIPTION
The current implementation of the lines query consumes too much memory and don't run on my laptop. So I used the [Window Range Query](https://bitbucket.org/zzzeek/sqlalchemy/wiki/UsageRecipes/WindowedRangeQuery) recipe to deal with the memory consumption. See also a related question http://stackoverflow.com/questions/7389759/memory-efficient-built-in-sqlalchemy-iterator-generator