### PR TITLE
Mixin for creating temporary tables for selecting ions from list

### DIFF
--- a/carsus/model/meta/__init__.py
+++ b/carsus/model/meta/__init__.py
@@ -1,4 +1,4 @@
 from .types import DBQuantity
 from .orm import UniqueMixin, yield_limit
 from .base import Base, setup
-from .schema import QuantityMixin, DataSourceMixin
+from .schema import QuantityMixin, DataSourceMixin, IonListMixin

--- a/carsus/model/meta/schema.py
+++ b/carsus/model/meta/schema.py
@@ -5,10 +5,27 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.declarative import declared_attr
 from ..meta.types import DBQuantity
+from carsus.util import convert_camel2snake
 from astropy.units import dimensionless_unscaled, UnitsError, set_enabled_equivalencies
 
 
+class IonListMixin(object):
 
+    """
+    Mixin for creating temporary tables for selecting ions from a list of ions.
+
+    Because SQLite doesn't support composite IN expressions
+    (you can't do WHERE atomic_number, ion_charge in some_list_of_ions)
+    temporary tables are needed for selecting ions.
+    """
+    @declared_attr
+    def __tablename__(cls):
+        return convert_camel2snake(cls.__name__)
+
+    atomic_number = Column(Integer, primary_key=True)
+    ion_charge = Column(Integer, primary_key=True)
+
+    __table_args__ = {'prefixes': ['TEMPORARY']}
 
 
 class DataSourceMixin(object):

--- a/carsus/model/tests/test_schema.py
+++ b/carsus/model/tests/test_schema.py
@@ -1,0 +1,31 @@
+from carsus.model import Ion
+from carsus.model.meta import IonListMixin, Base
+from sqlalchemy import and_
+
+
+def test_ion_list_mixin_insert_values(memory_session):
+
+    class ChiantiIonList(Base, IonListMixin):
+        pass
+
+    ChiantiIonList.__table__.create(memory_session.connection())
+
+
+    h0 = Ion(atomic_number=1, ion_charge=0)
+    he0 = Ion(atomic_number=2, ion_charge=0)
+    he1 = Ion(atomic_number=2, ion_charge=1)
+
+    memory_session.add_all([h0, he0, he1])
+
+    chianti_ions = [(1,0), (2,0)]
+
+    for atomic_number, ion_charge in chianti_ions:
+        chianti_ion = ChiantiIonList(atomic_number=atomic_number, ion_charge=ion_charge)
+        memory_session.add(chianti_ion)
+
+    chianti_ions_query = memory_session.query(Ion).\
+        join(ChiantiIonList, and_(Ion.atomic_number == ChiantiIonList.atomic_number,
+                                  Ion.ion_charge == ChiantiIonList.ion_charge)). \
+        order_by(Ion.atomic_number, Ion.ion_charge)
+
+    assert [(ion.atomic_number, ion.ion_charge) for ion in chianti_ions_query] == chianti_ions

--- a/carsus/tests/test_util.py
+++ b/carsus/tests/test_util.py
@@ -1,0 +1,12 @@
+import pytest
+
+from carsus.util import convert_camel2snake
+
+
+@pytest.mark.parametrize("input_camel_case, expected_snake_case", [
+    ("Atom", "atom"),
+    ("CHIANTIIon", "chianti_ion"),
+    ("LevelJJTerm", "level_jj_term")
+])
+def test_convert_camel2snake(input_camel_case, expected_snake_case):
+    assert convert_camel2snake(input_camel_case) == expected_snake_case

--- a/carsus/util.py
+++ b/carsus/util.py
@@ -1,4 +1,5 @@
 import os
+import re
 import numpy as np
 
 from collections import OrderedDict
@@ -15,3 +16,13 @@ symbol2atomic_number = OrderedDict(zip(atomic_symbols_data['symbol'],
                                        atomic_symbols_data['atomic_number']))
 atomic_number2symbol = OrderedDict(zip(atomic_symbols_data['atomic_number'],
                                        atomic_symbols_data['symbol']))
+
+
+def convert_camel2snake(name):
+    """
+    Convert CamelCase to snake_case.
+
+    http://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-snake-case
+    """
+    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()


### PR DESCRIPTION
Suppose you have a list of ions (list of tuples `atomic_number`, `ion_charge`) you want to select in your query:
```
wanted_ions = [(1,0), (2,0), (2,1) ... ]
```
Ideally, you would write a composite IN expression to select them:
```
WHERE atomic_number, ion_charge IN wanted_ions
```
Unfortunately, SQLite doesn't support such queries so we need a workaround. As suggested in http://stackoverflow.com/questions/10525779/how-can-i-rewrite-a-multi-column-in-clause-to-work-on-sqlite I suggest to use temporary tables. 

This PR provides a mixin class `IonListMixin` for creating temporary tables for selecting ions from list. 
To create a temporary table you need to subclass from `IonListMixin` and `Base`:
```
class ChiantiIonList(Base, IonListMixin):
    pass
# to create the table you go
ChiantiIonList.__table__.create(session.connectable())
```
Then you can populate the table with the ions from the list and do a join to this table as explained in the stackoverflow question above.