### PR TITLE
Change the levels query to choose sources for different ions

### DIFF
--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -151,11 +151,16 @@ class AtomData(object):
         }
 
         self.ions = [tuple(species_string_to_tuple(species_str)) for species_str in ions]
-        if chianti_ions is None:
-            self.chianti_ions = chianti_ions
-        else:
+
+        if chianti_ions is not None:
             # Get a list of tuples (atomic_number, ion_charge) for the chianti ions
             self.chianti_ions = [tuple(species_string_to_tuple(species_str)) for species_str in chianti_ions]
+            try:
+                assert set(self.chianti_ions).issubset(set(self.ions))
+            except AssertionError:
+                raise ValueError("`chianti_ions` *must* be a subset of `ions`!")
+        else:
+            self.chianti_ions = None
 
         # Query the data sources
         self.ku_ds = None

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -170,21 +170,19 @@ class AtomData(object):
         try:
             self.ku_ds = session.query(DataSource).filter(DataSource.short_name == kurucz_short_name).one()
         except NoResultFound:
-            print "Kurucz data source does not exist!"
+            raise NoResultFound("Kurucz data source is not found!")
             raise
 
         try:
             self.nist_ds = session.query(DataSource).filter(DataSource.short_name == nist_short_name).one()
         except NoResultFound:
-            print "NIST ASD data source does not exist!"
-            raise
+            raise NoResultFound("NIST ASD data source is not found!")
 
         if self.chianti_ions is not None:
             try:
                 self.ch_ds = session.query(DataSource).filter(DataSource.short_name == chianti_short_name).one()
             except NoResultFound:
-                print "Chianti data source does not exist!"
-                raise
+                raise NoResultFound("Chianti data source is not found!")
 
         self.zeta_datafile = zeta_datafile
 

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -552,7 +552,7 @@ class AtomData(object):
         levels_w_ionization_energies = levels_all.join(ionization_energies, on=["atomic_number", "ion_number"])
         levels = levels_all.loc[
             levels_w_ionization_energies["energy"] < levels_w_ionization_energies["ionization_energy"]
-        ]
+        ].copy()
 
         # Clean lines
         lines = lines_all.join(pd.DataFrame(index=levels.index), on="lower_level_id", how="inner").\

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -18,7 +18,7 @@ with_test_db = pytest.mark.skipif(
 @pytest.fixture
 def atom_data(test_session):
     atom_data = AtomData(test_session,
-                         ions=["He II", "Be III", "B IV", "N VI"],
+                         ions=["He II", "Be III", "B IV", "N VI", "Zn XX"],
                          chianti_ions=["He II", "N VI"])
     return atom_data
 
@@ -101,8 +101,22 @@ def test_atom_data_join_on_chianti_ions_table(test_session, atom_data):
                                           Ion.ion_charge == atom_data.chianti_ions_table.c.ion_charge)).\
         order_by(Ion.atomic_number, Ion.ion_charge)
     chianti_ions = [(ion.atomic_number, ion.ion_charge) for ion in chiatni_ions_q]
-    import pdb; pdb.set_trace()
     assert set(chianti_ions) == set([(2,1), (7,5)])
+
+
+@with_test_db
+def test_atom_data_two_instances_same_session(test_session):
+
+    atom_data1 = AtomData(test_session,
+                         ions=["He II", "Be III", "B IV", "N VI", "Zn XX"],
+                         chianti_ions=["He II", "N VI"])
+    atom_data2 = AtomData(test_session,
+                         ions=["He II", "Be III", "B IV", "N VI", "Zn XX"],
+                         chianti_ions=["He II", "N VI"])
+    atom_data1.ions_table
+    atom_data2.ions_table
+    atom_data1.chianti_ions_table
+    atom_data2.chianti_ions_table
 
 
 @with_test_db
@@ -117,7 +131,7 @@ def test_create_atom_masses(atom_masses, atomic_number, exp_mass):
 
 @with_test_db
 def test_create_atom_masses_max_atomic_number(test_session):
-    atom_data = AtomData(test_session, atom_masses_max_atomic_number=15)
+    atom_data = AtomData(test_session, ions=[], atom_masses_max_atomic_number=15)
     atom_masses = atom_data.atom_masses
     assert atom_masses["atomic_number"].max() == 15
 

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -16,9 +16,10 @@ with_test_db = pytest.mark.skipif(
 
 @pytest.fixture
 def atom_data(test_session):
-    atom_data = AtomData(test_session, chianti_species=["He 2", "N 6"])
+    atom_data = AtomData(test_session,
+                         ions=["He II", "Be III", "B IV", "N VI"],
+                         chianti_ions=["He II", "N VI"])
     return atom_data
-
 
 @pytest.fixture
 def atom_masses(atom_data):
@@ -69,6 +70,27 @@ def hdf5_path(request, data_dir):
     request.addfinalizer(fin)
 
     return hdf5_path
+
+
+def test_atom_data_init(memory_session):
+    nist = DataSource.as_unique(memory_session, short_name="nist-asd")
+    ch = DataSource.as_unique(memory_session, short_name="chianti_v8.0.2")
+    ku = DataSource.as_unique(memory_session, short_name="ku_latest")
+    atom_data = AtomData(memory_session,
+                         ions=["He II", "Be III", "B IV", "N VI"],
+                         chianti_ions=["He II", "N VI"])
+    assert set(atom_data.ions) == set([(2,1), (4,2), (5,3), (7,5)])
+    assert set(atom_data.chianti_ions) == set([(2,1), (7,5)])
+
+
+def test_atom_data_chianti_ions_subset(memory_session):
+    nist = DataSource.as_unique(memory_session, short_name="nist-asd")
+    ch = DataSource.as_unique(memory_session, short_name="chianti_v8.0.2")
+    ku = DataSource.as_unique(memory_session, short_name="ku_latest")
+    with pytest.raises(ValueError):
+        atom_data = AtomData(memory_session,
+                             ions=["He II", "Be III", "B IV", "N VI"],
+                             chianti_ions=["He II", "N VI", "Si II"])
 
 
 @with_test_db

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -150,7 +150,8 @@ def test_create_ionizatinon_energies(ionization_energies, atomic_number, ion_num
 @with_test_db
 @pytest.mark.parametrize("atomic_number, ion_number, level_number, exp_energy",[
     (7, 5, 7, 3991860.0 * u.Unit("cm-1")),
-    (4, 2, 2, 981177.5 * u.Unit("cm-1"))
+    (4, 2, 2, 981177.5 * u.Unit("cm-1")),
+    (30, 19, 0, 0.0*u.Unit("cm-1"))
 ])
 def test_create_levels(levels, atomic_number, ion_number, level_number, exp_energy):
     levels = levels.set_index(["atomic_number", "ion_number", "level_number"])

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -22,6 +22,13 @@ def atom_data(test_session):
                          chianti_ions=["He II", "N VI"])
     return atom_data
 
+
+@pytest.fixture
+def atom_data_only_be2(test_session):
+    atom_data = AtomData(test_session, ions=["Be III"])
+    return atom_data
+
+
 @pytest.fixture
 def atom_masses(atom_data):
     return atom_data.atom_masses
@@ -92,6 +99,16 @@ def test_atom_data_chianti_ions_subset(memory_session):
         atom_data = AtomData(memory_session,
                              ions=["He II", "Be III", "B IV", "N VI"],
                              chianti_ions=["He II", "N VI", "Si II"])
+
+
+def test_atom_data_wo_chianti_ions_attributes(atom_data_only_be2, test_session):
+    assert atom_data_only_be2.chianti_ions == list()
+    assert test_session.query(atom_data_only_be2.chianti_ions_table).count() == 0
+
+
+def test_atom_data_wo_chianti_ions_levels(atom_data_only_be2):
+    levels402 = atom_data_only_be2.levels.copy()
+    assert ((levels402["atomic_number"] == 4) & (levels402["ion_number"] == 2)).all()
 
 
 @with_test_db

--- a/carsus/tests/create_test_db.py
+++ b/carsus/tests/create_test_db.py
@@ -38,8 +38,8 @@ def create_test_db(test_db_fname=TEST_DB_FNAME, gfall_fname=GFALL_FNAME):
 
     # Ingest ionization energies
     ioniz_energies_ingester = NISTIonizationEnergiesIngester(session)
-    ioniz_energies_ingester.download()
-    ioniz_energies_ingester.ingest()
+    ioniz_energies_ingester.download(spectra="h-zn")
+    ioniz_energies_ingester.ingest(ionization_energies=True, ground_levels=True)
     session.commit()
 
     # Ingest kurucz levels and lines


### PR DESCRIPTION
This PR changes the logic of the levels query. There are two lists: the main list - `ions` and the chianti list - `chianti_ions`. `chianti_ions` must be a subset of `ions`.
The rules for selecting levels are as follows:
1.  Only the levels for the ions from `ions` are selected
2. If the ion is in `chianti_ions` and there exist levels
   from the chianti source in the database, then they are selected from chianti
3. Else if there exist levels for this ion from the kurucz source,
     then they are selected from kurucz.
4. Else the  ion's ground level from NIST is selected (that previously was called artificial ions).

The rules are enforced with the CASE statement in the levels query.

 Also, the temporary tables are used for selecting levels for ions from `ions` and `chianti_ions` (because the SQLite doesnt' support composite IN statements). The temporary tables are stored as the attributes of `AtomData`: `ions_table` and `chianti_ions_table`. To create unique names for the temporary table I used the `hash` function and frozensets, e.g:
```
ions_table_name = "MainIonList" + str(hash(frozenset(self.ions)))
# The first name is the name of the mapping class and it will be converted to the snake_case
# So the name of the table would look like: main_ion_list293412347101
```
The temporary tables are created for the session's current connection.
