### PR TITLE
Atom data refactoring

### DIFF
--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -849,9 +849,9 @@ class AtomData(object):
 
         return macro_atom_references_prepared
 
-    def to_hdf(self, hdf5_path, store_basic_atom=True, store_ionization=True,
+    def to_hdf(self, hdf5_path, store_atom_masses=True, store_ionization_energies=True,
                store_levels=True, store_lines=True, store_collisions=True, store_macro_atom=True,
-               store_macro_atom_ref=True):
+               store_macro_atom_references=True):
         """
             Store the dataframes in an HDF5 file
 
@@ -859,51 +859,51 @@ class AtomData(object):
             ------------
             hdf5_path: str
                 The path of the HDF5 file
-            store_basic_atom: bool
-                Store the basic atom DataFrame
+            store_atom_masses: bool
+                Store the `atom_masses_prepared` DataFrame
                 (default: True)
-            store_ionization: bool
-                Store the ionzation DataFrame
+            store_ionization_energies: bool
+                Store the `ionization_energies_prepared` DataFrame
                 (default: True)
             store_levels: bool
-                Store the levels DataFrame
+                Store the `levels_prepared` DataFrame
                 (default: True)
             store_lines: bool
-                Store the lines DataFrame
+                Store the `lines_prepared` DataFrame
                 (default: True)
             store_collisions: bool
-                Store the electron collisions DataFrame
+                Store the `collisions_prepared` DataFrame
                 (default: True)
             store_macro_atom: bool
-                Store the macro_atom DataFrame
+                Store the `macro_atom_prepared` DataFrame
                 (default: True)
-            store_macro_atom_ref: bool
-                Store the macro_atom_references DataFrame
+            store_macro_atom_references: bool
+                Store the `macro_atom_references_prepared` DataFrame
                 (default: True)
         """
 
         with HDFStore(hdf5_path) as store:
 
-            if store_basic_atom:
-                store.put("basic_atom_df", self.basic_atom_df_prepared)
+            if store_atom_masses:
+                store.put("atom_masses", self.atom_masses_prepared)
 
-            if store_ionization:
-                store.put("ionization_df", self.ionization_df_prepared)
+            if store_ionization_energies:
+                store.put("ionization_energies", self.ionization_energies_prepared)
 
             if store_levels:
-                store.put("levels_df", self.levels_df_prepared)
+                store.put("levels", self.levels_prepared)
 
             if store_lines:
-                store.put("lines_df", self.lines_df_prepared)
+                store.put("lines", self.lines_prepared)
 
             if store_collisions:
-                store.put("collisions_df", self.collisions_df_prepared)
+                store.put("collisions", self.collisions_prepared)
 
             if store_macro_atom:
-                store.put("macro_atom_df", self.macro_atom_df_prepared)
+                store.put("macro_atom", self.macro_atom_prepared)
 
-            if store_macro_atom_ref:
-                store.put("macro_atom_ref_df", self.macro_atom_ref_df_prepared)
+            if store_macro_atom_references:
+                store.put("macro_atom_references", self.macro_atom_references_prepared)
 
             # Set the root attributes
             # It seems that the only way to set the root attributes is to use `_v_attrs`

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -158,7 +158,7 @@ class AtomData(object):
                 print "Chianti data source does not exist!"
                 raise
 
-        self._atomic_masses = None
+        self._atom_masses = None
         self._ionization_energies = None
         self._levels_all = None
         self._levels = None
@@ -169,58 +169,60 @@ class AtomData(object):
         self._macro_atom_references = None
 
     @property
-    def basic_atom_df(self):
-        if self._basic_atom_df is None:
-            self._basic_atom_df = self.create_basic_atom_df(**self.basic_atom_param)
-        return self._basic_atom_df
+    def atom_masses_df(self):
+        if self._atom_masses is None:
+            self._atom_masses = self.create_atom_masses(**self.atom_masses_param)
+        return self._atom_masses
 
-    def create_basic_atom_df(self, max_atomic_number=30):
+    def create_atom_masses(self, max_atomic_number=30):
         """
-        Create a DataFrame with basic atomic data.
+        Create a DataFrame containing *atomic masses*
 
         Parameters
         ----------
         max_atomic_number: int
-            The maximum atomic number to be stored in basic_atom_df
+            The maximum atomic number to be stored in `atom_masses`
             (default: 30)
 
         Returns
         -------
-        basic_atom_df : pandas.DataFrame
-            DataFrame with columns: atomic_number, columns: symbol, name, weight[u]
+        atom_masses : pandas.DataFrame
+            DataFrame with:
+                index: none;
+                columns: atom_masses, symbol, name, mass[u].
         """
-        basic_atom_q = self.session.query(Atom). \
+        atom_masses_q = self.session.query(Atom). \
             filter(Atom.atomic_number <= max_atomic_number).\
             order_by(Atom.atomic_number)
 
-        basic_atom_data = list()
-        for atom in basic_atom_q.options(joinedload(Atom.weights)):
+        atom_masses = list()
+        for atom in atom_masses_q.options(joinedload(Atom.weights)):
             weight = atom.weights[0].quantity.value if atom.weights else None  # Get the first weight from the collection
-            basic_atom_data.append((atom.atomic_number, atom.symbol, atom.name, weight))
+            atom_masses.append((atom.atomic_number, atom.symbol, atom.name, weight))
 
-        basic_atom_dtype = [("atomic_number", np.int), ("symbol", "|S5"), ("name", "|S150"),
-                            ("weight", np.float)]
-        basic_atom_data = np.array(basic_atom_data, dtype=basic_atom_dtype)
-        basic_atom_df = pd.DataFrame.from_records(basic_atom_data)
+        atom_masses_dtype = [("atomic_number", np.int), ("symbol", "|S5"), ("name", "|S150"), ("mass", np.float)]
+        atom_masses = np.array(atom_masses, dtype=atom_masses_dtype)
+        atom_masses = pd.DataFrame.from_records(atom_masses)
 
-        return basic_atom_df
+        return atom_masses
 
     @property
-    def basic_atom_df_prepared(self):
-        return self.prepare_basic_atom_df()
+    def atom_masses_prepared(self):
+        return self.prepare_atom_masses()
 
-    def prepare_basic_atom_df(self):
+    def prepare_atom_masses(self):
         """
-        Prepare the basic_atom_df for TARDIS
+        Prepare the DataFrame with atomic masses for TARDIS
 
         Returns
         -------
-        basic_atom_df : pandas.DataFrame
-               DataFrame with index: atomic_number
-                        and columns: symbol, name, weight[u]
+        atom_masses_prepared : pandas.DataFrame
+            DataFrame with:
+                index: atomic_number;
+                columns: symbol, name, mass[u].
         """
-        basic_atom_df = self.basic_atom_df.set_index("atomic_number")
-        return basic_atom_df
+        atom_masses_prepared = self.atom_masses.set_index("atomic_number")
+        return atom_masses_prepared
 
     @property
     def ionization_df(self):

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -283,15 +283,16 @@ class AtomData(object):
         e.g. H I - H II is described with ion_number = 0
         For this reason we add 1 to `ion_number` in this prepare method.
         """
-        ionization_energies = self.ionization_energies.copy()
-        ionization_energies["ion_number"] += 1
+        ionization_energies_prepared = self.ionization_energies.copy()
+        ionization_energies_prepared["ion_number"] += 1
 
         # Convert ionization energies to CGS
-        ionization_energies["ionization_energy"] = Quantity(ionization_energies["ionization_energy"].values, "eV").cgs
+        ionization_energies_prepared["ionization_energy"] = Quantity(
+            ionization_energies_prepared["ionization_energy"].values, "eV").cgs
 
-        ionization_energies.set_index(["atomic_number", "ion_number"], inplace=True)
+        ionization_energies_prepared.set_index(["atomic_number", "ion_number"], inplace=True)
 
-        return ionization_energies
+        return ionization_energies_prepared
 
     @property
     def levels(self):

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -56,10 +56,8 @@ class AtomData(object):
     session: SQLAlchemy session
     atom_masses_param: dict
         The parameters for creating the `atom_masses` DataFrame
-    levels_param: dict
-        The parameters for creating the `levels` DataFrame
-    lines_param: dict
-        The parameters for creating the `lines` DataFrame
+    levels_lines_param: dict
+        The parameters for creating the `levels` DataFrame and the `lines` DataFrame
     collisions_param: dict
         The parameters for creating the `collisions` DataFrame
 
@@ -70,8 +68,6 @@ class AtomData(object):
 
     atom_masses
     ionization_energies
-    levels_all
-    lines_all
     levels
     lines
     collisions
@@ -90,8 +86,7 @@ class AtomData(object):
     ---------
     create_atom_masses
     create_ionization_energies
-    create_levels
-    create_lines
+    create_levels_lines
     create_collisions
     create_macro_atom
     create_macro_atom_references
@@ -118,13 +113,10 @@ class AtomData(object):
             "max_atomic_number": atom_masses_max_atomic_number
         }
 
-        self.levels_param = {
-            "create_metastable_flags": levels_create_metastable_flags,
-            "metastable_loggf_threshold": levels_metastable_loggf_threshold
-        }
-
-        self.lines_param = {
-            "loggf_threshold": lines_loggf_threshold
+        self.levels_lines_param = {
+            "levels_create_metastable_flags": levels_create_metastable_flags,
+            "levels_metastable_loggf_threshold": levels_metastable_loggf_threshold,
+            "lines_loggf_threshold": lines_loggf_threshold
         }
 
         self.collisions_param = {
@@ -160,9 +152,7 @@ class AtomData(object):
 
         self._atom_masses = None
         self._ionization_energies = None
-        self._levels_all = None
         self._levels = None
-        self._lines_all = None
         self._lines = None
         self._collisions = None
         self._macro_atom = None
@@ -286,40 +276,28 @@ class AtomData(object):
         return ionization_energies
 
     @property
-    def levels_df(self):
-        if self._levels_df is None:
-            self._levels_df = self.create_levels_df()
-        return self._levels_df
+    def levels(self):
+        if self._levels is None:
+            self._levels, self._lines = self.create_levels_lines(**self.levels_lines_param)
+        return self._levels
 
-    def create_levels_df(self, create_metastable_flags=True, metastable_loggf_threshold=-3):
-        """
-            Create a DataFrame with levels data.
+    @property
+    def lines(self):
+        if self._lines is None:
+            self._levels, self._lines = self.create_levels_lines(**self.levels_lines_param)
+        return self._lines
 
-            Parameters
-            ----------
-            create_metastable_flags: bool
-                Create the `metastable` column containing flags for metastable levels (levels that take a long time to de-excite)
-                (default: True)
-            metastable_loggf_threshold: int
-                log(gf) threshold for flagging metastable levels
-                (default: -3)
-
-            Returns
-            -------
-            levels_df : pandas.DataFrame
-                DataFrame with index: level_id
-                         and columns: atomic_number, ion_number, level_number, energy[eV], g[1]
-        """
-
+    def _build_levels_q(self):
         if self.chianti_species is None:
-            kurucz_levels_q = self.session.query(Level).\
+            kurucz_levels_q = self.session.query(Level). \
                 filter(Level.data_source == self.ku_ds)
 
             levels_q = kurucz_levels_q
 
         else:
 
-            # To select ions we create a CTE (Common Table Expression), because sqlite doesn't support composite IN statements
+            # To select ions we create a CTE (Common Table Expression),
+            # because sqlite doesn't support composite IN statements
             chianti_species_cte = union_all(
                 *[self.session.query(
                     literal(atomic_number).label("atomic_number"),
@@ -328,22 +306,35 @@ class AtomData(object):
             ).cte("chianti_species_cte")
 
             # To select chianti ions we join on the CTE
-            chianti_levels_q = self.session.query(Level).\
+            chianti_levels_q = self.session.query(Level). \
                 join(chianti_species_cte, and_(Level.atomic_number == chianti_species_cte.c.atomic_number,
-                                               Level.ion_charge == chianti_species_cte.c.ion_charge)).\
+                                               Level.ion_charge == chianti_species_cte.c.ion_charge)). \
                 filter(Level.data_source == self.ch_ds)
 
-            # To select kurucz ions we do an outerjoin on the CTE and select rows that don't have a match from the CTE
-            kurucz_levels_q = self.session.query(Level).\
+            # To select kurucz ions we do an outerjoin on the CTE and
+            # select rows that don't have a match from the CTE
+            kurucz_levels_q = self.session.query(Level). \
                 outerjoin(chianti_species_cte, and_(Level.atomic_number == chianti_species_cte.c.atomic_number,
-                                               Level.ion_charge == chianti_species_cte.c.ion_charge)).\
-                filter(chianti_species_cte.c.atomic_number.is_(None)).\
+                                                    Level.ion_charge == chianti_species_cte.c.ion_charge)). \
+                filter(chianti_species_cte.c.atomic_number.is_(None)). \
                 filter(Level.data_source == self.ku_ds)
 
             levels_q = kurucz_levels_q.union(chianti_levels_q)
 
-        # Get the levels data
-        levels_data = list()
+        return levels_q
+
+    def _build_lines_q(self, levels_ids):
+        levels_subq = self.session.query(Level.level_id.label("level_id")). \
+            filter(Level.level_id.in_(levels_ids)).subquery()
+
+        lines_q = self.session.query(Line). \
+            join(levels_subq, Line.lower_level_id == levels_subq.c.level_id)
+
+        return lines_q
+
+    @staticmethod
+    def _get_all_levels_data(levels_q):
+        levels = list()
         for lvl in levels_q.options(joinedload(Level.energies)):
             try:
                 energy = None
@@ -358,115 +349,20 @@ class AtomData(object):
             except IndexError:
                 print "No energy is available for level {0}".format(lvl.level_id)
                 continue
-            levels_data.append((lvl.level_id, lvl.atomic_number, lvl.ion_charge, energy.value, lvl.g, lvl.data_source_id))
+            levels.append(
+                (lvl.level_id, lvl.atomic_number, lvl.ion_charge, energy.value, lvl.g))
 
         # Create a dataframe with the levels data
         levels_dtype = [("level_id", np.int), ("atomic_number", np.int),
-                        ("ion_charge", np.int), ("energy", np.float), ("g", np.int), ("ds_id", np.int)]
-        levels_data = np.array(levels_data, dtype=levels_dtype)
-        levels_df = pd.DataFrame.from_records(levels_data, index="level_id")
+                        ("ion_number", np.int), ("energy", np.float), ("g", np.int)]
+        levels = np.array(levels, dtype=levels_dtype)
+        levels = pd.DataFrame.from_records(levels, index="level_id")
 
-        # Replace ion_charge with ion_number in the spectroscopic notation
-        levels_df["ion_number"] = levels_df["ion_charge"] + 1
-        levels_df.drop("ion_charge", axis=1, inplace=True)
+        return levels
 
-        # Create level numbers
-        levels_df.sort_values(["atomic_number", "ion_number", "energy", "g"], inplace=True)
-        levels_df["level_number"] = levels_df.groupby(['atomic_number', 'ion_number'])['energy']. \
-            transform(lambda x: np.arange(len(x))).values
-        levels_df["level_number"] = levels_df["level_number"].astype(np.int)
-
-        if create_metastable_flags:
-            # Create metastable flags
-            # ToDO: It is assumed that all lines are ingested. That may not always be the case
-
-            levels_subq = self.session.query(Level). \
-                filter(Level.level_id.in_(levels_df.index.values)).subquery()
-            metastable_q = self.session.query(Line). \
-                join(levels_subq, Line.upper_level)
-
-            metastable_data = list()
-            for line in yield_limit(metastable_q.options(joinedload(Line.gf_values)),
-                                    Line.line_id, maxrq=LINES_MAXRQ):
-                try:
-                    # Currently it is assumed that each line has only one gf value
-                    gf = line.gf_values[0].quantity  # Get the first gf value
-                except IndexError:
-                    print "No gf value is available for line {0}".format(line.line_id)
-                    continue
-                metastable_data.append((line.line_id, line.upper_level_id, gf.value))
-
-            metastable_dtype = [("line_id", np.int), ("upper_level_id", np.int), ("gf", np.float)]
-            metastable_data = np.array(metastable_data, dtype=metastable_dtype)
-            metastable_df = pd.DataFrame.from_records(metastable_data, index="line_id")
-
-            # Filter loggf on the threshold value
-            metastable_df["loggf"] = np.log10(metastable_df["gf"])
-            metastable_df = metastable_df.loc[metastable_df["loggf"] > metastable_loggf_threshold]
-
-            # Count the remaining strong transitions
-            metastable_df_grouped = metastable_df.groupby("upper_level_id")
-            metastable_flags = metastable_df_grouped["upper_level_id"].count()
-            metastable_flags.name = "metastable"
-
-            # If there are no strong transitions for a level (the count is NaN) then the metastable flag is True
-            # else (the count is a natural number) the metastable flag is False
-            levels_df = levels_df.join(metastable_flags)
-            levels_df["metastable"] = levels_df["metastable"].isnull()
-
-        return levels_df
-
-    @property
-    def levels_df_prepared(self):
-        return self.prepare_levels_df()
-
-    def prepare_levels_df(self):
-        """
-        Prepare levels_df for TARDIS
-
-        Returns
-        -------
-        levels_df : pandas.DataFrame
-            DataFrame with columns: atomic_number, ion_number, level_number, energy[eV], g[1], metastable
-        """
-
-        levels_df = self.levels_df.copy()
-
-        # Create multiindex
-        levels_df.reset_index(inplace=True)
-        levels_df.set_index(["atomic_number", "ion_number", "level_number"], inplace=True)
-
-        # Drop the unwanted columns
-        levels_df.drop(["level_id", "ds_id"], axis=1, inplace=True)
-
-        return levels_df
-
-    @property
-    def lines_df(self):
-        if self._lines_df is None:
-            self._lines_df = self.create_lines_df()
-        return self._lines_df
-
-    def create_lines_df(self):
-        """
-            Create a DataFrame with lines data.
-
-            Returns
-            -------
-            lines_df : pandas.DataFrame
-                DataFrame with index: line_id
-                and columns: atomic_number, ion_number, level_number_lower, level_number_upper,
-                             wavelength[AA], nu[Hz], f_lu, f_ul, B_ul, B_ul, A_ul
-        """
-        levels_df = self.levels_df.copy()
-
-        levels_subq = self.session.query(Level.level_id.label("level_id")). \
-            filter(Level.level_id.in_(levels_df.index.values)).subquery()
-
-        lines_q = self.session.query(Line).\
-            join(levels_subq, Line.lower_level_id == levels_subq.c.level_id)
-
-        lines_data = list()
+    @staticmethod
+    def _get_all_lines_data(lines_q):
+        lines = list()
         for line in yield_limit(lines_q.options(joinedload(Line.wavelengths), joinedload(Line.gf_values)),
                                 Line.line_id, maxrq=LINES_MAXRQ):
             try:
@@ -481,75 +377,173 @@ class AtomData(object):
             except IndexError:
                 print "No wavelength is available for line {0}".format(line.line_id)
                 continue
-            lines_data.append((line.line_id, line.lower_level_id, line.upper_level_id,
-                               line.data_source_id,  wavelength.value, gf.value))
+            lines.append((line.line_id, line.lower_level_id, line.upper_level_id, wavelength.value, gf.value))
 
         lines_dtype = [("line_id", np.int), ("lower_level_id", np.int), ("upper_level_id", np.int),
-                       ("ds_id", np.int), ("wavelength", np.float), ("gf", np.float)]
-        lines_data = np.array(lines_data, dtype=lines_dtype)
-        lines_df = pd.DataFrame.from_records(lines_data, index="line_id")
+                       ("wavelength", np.float), ("gf", np.float)]
+        lines = np.array(lines, dtype=lines_dtype)
+        lines = pd.DataFrame.from_records(lines, index="line_id")
 
-        # Join atomic_number, ion_number, level_number_lower, level_number_upper and set multiindex
-        ions_df = levels_df[["atomic_number", "ion_number"]]
+        lines["loggf"] = np.log10(lines["gf"])
 
-        lower_levels_df = levels_df.rename(columns={"level_number": "level_number_lower", "g": "g_l"}).\
-            loc[:,["level_number_lower", "g_l"]]
-        upper_levels_df = levels_df.rename(columns={"level_number": "level_number_upper", "g": "g_u"}).\
-            loc[:,["level_number_upper", "g_u"]]
+        return lines
 
-        lines_df = lines_df.join(ions_df, on="lower_level_id")
-        lines_df = lines_df.join(lower_levels_df, on="lower_level_id")
-        lines_df = lines_df.join(upper_levels_df, on="upper_level_id")
+    @staticmethod
+    def _create_metastable_flags(levels, lines, levels_metastable_loggf_threshold=-3):
+
+        # Filter lines on the loggf threshold value
+        metastable_lines = lines.loc[lines["loggf"] > levels_metastable_loggf_threshold]
+
+        # Count the remaining strong transitions
+        metastable_lines_grouped = metastable_lines.groupby("upper_level_id")
+        metastable_counts = metastable_lines_grouped["upper_level_id"].count()
+        metastable_counts.name = "metastable_counts"
+
+        # If there are no strong transitions for a level (the count is NaN) then the metastable flag is True
+        # else (the count is a natural number) the metastable flag is False
+        levels = levels.join(metastable_counts)
+        metastable_flags =  levels["metastable_counts"].isnull()
+        metastable_flags.name = "metastable"
+        return metastable_flags
+
+    def create_levels_lines(self, levels_create_metastable_flags=True, levels_metastable_loggf_threshold=-3,
+                            lines_loggf_threshold=-3):
+        """
+        Create a DataFrame containing *levels data* and a DataFrame containing *lines data*.
+
+        Parameters
+        ----------
+        levels_create_metastable_flags: bool
+            Create the `metastable` column containing flags for metastable levels (levels that take a long time to de-excite)
+        levels_metastable_loggf_threshold: int
+            log(gf) threshold for flagging metastable levels
+        lines_loggf_threshold: int
+            log(gf) threshold for lines
+
+        Returns
+        -------
+        levels: pandas.DataFrame
+            DataFrame with:
+                index: level_id
+                columns: atomic_number, ion_number, level_number, energy[eV], g[1]
+
+        lines: pandas.DataFrame
+            DataFrame with:
+                index: line_id;
+                columns: atomic_number, ion_number, level_number_lower, level_number_upper,
+                         wavelength[angstrom], nu[Hz], f_lu[1], f_ul[1], B_ul[?], B_ul[?], A_ul[1/s].
+        """
+        levels_q = self._build_levels_q()
+        levels_all = self._get_all_levels_data(levels_q)
+
+        lines_q = self._build_lines_q(levels_all.index.values)
+        lines_all = self._get_all_lines_data(lines_q)
+
+        # Culling autoionization levels
+        ionization_energies = self.ionization_energies.set_index(["atomic_number", "ion_number"])
+        levels_w_ionization_energies = levels_all.join(ionization_energies, on=["atomic_number", "ion_number"])
+        levels = levels_all.loc[
+            levels_w_ionization_energies["energy"] >= levels_w_ionization_energies["ionization_energy"]
+        ]
+
+        # Clean lines
+        lines = lines_all.join(pd.DataFrame(index=levels.index), on="lower_level_id", how="inner").\
+            join(pd.DataFrame(index=levels.index), on="upper_level_id", how="inner")
+
+        # Culling lines with low gf values
+        lines = lines.loc[lines["loggf"] > lines_loggf_threshold]
+
+        # Clean levels
+        lower_level_idx = lines.rename(columns={"lower_level_id": "level_id"}).loc[:, ["level_id"]]
+        upper_level_idx = lines.rename(columns={"upper_level_id": "level_id"}).loc[:, ["level_id"]]
+        level_idx = pd.concat([lower_level_idx, upper_level_idx]).drop_duplicates("level_id")
+        levels = levels.join(pd.DataFrame(index=level_idx["level_id"]), how="inner")
+
+        # Create the metastable flags for levels
+        if levels_create_metastable_flags:
+            levels["metastable"] = self._create_metastable_flags(levels, lines_all, levels_metastable_loggf_threshold)
+
+        # Create level numbers
+        levels.sort_values(["atomic_number", "ion_number", "energy", "g"], inplace=True)
+        levels["level_number"] = levels.groupby(['atomic_number', 'ion_number'])['energy']. \
+            transform(lambda x: np.arange(len(x))).values
+        levels["level_number"] = levels["level_number"].astype(np.int)
+
+        # Join atomic_number, ion_number, level_number_lower, level_number_upper on lines
+        lower_levels = levels.rename(columns={"level_number": "level_number_lower", "g": "g_l"}). \
+                              loc[:, ["atomic_number", "ion_number", "level_number_lower", "g_l"]]
+        upper_levels = levels.rename(columns={"level_number": "level_number_upper", "g": "g_u"}). \
+                              loc[:, ["level_number_upper", "g_u"]]
+        lines = lines.join(lower_levels, on="lower_level_id").join(upper_levels, on="upper_level_id")
 
         # Calculate absorption oscillator strength f_lu and emission oscillator strength f_ul
-        lines_df["f_lu"] = lines_df["gf"]/lines_df["g_l"]
-        lines_df["f_ul"] = -lines_df["gf"]/lines_df["g_u"]
+        lines["f_lu"] = lines["gf"] / lines["g_l"]
+        lines["f_ul"] = lines["gf"] / lines["g_u"]
 
         # Calculate frequency
-        lines_df['nu'] = u.Unit('angstrom').to('Hz', lines_df['wavelength'], u.spectral())
+        lines['nu'] = u.Unit('angstrom').to('Hz', lines['wavelength'], u.spectral())
 
         # Calculate Einstein coefficients
-        einstein_coeff = (4 * np.pi**2 * const.e.gauss.value**2) / (const.m_e.cgs.value * const.c.cgs.value)
-        lines_df['B_lu'] = einstein_coeff * lines_df['f_lu'] / (const.h.cgs.value * lines_df['nu'])
-        lines_df['B_ul'] = einstein_coeff * lines_df['f_ul'] / (const.h.cgs.value * lines_df['nu'])
-        lines_df['A_ul'] = -2 * einstein_coeff * lines_df['nu']**2 / const.c.cgs.value**2 * lines_df['f_ul']
+        einstein_coeff = (4 * np.pi ** 2 * const.e.gauss.value ** 2) / (const.m_e.cgs.value * const.c.cgs.value)
+        lines['B_lu'] = einstein_coeff * lines['f_lu'] / (const.h.cgs.value * lines['nu'])
+        lines['B_ul'] = einstein_coeff * lines['f_ul'] / (const.h.cgs.value * lines['nu'])
+        lines['A_ul'] = 2 * einstein_coeff * lines['nu'] ** 2 / const.c.cgs.value ** 2 * lines['f_ul']
 
-        return lines_df
+        return levels, lines
 
     @property
-    def lines_df_prepared(self):
-        return self.prepare_lines_df()
+    def levels_prepared(self):
+        return self.prepare_levels()
 
-    def prepare_lines_df(self):
+    def prepare_levels(self):
         """
-            Prepare lines_df for TARDIS
-            Parameters
-            ----------
-            session : SQLAlchemy session
-            chianti_species: list of str in format <element_symbol> <ion_number>, eg. Fe 2
-                The lines data for these ions will be taken from the CHIANTI database
-                (default: None)
-            chianti_short_name: str
-                The short name of the CHIANTI database, if set to None the latest version will be used
-                (default: None)
-            kurucz_short_name: str
-                The short name of the Kurucz database, if set to None the latest version will be used
-                (default: None)
-            Returns
-            -------
-            lines_df : pandas.DataFrame
-                DataFrame with multiindex: atomic_number, ion_number, level_number_lower, level_number_upper
-                and columns: line_id, wavelength[AA], nu[Hz], f_lu, f_ul, B_ul, B_ul, A_ul
+        Prepare the DataFrame with levels for TARDIS
+
+        Returns
+        -------
+        levels_prepared: pandas.DataFrame
+            DataFrame with:
+                index: none;
+                columns: atomic_number, ion_number, level_number, energy[eV], g[1], metastable.
         """
 
-        #Set the multiindex
-        lines_df = self.lines_df.reset_index()
-        lines_df.set_index(["atomic_number", "ion_number", "level_number_lower", "level_number_upper"], inplace=True)
+        levels_prepared = self.levels.copy()
+
+        # Set index
+        levels_prepared.reset_index(inplace=True)
+        # levels.set_index(["atomic_number", "ion_number", "level_number"], inplace=True)
 
         # Drop the unwanted columns
-        lines_df.drop(["g_l", "g_u", "gf", "lower_level_id", "upper_level_id", "ds_id"], axis=1, inplace=True)
+        levels_prepared.drop(["level_id"], axis=1, inplace=True)
 
-        return lines_df
+        return levels_prepared
+
+    @property
+    def lines_prepared(self):
+        return self.prepare_lines()
+
+    def prepare_lines(self):
+        """
+            Prepare the DataFrame with lines for TARDIS
+
+            Returns
+            -------
+            lines_prepared : pandas.DataFrame
+                DataFrame with:
+                    index: none;
+                    columns: lind_id, atomic_number, ion_number, level_number_lower, level_number_upper,
+                             wavelength[angstrom], nu[Hz], f_lu[1], f_ul[1], B_ul[?], B_ul[?], A_ul[1/s].
+        """
+        lines_prepared = self.lines.copy()
+
+        # Set the index
+        lines_prepared.reset_index(inplace=True)
+        # lines.set_index(["atomic_number", "ion_number", "level_number_lower", "level_number_upper"], inplace=True)
+
+        # Drop the unwanted columns
+        lines_prepared.drop(["g_l", "g_u", "gf", "lower_level_id", "upper_level_id"], axis=1, inplace=True)
+
+        return lines_prepared
 
     @property
     def collisions_df(self):

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -21,38 +21,38 @@ def atom_data(test_session):
 
 
 @pytest.fixture
-def atom_masses_prepared(atom_data):
-    return atom_data.atom_masses_prepared
+def atom_masses(atom_data):
+    return atom_data.atom_masses
 
 
 @pytest.fixture
-def ionization_energies_prepared(atom_data):
-    return atom_data.ionization_energies_prepared
+def ionization_energies(atom_data):
+    return atom_data.ionization_energies
 
 
 @pytest.fixture
-def levels_prepared(atom_data):
-    return atom_data.levels_prepared
+def levels(atom_data):
+    return atom_data.levels
 
 
 @pytest.fixture
-def lines_prepared(atom_data):
-    return atom_data.lines_prepared
+def lines(atom_data):
+    return atom_data.lines
 
 
 @pytest.fixture
-def collisions_prepared(atom_data):
-    return atom_data.collisions_prepared
+def collisions(atom_data):
+    return atom_data.collisions
 
 
 @pytest.fixture
-def macro_atom_prepared(atom_data):
-    return atom_data.macro_atom_prepared
+def macro_atom(atom_data):
+    return atom_data.macro_atom
 
 
 @pytest.fixture
-def macro_atom_references_prepared(atom_data):
-    return atom_data.macro_atom_references_prepared
+def macro_atom_references(atom_data):
+    return atom_data.macro_atom_references
 
 
 @pytest.fixture
@@ -71,25 +71,26 @@ def hdf5_path(request, data_dir):
     (2, 4.002602),
     (11, 22.98976928)
 ])
-def test_prepare_atom_masses(atom_masses_prepared, atomic_number, exp_mass):
-    assert_almost_equal(atom_masses_prepared.loc[atomic_number]["mass"], exp_mass)
+def test_create_atom_masses(atom_masses, atomic_number, exp_mass):
+    atom_masses = atom_masses.set_index("atomic_number")
+    assert_almost_equal(atom_masses.loc[atomic_number]["mass"], exp_mass)
 
 
 @with_test_db
-def test_prepare_atom_masses_max_atomic_number(test_session):
+def test_create_atom_masses_max_atomic_number(test_session):
     atom_data = AtomData(test_session, atom_masses_max_atomic_number=15)
-    atom_masses = atom_data.atom_masses_prepared
-    atom_masses.reset_index(inplace=True)
+    atom_masses = atom_data.atom_masses
     assert atom_masses["atomic_number"].max() == 15
 
 
 @with_test_db
 @pytest.mark.parametrize("atomic_number, ion_number, exp_ioniz_energy", [
-    (8, 6, 138.1189),
-    (11, 1,  5.1390767)
+    (8, 5, 138.1189),
+    (11, 0,  5.1390767)
 ])
-def test_prepare_ionizatinon_energies(ionization_energies_prepared, atomic_number, ion_number, exp_ioniz_energy):
-    assert_almost_equal(ionization_energies_prepared.loc[(atomic_number, ion_number)]["ionization_energy"],
+def test_create_ionizatinon_energies(ionization_energies, atomic_number, ion_number, exp_ioniz_energy):
+    ionization_energies = ionization_energies.set_index(["atomic_number", "ion_number"])
+    assert_almost_equal(ionization_energies.loc[(atomic_number, ion_number)]["ionization_energy"],
                         exp_ioniz_energy)
 
 
@@ -98,9 +99,9 @@ def test_prepare_ionizatinon_energies(ionization_energies_prepared, atomic_numbe
     (7, 5, 7, 3991860.0 * u.Unit("cm-1")),
     (4, 2, 2, 981177.5 * u.Unit("cm-1"))
 ])
-def test_prepare_levels(levels_prepared, atomic_number, ion_number, level_number, exp_energy):
-    levels_prepared.set_index(["atomic_number", "ion_number", "level_number"], inplace=True)
-    energy = levels_prepared.loc[(atomic_number, ion_number, level_number)]["energy"] * u.eV
+def test_create_levels(levels, atomic_number, ion_number, level_number, exp_energy):
+    levels = levels.set_index(["atomic_number", "ion_number", "level_number"])
+    energy = levels.loc[(atomic_number, ion_number, level_number)]["energy"] * u.eV
     energy = energy.to(u.Unit("cm-1"), equivalencies=u.spectral())
     assert_quantity_allclose(energy, exp_energy)
 
@@ -110,28 +111,28 @@ def test_prepare_levels(levels_prepared, atomic_number, ion_number, level_number
     (7, 5, 1, 2, 1907.9000 * u.Unit("angstrom")),
     (4, 2, 0, 6, 10.0255 * u.Unit("angstrom"))
 ])
-def test_prepare_lines(lines_prepared, atomic_number, ion_number,
+def test_create_lines(lines, atomic_number, ion_number,
                        level_number_lower, level_number_upper, exp_wavelength):
-    lines_prepared.set_index(["atomic_number", "ion_number",
-                              "level_number_lower", "level_number_upper"], inplace=True)
-    wavelength = lines_prepared.loc[(atomic_number, ion_number,
+    lines = lines.set_index(["atomic_number", "ion_number",
+                              "level_number_lower", "level_number_upper"])
+    wavelength = lines.loc[(atomic_number, ion_number,
                                         level_number_lower, level_number_upper)]["wavelength"] * u.Unit("angstrom")
     assert_quantity_allclose(wavelength, exp_wavelength)
 
 
 # ToDo: Implement real tests
 @with_test_db
-def test_prepare_collisions_df(collisions_prepared):
+def test_create_collisions_df(collisions):
     assert True
 
 
 @with_test_db
-def test_prepare_macro_atom_df(macro_atom_prepared):
+def test_create_macro_atom_df(macro_atom):
     assert True
 
 
 @with_test_db
-def test_prepare_macro_atom_ref_df(macro_atom_references_prepared):
+def test_create_macro_atom_ref_df(macro_atom_references):
     assert True
 
 

--- a/carsus/model/atomic.py
+++ b/carsus/model/atomic.py
@@ -67,11 +67,6 @@ class Ion(UniqueMixin, Base):
     levels = relationship("Level", back_populates="ion")
     atom = relationship("Atom", back_populates='ions')
 
-    @hybrid_property
-    def ion_number(self):
-        """ Ion number in spectroscopic notation"""
-        return self.ion_charge + 1
-
     def __repr__(self):
         return "<Ion Z={0} +{1}>".format(self.atomic_number, self.ion_charge)
 


### PR DESCRIPTION
I made some changes to the `AtomData` class:
- Implemented a method `create_levels_lines()` for creating the `levels` and `lines` DataFrames. The rationale for using a single method instead of two methods is that both DataFrames need to be sorted and filtered together. 
- Ditched the "_df" ending in  DataFrames' names
- "Prepared" DataFrames are the exact DataFrames that are set in the `__init__` method of `AtomData` from `tardis.io.atomic` (refer to https://github.com/tardis-sn/tardis/pull/604)
- Improved the docstrings 