### PR TITLE
Select atomic masses and ionization energies based on the ions parameter.

### DIFF
--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -131,16 +131,13 @@ class AtomData(object):
 
     def __init__(self, session, ions, chianti_ions=None,
                  kurucz_short_name="ku_latest", chianti_short_name="chianti_v8.0.2", nist_short_name="nist-asd",
-                 atom_masses_max_atomic_number=30, lines_loggf_threshold=-3, levels_metastable_loggf_threshold=-3,
+                 lines_loggf_threshold=-3, levels_metastable_loggf_threshold=-3,
                  collisions_temperatures=None,
                  zeta_datafile=ZETA_DATAFILE):
 
         self.session = session
 
-        # Set the parameters for the dataframes
-        self.atom_masses_param = {
-            "max_atomic_number": atom_masses_max_atomic_number
-        }
+        # Set the parameters for the dataframes}
 
         self.levels_lines_param = {
             "levels_metastable_loggf_threshold": levels_metastable_loggf_threshold,
@@ -258,7 +255,7 @@ class AtomData(object):
     @property
     def atom_masses(self):
         if self._atom_masses is None:
-            self._atom_masses = self.create_atom_masses(**self.atom_masses_param)
+            self._atom_masses = self.create_atom_masses()
         return self._atom_masses
 
     def create_atom_masses(self, max_atomic_number=30):
@@ -279,7 +276,6 @@ class AtomData(object):
                 columns: atom_masses, symbol, name, mass[u].
         """
         atom_masses_q = self.session.query(Atom). \
-            filter(Atom.atomic_number <= max_atomic_number).\
             order_by(Atom.atomic_number)
 
         atom_masses = list()

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -331,6 +331,9 @@ class AtomData(object):
                 columns: atomic_number, ion_number, ionization_energy[eV]
         """
         ionization_energies_q = self.session.query(Ion).\
+            join(self.ions_table,
+                 and_(Ion.atomic_number == self.ions_table.c.atomic_number,
+                      Ion.ion_charge == self.ions_table.c.ion_charge)).\
             order_by(Ion.atomic_number, Ion.ion_charge)
 
         ionization_energies = list()

--- a/carsus/io/output/tardis_op.py
+++ b/carsus/io/output/tardis_op.py
@@ -82,6 +82,7 @@ class AtomData(object):
     chianti_ions: list of tuples (atomic_number, ion_charge)
 
     ions_sel: sqlalchemy.sql.schema.Table
+    atoms_sel: sqlalchemy.sql.selectable.Alias
     chianti_ions_sel: sqlalchemy.sql.schema.Table
 
     ku_ds: carsus.model.atomic.DataSource instance

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -161,6 +161,11 @@ def test_create_atom_masses(atom_masses, atomic_number, exp_mass):
     )
 
 
+def test_create_atom_masses_distinct_atomic_numbers(test_session):
+    atom_data = AtomData(test_session, ions=["He II",  "N VI", "Si II", "Si III"])
+    assert atom_data.atom_masses["atomic_number"].values.tolist() == [2, 7, 14]
+
+
 @with_test_db
 @pytest.mark.parametrize("atomic_number, ion_number, exp_ioniz_energy", [
     (2, 1,  54.41776311 * u.eV),

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -162,13 +162,6 @@ def test_create_atom_masses(atom_masses, atomic_number, exp_mass):
 
 
 @with_test_db
-def test_create_atom_masses_max_atomic_number(test_session):
-    atom_data = AtomData(test_session, ions=[], atom_masses_max_atomic_number=15)
-    atom_masses = atom_data.atom_masses
-    assert atom_masses["atomic_number"].max() == 15
-
-
-@with_test_db
 @pytest.mark.parametrize("atomic_number, ion_number, exp_ioniz_energy", [
     (2, 1,  54.41776311 * u.eV),
     (4, 2, 153.896198 * u.eV),

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -108,7 +108,7 @@ def test_atom_data_chianti_ions_subset(memory_session):
 
 def test_atom_data_wo_chianti_ions_attributes(atom_data_only_be2, test_session):
     assert atom_data_only_be2.chianti_ions == list()
-    assert test_session.query(atom_data_only_be2.chianti_ions_table).count() == 0
+    assert test_session.query(atom_data_only_be2.chianti_ions_sel).count() == 0
 
 
 def test_atom_data_wo_chianti_ions_levels(atom_data_only_be2):
@@ -120,10 +120,10 @@ def test_atom_data_wo_chianti_ions_levels(atom_data_only_be2):
 
 
 @with_test_db
-def test_atom_data_join_on_chianti_ions_table(test_session, atom_data):
-    chiatni_ions_q = test_session.query(Ion).join(atom_data.chianti_ions_table,
-                                     and_(Ion.atomic_number == atom_data.chianti_ions_table.c.atomic_number,
-                                          Ion.ion_charge == atom_data.chianti_ions_table.c.ion_charge)).\
+def test_atom_data_join_on_chianti_ions_sel(test_session, atom_data):
+    chiatni_ions_q = test_session.query(Ion).join(atom_data.chianti_ions_sel,
+                                     and_(Ion.atomic_number == atom_data.chianti_ions_sel.c.atomic_number,
+                                          Ion.ion_charge == atom_data.chianti_ions_sel.c.ion_charge)).\
         order_by(Ion.atomic_number, Ion.ion_charge)
     chianti_ions = [(ion.atomic_number, ion.ion_charge) for ion in chiatni_ions_q]
     assert set(chianti_ions) == set([(2,1), (7,5)])
@@ -138,10 +138,10 @@ def test_atom_data_two_instances_same_session(test_session):
     atom_data2 = AtomData(test_session,
                          ions=["He II", "Be III", "B IV", "N VI", "Zn XX"],
                          chianti_ions=["He II", "N VI"])
-    atom_data1.ions_table
-    atom_data2.ions_table
-    atom_data1.chianti_ions_table
-    atom_data2.chianti_ions_table
+    atom_data1.ions_sel
+    atom_data2.ions_sel
+    atom_data1.chianti_ions_sel
+    atom_data2.chianti_ions_sel
 
 
 @with_test_db


### PR DESCRIPTION
The most important parameter of `AtomData` in Carsus is `ions`: it is a list of species str, e.g. `["He II", "Be III", "B IV", "N VI", "Si II", "Zn XX"]` for which the data will be stored in the hdf file. In simple words that is the ions you want to have in the resulting dataframes.

This PR ensures that atomic masses and ionization energies are stored only for `ions`:
- for ionization energies a join is made to `ions_sel`
- for atom masses a join is made to `atoms_sel`

`atoms_sel` is a selectable that contains distinct atomic numbers from the `ions` parameter. Same as `ions_sel` it is implemented as a property.

Lastly, this PR renames `atoms_table`, `chianti_ions_table`, `atoms_table` to `atoms_sel`, `chianti_ions_sel`, `atoms_sel` because these names are more succinct.