### PR TITLE
Fix transition_line_id in macro_atom

### DIFF
--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -854,7 +854,8 @@ class AtomData(object):
         lvl_energy_lower = levels.rename(columns={"energy": "energy_lower"}).loc[:, ["energy_lower"]]
         lvl_energy_upper = levels.rename(columns={"energy": "energy_upper"}).loc[:, ["energy_upper"]]
 
-        lines = self.lines.join(lvl_energy_lower, on="lower_level_id").join(lvl_energy_upper, on="upper_level_id")
+        lines = self.lines.set_index("line_id")
+        lines = lines.join(lvl_energy_lower, on="lower_level_id").join(lvl_energy_upper, on="upper_level_id")
 
         macro_atom = list()
         macro_atom_dtype = [("atomic_number", np.int), ("ion_number", np.int),


### PR DESCRIPTION
This PR sets `line_id` as the index of `lines` before creating `macro_atom`. 
The `line_id` is no longer an index of `lines` so it has to be setted to get 
the id as index in `lines.iterrows()`.