### PR TITLE
Add levels for fully ionized ions to macro atom references

### DIFF
--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -657,12 +657,6 @@ class AtomData(object):
         # Drop the unwanted columns
         levels_prepared.drop(["level_id"], axis=1, inplace=True)
 
-        # Create and append artificial fully ionized ions
-        artificial_fully_ionized_levels = self._create_artificial_fully_ionized(levels_prepared)
-
-        levels_prepared = levels_prepared.append(artificial_fully_ionized_levels, ignore_index=True)
-        levels_prepared.sort_values(["atomic_number", "ion_number", "energy", "g"], inplace=True)
-
         # Covert energy to CGS
         levels_prepared["energy"] = Quantity(levels_prepared["energy"].values, 'eV').cgs
 

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -865,14 +865,13 @@ class AtomData(object):
                 Refer to the docs: http://tardis.readthedocs.io/en/latest/physics/plasma/macroatom.html
 
         """
+        # Exclude artificially created levels from levels
+        levels = self.levels.loc[self.levels["level_id"] != -1].set_index("level_id")
 
-        levels = self.levels.copy()
-        lines = self.lines.copy()
+        lvl_energy_lower = levels.rename(columns={"energy": "energy_lower"}).loc[:, ["energy_lower"]]
+        lvl_energy_upper = levels.rename(columns={"energy": "energy_upper"}).loc[:, ["energy_upper"]]
 
-        lvl_energy_lower = self.levels.rename(columns={"energy": "energy_lower"}).loc[:, ["energy_lower"]]
-        lvl_energy_upper = self.levels.rename(columns={"energy": "energy_upper"}).loc[:, ["energy_upper"]]
-
-        lines = lines.join(lvl_energy_lower, on="lower_level_id").join(lvl_energy_upper, on="upper_level_id")
+        lines = self.lines.join(lvl_energy_lower, on="lower_level_id").join(lvl_energy_upper, on="upper_level_id")
 
         macro_atom = list()
         macro_atom_dtype = [("atomic_number", np.int), ("ion_number", np.int),
@@ -901,7 +900,7 @@ class AtomData(object):
         macro_atom = np.array(macro_atom, dtype=macro_atom_dtype)
         macro_atom = pd.DataFrame(macro_atom)
 
-        macro_atom.sort_values(["atomic_number", "ion_number", "source_level_number"], inplace=True)
+        macro_atom = macro_atom.sort_values(["atomic_number", "ion_number", "source_level_number"])
 
         return macro_atom
 

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -651,7 +651,6 @@ class AtomData(object):
         levels_prepared = self.levels.copy()
 
         # Set index
-        levels_prepared.reset_index(inplace=True)
         # levels.set_index(["atomic_number", "ion_number", "level_number"], inplace=True)
 
         # Drop the unwanted columns
@@ -681,7 +680,6 @@ class AtomData(object):
         lines_prepared = self.lines.copy()
 
         # Set the index
-        lines_prepared.reset_index(inplace=True)
         # lines.set_index(["atomic_number", "ion_number", "level_number_lower", "level_number_upper"], inplace=True)
 
         # Create a new columns with wavelengths in the CGS units

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -530,7 +530,7 @@ class AtomData(object):
 
     @staticmethod
     def _create_artificial_fully_ionized(levels):
-
+        """ Create artificial levels for fully ionized ions. """
         fully_ionized_levels = list()
 
         for atomic_number, _ in levels.groupby("atomic_number"):

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -723,7 +723,10 @@ class AtomData(object):
                 DataFrame with:
         """
 
-        levels_idx = self.levels.index.values
+        # Exclude artificially created levels from levels
+        levels = self.levels.loc[self.levels["level_id"] != -1].set_index("level_id")
+
+        levels_idx = levels.index.values
         collisions_q = self._build_collisions_q(levels_idx)
 
         collisions = list()
@@ -750,9 +753,9 @@ class AtomData(object):
         collisions = pd.DataFrame.from_records(collisions, index="e_col_id")
 
         # Join atomic_number, ion_number, level_number_lower, level_number_upper
-        lower_levels = self.levels.rename(columns={"level_number": "level_number_lower", "g": "g_l", "energy": "energy_lower"}). \
+        lower_levels = levels.rename(columns={"level_number": "level_number_lower", "g": "g_l", "energy": "energy_lower"}). \
                               loc[:, ["atomic_number", "ion_number", "level_number_lower", "g_l", "energy_lower"]]
-        upper_levels = self.levels.rename(columns={"level_number": "level_number_upper", "g": "g_u", "energy": "energy_upper"}). \
+        upper_levels = levels.rename(columns={"level_number": "level_number_upper", "g": "g_u", "energy": "energy_upper"}). \
                               loc[:, ["level_number_upper", "g_u", "energy_upper"]]
 
         collisions = collisions.join(lower_levels, on="lower_level_id").join(upper_levels, on="upper_level_id")

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -112,8 +112,11 @@ def test_atom_data_wo_chianti_ions_attributes(atom_data_only_be2, test_session):
 
 
 def test_atom_data_wo_chianti_ions_levels(atom_data_only_be2):
-    levels402 = atom_data_only_be2.levels.copy()
-    assert ((levels402["atomic_number"] == 4) & (levels402["ion_number"] == 2)).all()
+    levels402 = atom_data_only_be2.levels
+    ions_in_levels402 = levels402.loc[:, ("atomic_number", "ion_number")].to_records(index=False).tolist()
+    # Exclude fully ionized, it is supposed to be there
+    ions_in_levels402 = [ion for ion in ions_in_levels402 if ion != (4, 4)]
+    assert all([ion == (4, 2) for ion in ions_in_levels402])
 
 
 @with_test_db

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -312,6 +312,24 @@ def test_create_macro_atom_ref_df(macro_atom_references):
 
 
 @with_test_db
+@pytest.mark.parametrize("atomic_number, ion_number, source_level_number", [
+    (2, 2, 0),
+    (5, 5, 0),
+    (30, 19, 0),
+    (30, 30, 0)
+])
+def test_create_macro_atom_references_levels_wo_lines(macro_atom_references, atomic_number,
+                                                      ion_number, source_level_number):
+    macro_atom_references = macro_atom_references.set_index(
+        ["atomic_number", "ion_number", "source_level_number"]
+    )
+    count_up, count_down, count_total = macro_atom_references.loc[
+        (atomic_number, ion_number, source_level_number), ("count_up", "count_down", "count_total")
+    ]
+    assert all([count == 0 for count in [count_up, count_down, count_total]])
+
+
+@with_test_db
 def test_create_zeta_data(zeta_data):
     assert True
 

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -288,10 +288,9 @@ def test_create_lines_loggf_treshold(lines, atomic_number, ion_number, level_num
 
 @with_test_db
 @pytest.mark.parametrize("atomic_number", [2, 14, 30])
-def test_levels_prepare_create_artificial_ions(levels_prepared, atomic_number):
-    levels_prepared = levels_prepared.set_index(["atomic_number", "ion_number", "level_number"])
-    energy, g, metastable = levels_prepared.loc[(atomic_number, atomic_number, 0),
-                                                ["energy", "g", "metastable"]]
+def test_levels_create_artificial_fully_ionized(levels, atomic_number):
+    levels = levels.set_index(["atomic_number", "ion_number", "level_number"])
+    energy, g, metastable = levels.loc[(atomic_number, atomic_number, 0), ["energy", "g", "metastable"]]
     assert_almost_equal(energy, 0.0)
     assert g == 1
     assert metastable == 1


### PR DESCRIPTION
This PR moves the creation of artificial levels for fully ionized ions from `prepare_levels()` to 
`create_levels_lines()`. It important to add these levels to `levels` because they **also should be
counted in macro atom references**. The main issue was that they don't have `level_id`. 
The PR assigns `level_id=-1` for them and ensures that  `level_id` is not used as the index of the `levels` DataFrame after the artificial levels were added:

|     | atomic_number | energy        | g  | ion_number | level_id | level_number | metastable |
|-----|---------------|---------------|----|------------|----------|--------------|------------|
| 22  | 2             | 52.2411422635 | 8  | 1          | 695      | 22           | 0          |
| 23  | 2             | 52.2411422635 | 8  | 1          | 696      | 23           | 0          |
| 24  | 2             | 52.2411468509 | 10 | 1          | 697      | 24           | 0          |
| 202 | 2             | 0.0           | 1  | 2          | -1       | 0            | 1          |
| 25  | 4             | 0.0           | 1  | 2          | 466      | 0            | 1          |
| 26  | 4             | 118.591116098 | 3  | 2          | 467      | 1            | 1          |

The PR also fixes the creation of other DataFrames and tests. A new test is implemented that checks that counts (in `macro_atom_references`) for levels without lines are all equal to 0.
