### PR TITLE
Fix prepare collisions method

### DIFF
--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -817,7 +817,7 @@ class AtomData(object):
 
         collisions_prepared = self.collisions.loc[:, ["atomic_number", "ion_number",
                                                       "level_number_lower", "level_number_upper",
-                                                      "e_col_id", "delta_e", "g_ratio", "c_ul"]].copy()
+                                                      "delta_e", "g_ratio", "c_ul"]].copy()
 
         # Set multiindex
         collisions_prepared = collisions_prepared.reset_index()

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -820,9 +820,9 @@ class AtomData(object):
                                                       "e_col_id", "delta_e", "g_ratio", "c_ul"]].copy()
 
         # Set multiindex
-        collisions_prepared = collisions_prepared.reset_index(inplace=True)
+        collisions_prepared = collisions_prepared.reset_index()
         collisions_prepared = collisions_prepared.set_index(["atomic_number", "ion_number",
-                                                             "level_number_lower", "level_number_upper"], inplace=True)
+                                                             "level_number_lower", "level_number_upper"])
 
         return collisions_prepared
 


### PR DESCRIPTION
This PR fixes bugs in the `prepare_collisions` method, namely:
- removes `e_col_id` from the `loc` columns list  because it's an index
- removes the `inplace` parameter.