### PR TITLE
Convert kurucz air wavelengths to vacuum

### DIFF
--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -252,6 +252,24 @@ def test_create_lines(lines, atomic_number, ion_number, level_number_lower, leve
 
 
 @with_test_db
+@pytest.mark.parametrize("atomic_number, ion_number, level_number_lower, level_number_upper, exp_wavelength, exp_loggf",[
+    # Kurucz lines with wavelength above 2000 Angstrom
+    (14, 1, 8, 83, 2015.574293 * u.Unit("angstrom"), -0.120),
+    (14, 1, 8, 82, 2017.305610 * u.Unit("angstrom"), 0.190)
+])
+def test_create_lines_convert_air2vacuum(lines, atomic_number, ion_number, level_number_lower, level_number_upper,
+                      exp_wavelength, exp_loggf):
+    lines = lines.set_index(["atomic_number", "ion_number",
+                              "level_number_lower", "level_number_upper"])
+    wavelength = lines.loc[(atomic_number, ion_number,
+                            level_number_lower, level_number_upper)]["wavelength"] * u.Unit("angstrom")
+    loggf = lines.loc[(atomic_number, ion_number,
+                            level_number_lower, level_number_upper)]["loggf"]
+    assert_quantity_allclose(wavelength, exp_wavelength)
+    assert_almost_equal(loggf, exp_loggf)
+
+
+@with_test_db
 @pytest.mark.parametrize("atomic_number, ion_number, level_number_lower, level_number_upper", [
     # Default loggf_threshold = -3
     # Kurucz lines

--- a/carsus/util.py
+++ b/carsus/util.py
@@ -26,3 +26,41 @@ def convert_camel2snake(name):
     """
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+
+
+def convert_wavelength_vacuum2air(wavelength_vacuum):
+    """
+    Convert vacuum wavelength to air wavelength
+    Parameters
+    -----------
+    wavelength_vacuum: float
+        Vacuum wavelength in Angstroms
+
+    Returns
+    --------
+    float
+        Air wavelength in Angstroms
+    """
+    sigma2 = (1e4/wavelength_vacuum)**2.
+    fact = 1.0 + 5.792105e-2/(238.0185 - sigma2) + 1.67917e-3/(57.362 - sigma2)
+
+    return wavelength_vacuum/fact
+
+
+def convert_wavelength_air2vacuum(wavelength_air):
+    """
+    Convert air wavelength to vacuum wavelength
+    Parameters
+    -----------
+    wavelength_air: float
+        Air wavelength in Angstroms
+
+    Returns
+    --------
+    float
+        Vacuum wavelength in Angstroms
+    """
+    sigma2 = (1e4/wavelength_air)**2.
+    fact = 1.0 + 5.792105e-2/(238.0185 - sigma2) + 1.67917e-3/(57.362 - sigma2)
+
+    return wavelength_air * fact


### PR DESCRIPTION
This PR borrows the functions for converting wavelengths for tardisatomic and converts the kurucz wavelengths above 2000 angstrome in the output module for TARDIS. This is quick and dirty implementation, later the `medium` field will be created for then `Line` table.