### PR TITLE
Improve the unit tests for the output dataframes

### DIFF
--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -178,11 +178,29 @@ def test_create_ionizatinon_energies(ionization_energies, atomic_number, ion_num
 
 
 @with_test_db
+@pytest.mark.parametrize("atomic_number, ion_number, ionization_energy",[
+    (2, 1, 54.41776311 * u.eV),
+    (4, 2, 153.896198 * u.eV),
+    (5, 3, 259.3715 * u.eV),
+    (7, 5, 552.06731 * u.eV),
+    (14, 1, 16.345845 * u.eV)  # In fact, only Si II has levels with energy > ionization potential
+])
+def test_create_levels_filter_auto_ionizing_levels(levels, atomic_number, ion_number, ionization_energy):
+    levels_ion = levels.loc[(levels["atomic_number"] == atomic_number) &
+                            (levels["ion_number"] == ion_number)].copy()
+    levels_energies = levels_ion["energy"].values * u.eV
+    assert all(levels_energies < ionization_energy)
+
+
+@with_test_db
 @pytest.mark.parametrize("atomic_number, ion_number, level_number, exp_energy, exp_g, exp_metastable_flag",[
     # Kurucz levels
     (4, 2, 0, 0.0 * u.Unit("cm-1"), 1, True),
     (4, 2, 1, 956501.9 * u.Unit("cm-1"), 3, True),
     (4, 2, 6, 997455.0 * u.Unit("cm-1"), 3, False),
+    (14, 1, 0, 0.0 * u.Unit("cm-1"), 2, True),
+    (14, 1, 15, 81251.320 * u.Unit("cm-1"), 4, False),
+    (14, 1, 16, 83801.950 * u.Unit("cm-1"), 2, True),
     # CHIANTI levels
     # Theoretical values from CHIANTI aren't ingested!!!
     (7, 5, 0, 0.0 * u.Unit("cm-1"), 1, True),

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -161,13 +161,18 @@ def test_create_atom_masses_max_atomic_number(test_session):
 
 @with_test_db
 @pytest.mark.parametrize("atomic_number, ion_number, exp_ioniz_energy", [
-    (8, 5, 138.1189),
-    (11, 0,  5.1390767)
+    (2, 1,  54.41776311 * u.eV),
+    (4, 2, 153.896198 * u.eV),
+    (5, 3, 259.3715 * u.eV),
+    (7, 5, 552.06731 * u.eV),
+    (30, 19, 737.366 * u.eV)
 ])
 def test_create_ionizatinon_energies(ionization_energies, atomic_number, ion_number, exp_ioniz_energy):
     ionization_energies = ionization_energies.set_index(["atomic_number", "ion_number"])
-    assert_almost_equal(ionization_energies.loc[(atomic_number, ion_number)]["ionization_energy"],
-                        exp_ioniz_energy)
+    assert_quantity_allclose(
+        ionization_energies.loc[(atomic_number, ion_number)]["ionization_energy"] * u.eV,
+        exp_ioniz_energy
+    )
 
 
 @with_test_db

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -138,12 +138,18 @@ def test_atom_data_two_instances_same_session(test_session):
 
 @with_test_db
 @pytest.mark.parametrize("atomic_number, exp_mass", [
-    (2, 4.002602),
-    (11, 22.98976928)
+    (2, 4.002602 * u.u),
+    (4, 9.0121831 * u.u),
+    (5, (10.806 + 10.821)/2 *u.u),
+    (7, (14.00643 + 14.00728)/2 *u.u),
+    (30, 65.38 *u.u)
 ])
 def test_create_atom_masses(atom_masses, atomic_number, exp_mass):
     atom_masses = atom_masses.set_index("atomic_number")
-    assert_almost_equal(atom_masses.loc[atomic_number]["mass"], exp_mass)
+    assert_quantity_allclose(
+        atom_masses.loc[atomic_number]["mass"] * u.u,
+        exp_mass
+    )
 
 
 @with_test_db


### PR DESCRIPTION
This PR adds more reliable unit tests for atomic masses, ionization energies, levels and lines. Important Si II levels and lines were included into the test.db.