### PR TITLE
Change metastable from int to bool

### DIFF
--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -508,11 +508,10 @@ class AtomData(object):
         metastable_counts = metastable_lines_grouped["upper_level_id"].count()
         metastable_counts.name = "metastable_counts"
 
-        # If there are no strong transitions for a level (the count is NaN) then the metastable flag is 1
-        # else (the count is a natural number) the metastable flag is 0
+        # If there are no strong transitions for a level (the count is NaN) then the metastable flag is True
+        # else (the count is a natural number) the metastable flag is False
         levels = levels.join(metastable_counts)
         metastable_flags = levels["metastable_counts"].isnull()
-        metastable_flags = metastable_flags.apply(lambda x: 1 if x else 0)  # convert bool to 0/1
         metastable_flags.name = "metastable"
 
         return metastable_flags

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -523,7 +523,7 @@ class AtomData(object):
 
         for atomic_number, _ in levels.groupby("atomic_number"):
             fully_ionized_levels.append(
-                (-1, atomic_number, atomic_number, 0, 0.0, 1, 1)
+                (-1, atomic_number, atomic_number, 0, 0.0, 1, True)
             )
 
         levels_columns = ["level_id", "atomic_number", "ion_number", "level_number", "energy", "g", "metastable"]

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -203,19 +203,19 @@ def test_create_levels_filter_auto_ionizing_levels(levels, atomic_number, ion_nu
 @with_test_db
 @pytest.mark.parametrize("atomic_number, ion_number, level_number, exp_energy, exp_g, exp_metastable_flag",[
     # Kurucz levels
-    (4, 2, 0, 0.0 * u.Unit("cm-1"), 1, 1),
-    (4, 2, 1, 956501.9 * u.Unit("cm-1"), 3, 1),
-    (4, 2, 6, 997455.0 * u.Unit("cm-1"), 3, 0),
-    (14, 1, 0, 0.0 * u.Unit("cm-1"), 2, 1),
-    (14, 1, 15, 81251.320 * u.Unit("cm-1"), 4, 0),
+    (4, 2, 0, 0.0 * u.Unit("cm-1"), 1, True),
+    (4, 2, 1, 956501.9 * u.Unit("cm-1"), 3, True),
+    (4, 2, 6, 997455.0 * u.Unit("cm-1"), 3, False),
+    (14, 1, 0, 0.0 * u.Unit("cm-1"), 2, True),
+    (14, 1, 15, 81251.320 * u.Unit("cm-1"), 4, False),
     # (14, 1, 16, 83801.950 * u.Unit("cm-1"), 2, 1),  investigate the issue with this level (probably labels)!
     # CHIANTI levels
     # Theoretical values from CHIANTI aren't ingested!!!
-    (7, 5, 0, 0.0 * u.Unit("cm-1"), 1, 1),
-    (7, 5, 7, 3991860.0 * u.Unit("cm-1"), 3, 0),
-    (7, 5, 43, 4294670.00 * u.Unit("cm-1"), 5, 0),
+    (7, 5, 0, 0.0 * u.Unit("cm-1"), 1, True),
+    (7, 5, 7, 3991860.0 * u.Unit("cm-1"), 3, False),
+    (7, 5, 43, 4294670.00 * u.Unit("cm-1"), 5, False),
     # NIST Ground level
-    (30, 19, 0, 0.0 * u.eV, 2, 1)
+    (30, 19, 0, 0.0 * u.eV, 2, True)
 ])
 def test_create_levels(levels, atomic_number, ion_number, level_number,
                        exp_energy, exp_g, exp_metastable_flag):
@@ -296,7 +296,7 @@ def test_levels_create_artificial_fully_ionized(levels, atomic_number):
     energy, g, metastable = levels.loc[(atomic_number, atomic_number, 0), ["energy", "g", "metastable"]]
     assert_almost_equal(energy, 0.0)
     assert g == 1
-    assert metastable == 1
+    assert metastable
 
 # ToDo: Implement real tests
 @with_test_db


### PR DESCRIPTION
This PR changes the dtype of the `metastable` column from `levels` to bool. The purpose is that TARDIS expects this column to be boolean.