### PR TITLE
Store ground levels from NIST Ionization energies 2

### DIFF
--- a/carsus/io/nist/ionization.py
+++ b/carsus/io/nist/ionization.py
@@ -189,23 +189,29 @@ class NISTIonizationEnergiesIngester(BaseIngester):
         data = self.downloader(spectra=spectra)
         self.parser(data)
 
-    def ingest(self):
-        """ *Only* ingests ions and ionization energies *for now* """
-        print "Ingesting ionization energies data"
+    def ingest_ionization_energies(self):
+        print("Ingesting ionization energies from {}".format(self.data_source.short_name))
+
         ioniz_energies_df = self.parser.prepare_ioniz_energies_df()
 
         for index, row in ioniz_energies_df.iterrows():
-
             atomic_number, ion_charge = index
             # Query for an existing ion; create if doesn't exists
             ion = Ion.as_unique(self.session,
                                 atomic_number=atomic_number, ion_charge=ion_charge)
             ion.energies = [
-               IonizationEnergy(ion=ion,
-                                data_source=self.data_source,
-                                quantity=row['ionization_energy_value']*u.eV,
-                                uncert=row['ionization_energy_uncert'],
-                                method=row['ionization_energy_method'])
+                IonizationEnergy(ion=ion,
+                                 data_source=self.data_source,
+                                 quantity=row['ionization_energy_value'] * u.eV,
+                                 uncert=row['ionization_energy_uncert'],
+                                 method=row['ionization_energy_method'])
             ]
             # No need to add ion to the session, because
             # that was done in `as_unique`
+
+    def ingest(self, ionization_energies=True):
+
+        print("Ingesting data from {}".format(self.data_source.short_name))
+
+        if ionization_energies:
+            self.ingest_ionization_energies()

--- a/carsus/io/nist/ionization_grammar.py
+++ b/carsus/io/nist/ionization_grammar.py
@@ -1,0 +1,69 @@
+"""
+BNF grammar for parsing Ground Levels
+
+level  ::= [ ls_term | jj_term ] + ["*"] + [(J | <J>)]
+
+ls_term  ::= mult + L
+jj_term  ::= "(" + J + "," + J + ")"
+
+mult   ::= decimal
+L      ::= "A" .. "Z"
+J      ::= decimal | (decimal + "/" + decimal)
+
+decimal  ::= digit+
+digit    ::= "0"..."9"
+"""
+
+from pyparsing import Word, Literal, Suppress, Group, Optional, nums, srange
+
+
+LPAREN, RPAREN = map(Suppress, "()")
+
+# digit ::= "0" ... "9"
+# use nums
+
+# decimal  ::= digit +
+decimal = Word(nums)
+to_int = lambda t: int(t[0])
+decimal.setParseAction(to_int)
+
+# J  ::= decimal | (decimal + "/" + decimal)
+J = decimal ^ decimal + Suppress("/") + decimal
+
+
+def parse_j(tokens):
+    if len(tokens) == 1:
+        return float(tokens[0])
+    else:
+        return float(tokens[0])/tokens[1]
+
+J.setParseAction(parse_j)
+
+# mult ::= decimal
+mult = decimal
+
+# L  ::= "A" .. "Z"
+L = Word(srange("[A-Z]"))
+
+# ls_term  ::= mult + L
+ls_term = mult.setResultsName("mult") + L.setResultsName("L")
+
+# jj_term  ::= "(" + J + "," + J + ")"
+jj_term = Literal("(") + J.setResultsName("first_J") + "," + \
+          J.setResultsName("second_J") + Literal(")")
+
+# level  ::= [ ls_term | jj_term ] + ["*"] + [(J | <J>)]
+level = Optional(
+            Group(ls_term).setResultsName("ls_term") |
+            Group(jj_term).setResultsName("jj_term")) + \
+        Optional("*") + \
+        Optional((J | Suppress("<") + J + Suppress(">")).setResultsName("J"))
+
+
+def parse_parity(tokens):
+    if "*" in tokens.asList():
+        tokens["parity"] = 1
+    else:
+        tokens["parity"] = 0
+
+level.setParseAction(parse_parity)

--- a/carsus/io/tests/test_ionization.py
+++ b/carsus/io/tests/test_ionization.py
@@ -17,8 +17,8 @@ test_data = """
 At. num | Ion Charge | Ground Shells | Ground Level |      Ionization Energy (a) (eV)      |
 --------|------------|---------------|--------------|--------------------------------------|
       4 |          0 | 1s2.2s2       | 1S0          |                 9.3226990(70)        |
-      4 |         +1 | 1s2.2s        | 2S<1/2>      |                18.211153(40)         |
-      4 |         +2 | 1s2           | 1S0          |   <a class=bal>[</a>153.8961980(40)<a class=bal>]</a>       |
+      4 |         +1 | 1s2.2s        | 2S*<1/2>      |                18.211153(40)         |
+      4 |         +2 | 1s2           | (1,3/2)<2>          |   <a class=bal>[</a>153.8961980(40)<a class=bal>]</a>       |
       4 |         +3 | 1s            | 2S<1/2>      |   <a class=bal>(</a>217.7185766(10)<a class=bal>)</a>       |
 --------------------------------------------------------------------------------------------
 </pre>
@@ -35,8 +35,10 @@ expected_ground_shells = ('ground_shells',
                           )
 
 expected_ground_level = ('ground_level',
-                         ['1S0', '2S<1/2>', '1S0', '2S<1/2>']
+                         ['1S0', '2S*<1/2>', '(1,3/2)<2>', '2S<1/2>']
                          )
+
+expected_j = ('J', [0.0, 0.5, 2.0, 0.5])
 
 expected_ioniz_energy_value = ('ionization_energy_value',
                                [9.3226990, 18.211153, 153.8961980, 217.7185766]
@@ -63,6 +65,11 @@ def ioniz_energies_df(ioniz_energies_parser):
 
 
 @pytest.fixture
+def ground_levels_df(ioniz_energies_parser):
+    return ioniz_energies_parser.prepare_ground_levels_df()
+
+
+@pytest.fixture
 def ioniz_energies_ingester(memory_session):
     ingester = NISTIonizationEnergiesIngester(memory_session)
     ingester.parser(test_data)
@@ -71,7 +78,15 @@ def ioniz_energies_ingester(memory_session):
 @pytest.fixture(params=[expected_ground_shells,
                         expected_ground_level, expected_ioniz_energy_value,
                         expected_ioniz_energy_uncert, expected_ioniz_energy_method])
-def expected_series(request):
+def expected_series_ioniz_energies(request):
+    index = pd.MultiIndex.from_tuples(tuples=expected_indices,
+                                       names=['atomic_number', 'ion_charge'])
+    name, data = request.param
+    return pd.Series(data=data, name=name, index=index)
+
+
+@pytest.fixture(params=[expected_j])
+def expected_series_ground_levels(request):
     index = pd.MultiIndex.from_tuples(tuples=expected_indices,
                                        names=['atomic_number', 'ion_charge'])
     name, data = request.param
@@ -82,9 +97,15 @@ def test_prepare_ioniz_energies_df_null_values(ioniz_energies_df):
     assert all(pd.notnull(ioniz_energies_df["ionization_energy_value"]))
 
 
-def test_prepare_ioniz_energies_df(ioniz_energies_df, expected_series):
-    series = ioniz_energies_df[expected_series.name]
-    assert_series_equal(series, expected_series)
+def test_prepare_ioniz_energies_df(ioniz_energies_df, expected_series_ioniz_energies):
+    series = ioniz_energies_df[expected_series_ioniz_energies.name]
+    assert_series_equal(series, expected_series_ioniz_energies)
+
+
+
+def test_prepare_ground_levels_df(ground_levels_df, expected_series_ground_levels):
+    series = ground_levels_df[expected_series_ground_levels.name]
+    assert_series_equal(series, expected_series_ground_levels)
 
 
 @pytest.mark.parametrize("index, value, uncert",

--- a/carsus/io/tests/test_ionization.py
+++ b/carsus/io/tests/test_ionization.py
@@ -114,7 +114,7 @@ def test_prepare_ground_levels_df(ground_levels_df, expected_series_ground_level
                              expected_ioniz_energy_uncert[1]))
 def test_ingest_ionization_energies(index, value, uncert, memory_session, ioniz_energies_ingester):
 
-    ioniz_energies_ingester.ingest(ionization_energies=True)
+    ioniz_energies_ingester.ingest(ionization_energies=True, ground_levels=False)
 
     atomic_number, ion_charge = index
     ion = memory_session.query(Ion).options(joinedload('ionization_energies')).get((atomic_number, ion_charge))
@@ -124,8 +124,18 @@ def test_ingest_ionization_energies(index, value, uncert, memory_session, ioniz_
     assert_almost_equal(ion_energy.uncert, uncert)
 
 
+@pytest.mark.parametrize("index, exp_j", zip(expected_indices, expected_j[1]))
+def test_ingest_ground_levels(index, exp_j, memory_session, ioniz_energies_ingester):
+    ioniz_energies_ingester.ingest(ionization_energies=True, ground_levels=True)
+
+    atomic_number, ion_charge = index
+    ion = memory_session.query(Ion).options(joinedload('levels')).get((atomic_number, ion_charge))
+    ground_level = ion.levels[0]
+    assert_almost_equal(ground_level.J, exp_j)
+
+
 @pytest.mark.remote_data
 def test_ingest_nist_asd_ion_data(memory_session):
     ingester = NISTIonizationEnergiesIngester(memory_session)
     ingester.download('h-uuh')
-    ingester.ingest(ionization_energies=True)
+    ingester.ingest(ionization_energies=True, ground_levels=True)

--- a/carsus/io/tests/test_ionization.py
+++ b/carsus/io/tests/test_ionization.py
@@ -112,9 +112,9 @@ def test_prepare_ground_levels_df(ground_levels_df, expected_series_ground_level
                          zip(expected_indices,
                              expected_ioniz_energy_value[1],
                              expected_ioniz_energy_uncert[1]))
-def test_ingest_test_data(index, value, uncert, memory_session, ioniz_energies_ingester):
+def test_ingest_ionization_energies(index, value, uncert, memory_session, ioniz_energies_ingester):
 
-    ioniz_energies_ingester.ingest()
+    ioniz_energies_ingester.ingest(ionization_energies=True)
 
     atomic_number, ion_charge = index
     ion = memory_session.query(Ion).options(joinedload('ionization_energies')).get((atomic_number, ion_charge))
@@ -128,4 +128,4 @@ def test_ingest_test_data(index, value, uncert, memory_session, ioniz_energies_i
 def test_ingest_nist_asd_ion_data(memory_session):
     ingester = NISTIonizationEnergiesIngester(memory_session)
     ingester.download('h-uuh')
-    ingester.ingest()
+    ingester.ingest(ionization_energies=True)

--- a/carsus/io/tests/test_ionization_grammar.py
+++ b/carsus/io/tests/test_ionization_grammar.py
@@ -1,0 +1,81 @@
+import pytest
+from carsus.io.nist.ionization_grammar import *
+from numpy.testing import assert_almost_equal
+
+
+@pytest.mark.parametrize("test_input,exp_j",[
+    ("0", 0.0),
+    ("2", 2.0),
+    ("3/2", 1.5)
+])
+def test_j(test_input, exp_j):
+    tkns = J.parseString(test_input)
+    assert_almost_equal(tkns[0], exp_j)
+
+
+@pytest.mark.parametrize("test_input, exp_mult, exp_l",[
+    ("1S", 1, "S"),
+    ("2P", 2, "P"),
+    ("1S", 1, "S")
+])
+def test_ls_term(test_input, exp_mult, exp_l):
+    tkns = ls_term.parseString(test_input)
+    assert tkns["mult"] == exp_mult
+    assert tkns["L"] == exp_l
+
+
+@pytest.mark.parametrize("test_input, exp_first_j, exp_second_j",[
+    ("(0,1/2)", 0.0, 0.5),
+    ("(3/2,1)", 1.5, 1.0),
+    ("(0,2)", 0.0, 2.0)
+])
+def test_jj_term(test_input, exp_first_j, exp_second_j):
+    tkns = jj_term.parseString(test_input)
+    assert_almost_equal(tkns["first_J"], exp_first_j)
+    assert_almost_equal(tkns["second_J"], exp_second_j)
+
+
+@pytest.mark.parametrize("test_input, exp_mult, exp_l, exp_parity, exp_j",[
+    ("1S0", 1, "S", 0, 0.0),
+    ("2P<1/2>", 2, "P", 0, 0.5),
+    ("1S*<4>", 1, "S", 1, 4.0)
+])
+def test_level_w_ls_term(test_input, exp_mult, exp_l, exp_parity, exp_j):
+    tkns = level.parseString(test_input)
+    assert tkns["ls_term"]["mult"] == exp_mult
+    assert tkns["ls_term"]["L"] == exp_l
+    assert tkns["parity"] == exp_parity
+    assert_almost_equal(tkns["J"], exp_j)
+
+
+@pytest.mark.parametrize("test_input, exp_first_j, exp_second_j, exp_parity, exp_j",[
+    ("(0,1/2)0", 0.0, 0.5, 0, 0.0),
+    ("(3/2,5/2)<1/2>", 1.5, 2.5, 0, 0.5),
+    ("(1/2, 2)*<2>", 0.5, 2.0, 1, 2.0)
+])
+def test_level_w_jj_term(test_input, exp_first_j, exp_second_j, exp_parity, exp_j):
+    tkns = level.parseString(test_input)
+    assert tkns["jj_term"]["first_J"] == exp_first_j
+    assert tkns["jj_term"]["second_J"] == exp_second_j
+    assert tkns["parity"] == exp_parity
+    assert_almost_equal(tkns["J"], exp_j)
+
+
+@pytest.mark.parametrize("test_input, exp_parity, exp_j",[
+    ("0", 0, 0.0),
+    ("<1/2>", 0,  0.5),
+    ("*<2>", 1, 2.0)
+])
+def test_level_wo_term(test_input, exp_parity, exp_j):
+    tkns = level.parseString(test_input)
+    assert tkns["parity"] == exp_parity
+    assert_almost_equal(tkns["J"], exp_j)
+
+
+@pytest.mark.parametrize("test_input, exp_parity",[
+    ("", 0),
+    ("*", 1)
+])
+def test_level_wo_term_and_j(test_input, exp_parity):
+    tkns = level.parseString(test_input)
+    assert tkns["parity"] == exp_parity


### PR DESCRIPTION
This PR:
 - Implements a parsing grammar (using pyparsing) for parsing J values (and other stuff) from the "Ground Level" column. The grammar is implemented in `carsus/io/nist/ionization_grammar.py` and is well documented and tested.
 - Implements the `prepare_ground_levels_df` method for creating dataframes which contain ground levels data ([example](https://drive.google.com/file/d/0BxXCddocl9m3TktRd21qb0hNU00/view?usp=sharing)).
 - Implements the `ingest_ground_levels` method for storing the data in the database

Storing the ground levels data is necessary for creating artificial ions that have only ground level.   