### PR TITLE
Remove label from drop_duplicates in GFALLReader

### DIFF
--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -150,6 +150,11 @@ class GFALLReader(object):
         gfall_df["label_lower"] = gfall_df["label_lower"].str.strip()
         gfall_df["label_upper"] = gfall_df["label_upper"].str.strip()
 
+        # Ignore lines with the labels "AVARAGE ENERGIES" and "CONTINUUM"
+        ignored_labels = ["AVERAGE", "ENERGIES", "CONTINUUM"]
+        gfall_df = gfall_df.loc[(gfall_df["label_lower"].isin(ignored_labels)) |
+                                (gfall_df["label_upper"].isin(ignored_labels))].copy()
+
         gfall_df['e_lower_predicted'] = gfall_df["e_lower"] < 0
         gfall_df["e_lower"] = gfall_df["e_lower"].abs()
         gfall_df['e_upper_predicted'] = gfall_df["e_upper"] < 0

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -201,7 +201,7 @@ class GFALLReader(object):
         levels = pd.concat([e_lower_levels[selected_columns],
                             e_upper_levels[selected_columns]])
 
-        levels = levels.drop_duplicates(['atomic_number', 'ion_charge', 'energy', 'j', 'label']). \
+        levels = levels.drop_duplicates(['atomic_number', 'ion_charge', 'energy', 'j']). \
             sort_values(['atomic_number', 'ion_charge', 'energy', 'j'])
 
         levels["method"] = levels["theoretical"].\


### PR DESCRIPTION
This PR removes `label` from `drop_duplicates` so that the unique kurucz levels are determined by 'atomic_number', 'ion_charge', 'energy' and 'j'. `label` apparently needs additional parsing before it is used as a criterion of uniqueness. 
Also, lines and levels with labels "AVERAGE ENERGIES" and "CONTINUUM" are ignored for now.