### PR TITLE
GFALLReader and GFALLIngester fixes and improvements

### DIFF
--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -227,6 +227,7 @@ class GFALLReader(object):
 
         levels["level_index"] = levels.groupby(['atomic_number', 'ion_charge'])['j'].\
             transform(lambda x: np.arange(len(x))).values
+        levels["levels_index"] = levels["levels_index"].astype(int)
 
         # ToDo: The commented block below does not work with all lines. Find a way to parse it.
         # levels[["configuration", "term"]] = levels["label"].str.split(expand=True)
@@ -262,7 +263,6 @@ class GFALLReader(object):
             selected_columns = ['wavelength', 'loggf', 'atomic_number', 'ion_charge']
 
         levels_df_idx = levels_df.reset_index()
-        levels_df_idx["level_index"] = levels_df_idx["level_index"].astype(int)  # convert to int
         levels_df_idx = levels_df_idx.set_index(['atomic_number', 'ion_charge', 'energy', 'j'])
 
         lines = gfall_df[selected_columns].copy()

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -147,8 +147,12 @@ class GFALLReader(object):
             del gfall_df['{0}_first'.format(column)]
             del gfall_df['{0}_second'.format(column)]
 
+        # Clean labels
         gfall_df["label_lower"] = gfall_df["label_lower"].str.strip()
         gfall_df["label_upper"] = gfall_df["label_upper"].str.strip()
+
+        gfall_df["label_lower"] = gfall_df["label_lower"].str.replace('\s+', ' ')
+        gfall_df["label_upper"] = gfall_df["label_upper"].str.replace('\s+', ' ')
 
         # Ignore lines with the labels "AVARAGE ENERGIES" and "CONTINUUM"
         ignored_labels = ["AVERAGE", "ENERGIES", "CONTINUUM"]

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -227,7 +227,7 @@ class GFALLReader(object):
 
         levels["level_index"] = levels.groupby(['atomic_number', 'ion_charge'])['j'].\
             transform(lambda x: np.arange(len(x))).values
-        levels["levels_index"] = levels["levels_index"].astype(int)
+        levels["level_index"] = levels["level_index"].astype(int)
 
         # ToDo: The commented block below does not work with all lines. Find a way to parse it.
         # levels[["configuration", "term"]] = levels["label"].str.split(expand=True)
@@ -263,20 +263,20 @@ class GFALLReader(object):
             selected_columns = ['wavelength', 'loggf', 'atomic_number', 'ion_charge']
 
         levels_df_idx = levels_df.reset_index()
-        levels_df_idx = levels_df_idx.set_index(['atomic_number', 'ion_charge', 'energy', 'j'])
+        levels_df_idx = levels_df_idx.set_index(['atomic_number', 'ion_charge', 'energy', 'j', 'label'])
 
         lines = gfall_df[selected_columns].copy()
         lines["gf"] = np.power(10, lines["loggf"])
         lines = lines.drop(["loggf"], 1)
 
-        level_lower_idx = gfall_df[['atomic_number', 'ion_charge', 'e_lower', 'j_lower']].values.tolist()
+        level_lower_idx = gfall_df[['atomic_number', 'ion_charge', 'e_lower', 'j_lower', 'label_lower']].values.tolist()
         level_lower_idx = [tuple(item) for item in level_lower_idx]
 
-        level_upper_idx = gfall_df[['atomic_number', 'ion_charge', 'e_upper', 'j_upper']].values.tolist()
+        level_upper_idx = gfall_df[['atomic_number', 'ion_charge', 'e_upper', 'j_upper', 'label_upper']].values.tolist()
         level_upper_idx = [tuple(item) for item in level_upper_idx]
 
-        lines['level_index_lower'] = levels_df_idx["level_index"].loc[level_lower_idx].values
-        lines['level_index_upper'] = levels_df_idx["level_index"].loc[level_upper_idx].values
+        lines['level_index_lower'] = levels_df_idx.loc[level_lower_idx, "level_index"].values
+        lines['level_index_upper'] = levels_df_idx.loc[level_upper_idx, "level_index"].values
 
         lines.set_index(['atomic_number', 'ion_charge', 'level_index_lower', 'level_index_upper'], inplace=True)
 

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -218,8 +218,8 @@ class GFALLReader(object):
         levels = pd.concat([e_lower_levels[selected_columns],
                             e_upper_levels[selected_columns]])
 
-        levels = levels.sort_values(['atomic_number', 'ion_charge', 'energy', 'j']).\
-            drop_duplicates(['atomic_number', 'ion_charge', 'energy', 'j'])
+        levels = levels.sort_values(['atomic_number', 'ion_charge', 'energy', 'j', 'label']).\
+            drop_duplicates(['atomic_number', 'ion_charge', 'energy', 'j', 'label'])
 
         levels["method"] = levels["theoretical"].\
             apply(lambda x: "theor" if x else "meas")  # Theoretical or measured

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -91,8 +91,14 @@ class GFALLReader(object):
         field_widths = type_match.sub('', kurucz_fortran_format)
         field_widths = map(int, re.sub(r'\.\d+', '', field_widths).split(','))
 
-        gfall = np.genfromtxt(fname, dtype=field_types, delimiter=field_widths,
-                              skip_header=2)
+        def read_remove_empty(fname):
+            """ Generator to remove empty lines from the gfall file"""
+            with open(fname, "r") as f:
+                for line in f:
+                    if not re.match(r'^\s*$', line):
+                        yield line
+
+        gfall = np.genfromtxt(read_remove_empty(fname), dtype=field_types, delimiter=field_widths)
 
         columns = ['wavelength', 'loggf', 'element_code', 'e_first', 'j_first',
                    'blank1', 'label_first', 'e_second', 'j_second', 'blank2',

--- a/carsus/io/tests/test_gfall.py
+++ b/carsus/io/tests/test_gfall.py
@@ -72,13 +72,6 @@ def test_gfall_reader_gfall_df_ignore_labels(gfall_df):
                                   (gfall_df["label_upper"].isin(ignored_labels))]) == 0
 
 
-def test_gfall_reader_levels_df_unique(levels_df):
-    levels_df = levels_df.reset_index()
-    assert pd.Series(
-        levels_df.groupby(["atomic_number", "ion_charge", "energy", "j"]).size() == 1
-    ).all()
-
-
 @pytest.mark.parametrize("atomic_number, ion_charge, level_index, "
                          "energy, j, method",[
     (4, 2, 0, 0.0, 0.0, "meas"),

--- a/carsus/io/tests/test_gfall.py
+++ b/carsus/io/tests/test_gfall.py
@@ -35,7 +35,7 @@ def lines_df(gfall_rdr):
 
 @pytest.fixture()
 def gfall_ingester(memory_session, gfall_fname):
-    return GFALLIngester(memory_session, gfall_fname)
+    return GFALLIngester(memory_session, gfall_fname, ions=["Be III", "N VI"])
 
 
 @pytest.mark.parametrize("index, wavelength, element_code, e_first, e_second",[

--- a/carsus/io/tests/test_gfall.py
+++ b/carsus/io/tests/test_gfall.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 import pandas as pd
 
 from carsus.io.kurucz import GFALLReader, GFALLIngester
@@ -70,6 +71,12 @@ def test_gfall_reader_gfall_df_ignore_labels(gfall_df):
     ignored_labels = ["AVERAGE", "ENERGIES", "CONTINUUM"]
     assert len(gfall_df.loc[(gfall_df["label_lower"].isin(ignored_labels)) |
                                   (gfall_df["label_upper"].isin(ignored_labels))]) == 0
+
+
+def test_gfall_reader_clean_levels_labels(levels_df):
+    # One label for the ground level of Be III has an extra space
+    levels0402 = levels_df.loc[(4,2)]
+    assert len(levels0402.loc[(np.isclose(levels0402["energy"], 0.0))]) == 1
 
 
 @pytest.mark.parametrize("atomic_number, ion_charge, level_index, "


### PR DESCRIPTION
This PR introduces a few changes to `GFALLReader` and `GFALLIngester`:
- **Do use** `label` in `drop_duplicates()` (revert https://github.com/tardis-sn/carsus/pull/65) because some levels with equal energy and j have different labels. Replace all whitespace in `label` with a single space. Also use `label` when locating levels for lines.
- Use a generator to remove empty lines from gfall files (sometimes there are empty lines in the header, sometimes not).
- `level_index` was converted to int in the `extract_lines()` method. Move it to `extract_levels()`.
- Add the `ions` parameter to `GFALLIngester` to select ions for which to ingest  lines and levels. 
- Fix tests. 
