### PR TITLE
Fully ionized ions

### DIFF
--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -51,10 +51,7 @@ class AtomData(object):
         (default: "chianti_v8.0.2")
     atom_masses_max_atomic_number: int
         The maximum atomic number to be stored in atom_masses
-            (default: 30)
-    levels_create_metastable_flags: bool
-        Create the `metastable` column containing flags for metastable levels (levels that take a long time to de-excite)
-        (default: True)
+        (default: 30)
     lines_loggf_threshold: int
         log(gf) threshold for lines
     levels_metastable_loggf_threshold: int
@@ -127,8 +124,7 @@ class AtomData(object):
 
     def __init__(self, session, ions, chianti_ions=None,
                  kurucz_short_name="ku_latest", chianti_short_name="chianti_v8.0.2", nist_short_name="nist-asd",
-                 atom_masses_max_atomic_number=30, levels_create_metastable_flags=True,
-                 lines_loggf_threshold=-3, levels_metastable_loggf_threshold=-3,
+                 atom_masses_max_atomic_number=30, lines_loggf_threshold=-3, levels_metastable_loggf_threshold=-3,
                  collisions_temperatures=None,
                  zeta_datafile=ZETA_DATAFILE):
 
@@ -140,7 +136,6 @@ class AtomData(object):
         }
 
         self.levels_lines_param = {
-            "levels_create_metastable_flags": levels_create_metastable_flags,
             "levels_metastable_loggf_threshold": levels_metastable_loggf_threshold,
             "lines_loggf_threshold": lines_loggf_threshold
         }
@@ -514,15 +509,12 @@ class AtomData(object):
         metastable_flags.name = "metastable"
         return metastable_flags
 
-    def create_levels_lines(self, levels_create_metastable_flags=True, levels_metastable_loggf_threshold=-3,
-                            lines_loggf_threshold=-3):
+    def create_levels_lines(self, levels_metastable_loggf_threshold=-3, lines_loggf_threshold=-3):
         """
         Create a DataFrame containing *levels data* and a DataFrame containing *lines data*.
 
         Parameters
         ----------
-        levels_create_metastable_flags: bool
-            Create the `metastable` column containing flags for metastable levels (levels that take a long time to de-excite)
         levels_metastable_loggf_threshold: int
             log(gf) threshold for flagging metastable levels
         lines_loggf_threshold: int
@@ -565,8 +557,7 @@ class AtomData(object):
         # Do not clean levels that don't exist in lines
 
         # Create the metastable flags for levels
-        if levels_create_metastable_flags:
-            levels["metastable"] = self._create_metastable_flags(levels, lines_all, levels_metastable_loggf_threshold)
+        levels["metastable"] = self._create_metastable_flags(levels, lines_all, levels_metastable_loggf_threshold)
 
         # Create level numbers
         levels.sort_values(["atomic_number", "ion_number", "energy", "g"], inplace=True)
@@ -712,7 +703,7 @@ class AtomData(object):
 
         collisions = np.array(collisions, dtype=collisions_dtype)
         collisions = pd.DataFrame.from_records(collisions, index="e_col_id")
-
+    
         # Join atomic_number, ion_number, level_number_lower, level_number_upper
         lower_levels = self.levels.rename(columns={"level_number": "level_number_lower", "g": "g_l", "energy": "energy_lower"}). \
                               loc[:, ["atomic_number", "ion_number", "level_number_lower", "g_l", "energy_lower"]]

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -502,11 +502,13 @@ class AtomData(object):
         metastable_counts = metastable_lines_grouped["upper_level_id"].count()
         metastable_counts.name = "metastable_counts"
 
-        # If there are no strong transitions for a level (the count is NaN) then the metastable flag is True
-        # else (the count is a natural number) the metastable flag is False
+        # If there are no strong transitions for a level (the count is NaN) then the metastable flag is 1
+        # else (the count is a natural number) the metastable flag is 0
         levels = levels.join(metastable_counts)
-        metastable_flags =  levels["metastable_counts"].isnull()
+        metastable_flags = levels["metastable_counts"].isnull()
+        metastable_flags = metastable_flags.apply(lambda x: 1 if x else 0)  # convert bool to 0/1
         metastable_flags.name = "metastable"
+
         return metastable_flags
 
     def create_levels_lines(self, levels_metastable_loggf_threshold=-3, lines_loggf_threshold=-3):
@@ -603,7 +605,7 @@ class AtomData(object):
                  "level_number": 0,
                  "energy": 0.0,
                  "g": 1,
-                 "metastable": True}
+                 "metastable": 1}
             )
 
         return pd.DataFrame.from_dict(data=fully_ionized_levels, dtype=levels_prepared.dtypes)

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -71,6 +71,10 @@ def zeta_data(atom_data):
 
 
 @pytest.fixture
+def levels_prepared(atom_data):
+    return atom_data.levels_prepared
+
+@pytest.fixture
 def hdf5_path(request, data_dir):
     hdf5_path = os.path.join(data_dir, "test_hdf.hdf5")
 
@@ -262,6 +266,17 @@ def test_create_lines_loggf_treshold(lines, atomic_number, ion_number, level_num
                              "level_number_lower", "level_number_upper"])
     with pytest.raises(KeyError):
         lines.loc[(atomic_number, ion_number, level_number_lower, level_number_upper)]
+
+
+@with_test_db
+@pytest.mark.parametrize("atomic_number", [2, 14, 30])
+def test_levels_prepare_create_artificial_ions(levels_prepared, atomic_number):
+    levels_prepared = levels_prepared.set_index(["atomic_number", "ion_number", "level_number"])
+    energy, g, metastable = levels_prepared.loc[(atomic_number, atomic_number, 0),
+                                                ["energy", "g", "metastable"]]
+    assert_almost_equal(energy, 0.0)
+    assert g == 1
+    assert metastable == True
 
 
 # ToDo: Implement real tests

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -200,19 +200,19 @@ def test_create_levels_filter_auto_ionizing_levels(levels, atomic_number, ion_nu
 @with_test_db
 @pytest.mark.parametrize("atomic_number, ion_number, level_number, exp_energy, exp_g, exp_metastable_flag",[
     # Kurucz levels
-    (4, 2, 0, 0.0 * u.Unit("cm-1"), 1, True),
-    (4, 2, 1, 956501.9 * u.Unit("cm-1"), 3, True),
-    (4, 2, 6, 997455.0 * u.Unit("cm-1"), 3, False),
-    (14, 1, 0, 0.0 * u.Unit("cm-1"), 2, True),
-    (14, 1, 15, 81251.320 * u.Unit("cm-1"), 4, False),
-    (14, 1, 16, 83801.950 * u.Unit("cm-1"), 2, True),
+    (4, 2, 0, 0.0 * u.Unit("cm-1"), 1, 1),
+    (4, 2, 1, 956501.9 * u.Unit("cm-1"), 3, 1),
+    (4, 2, 6, 997455.0 * u.Unit("cm-1"), 3, 0),
+    (14, 1, 0, 0.0 * u.Unit("cm-1"), 2, 1),
+    (14, 1, 15, 81251.320 * u.Unit("cm-1"), 4, 0),
+    (14, 1, 16, 83801.950 * u.Unit("cm-1"), 2, 1),
     # CHIANTI levels
     # Theoretical values from CHIANTI aren't ingested!!!
-    (7, 5, 0, 0.0 * u.Unit("cm-1"), 1, True),
-    (7, 5, 7, 3991860.0 * u.Unit("cm-1"), 3, False),
-    (7, 5, 43, 4294670.00 * u.Unit("cm-1"), 5, False),
+    (7, 5, 0, 0.0 * u.Unit("cm-1"), 1, 1),
+    (7, 5, 7, 3991860.0 * u.Unit("cm-1"), 3, 0),
+    (7, 5, 43, 4294670.00 * u.Unit("cm-1"), 5, 0),
     # NIST Ground level
-    (30, 19, 0, 0.0 * u.eV, 2, True)
+    (30, 19, 0, 0.0 * u.eV, 2, 1)
 ])
 def test_create_levels(levels, atomic_number, ion_number, level_number,
                        exp_energy, exp_g, exp_metastable_flag):
@@ -276,8 +276,7 @@ def test_levels_prepare_create_artificial_ions(levels_prepared, atomic_number):
                                                 ["energy", "g", "metastable"]]
     assert_almost_equal(energy, 0.0)
     assert g == 1
-    assert metastable == True
-
+    assert metastable == 1
 
 # ToDo: Implement real tests
 @with_test_db


### PR DESCRIPTION
- This PR adds artificial fully ionized levels (legacy name) to the levels DataFrame. They are completely made up for atoms present in the levels DataFrame. 
- Also this PR converts the metastable flag from boolean to 0/1 - this is how it was in the original dataframe.
- Also this PR removes the `create_metastable_flags` option - the metastable flags are always created