### PR TITLE
Ditch the "_df" ending in names

### DIFF
--- a/carsus/io/base.py
+++ b/carsus/io/base.py
@@ -16,13 +16,13 @@ class BaseParser(object):
 
     Attributes
     ----------
-    base_df : pandas.DataFrame
+    base : pandas.DataFrame
         Contains parsed results from the provided input data.
 
     Methods
     -------
     load(input_data)
-        Parses the input data and stores the results in the `base_df` attribute
+        Parses the input data and stores the results in the `base` attribute
 
     __call__(input_data)
         Call an instance with input data to invoke the `load` method.
@@ -31,7 +31,7 @@ class BaseParser(object):
     __metaclass__ = ABCMeta
 
     def __init__(self, input_data=None):
-        self.base_df = pd.DataFrame()
+        self.base = pd.DataFrame()
         if input_data is not None:
             self.load(input_data)
 
@@ -49,26 +49,26 @@ class BasePyparser(BaseParser):
 
     Attributes
     ----------
-    base_df : pandas.DataFrame
+    base : pandas.DataFrame
         Contains parsed results from the provided input data.
 
     grammar : pyparsing.ParseElement
         The grammar used to parse input.
-        Its labeled tokens correspond to the columns of the `base_df`
+        Its labeled tokens correspond to the columns of the `base`
 
     columns : list of str
-        The column names of the `base_df`
+        The column names of the `base`
 
     Methods
     -------
     load(input_data)
-        Parses the input data and stores the results in the `base_df` attribute
+        Parses the input data and stores the results in the `base` attribute
 
     Notes
     -----
     Rationale: pyparsers have a specific load workflow illustrated below.
 
-    Suppose a `base_df` of some parser has three columns::
+    Suppose a `base` of some parser has three columns::
 
         atomic_mass_nominal_value | atomic_mass_std_dev | notes
 
@@ -81,7 +81,7 @@ class BasePyparser(BaseParser):
             - std_dev: 2.1e-07
 
     The `load` method then infers the columns' values from
-    the nested labels and adds the following row to the `base_df`::
+    the nested labels and adds the following row to the `base`::
 
         atomic_mass_nominal_value            37.9627
         atomic_mass_std_dev                  2.1e-07
@@ -97,11 +97,11 @@ class BasePyparser(BaseParser):
 
     def load(self, input_data):
         results = self.grammar.scanString(input_data)
-        base_df_data = list()  # list of dicts that will be passed to the base_df
+        base = list()  # list of dicts that will be passed to the base
         for tokens, start, end in results:
             tokens_dict = to_flat_dict(tokens)  # make a flattened dict with the column names as keys
-            base_df_data.append(tokens_dict)
-        self.base_df = pd.DataFrame(data=base_df_data, columns=self.columns)
+            base.append(tokens_dict)
+        self.base = pd.DataFrame(data=base, columns=self.columns)
 
 
 

--- a/carsus/io/chianti_io.py
+++ b/carsus/io/chianti_io.py
@@ -147,8 +147,8 @@ class ChiantiIonReader(object):
 
     @property
     def bound_collisions(self):
-        bound_collision = self.filter_bound_transitions(self.collisions)
-        return bound_collision
+        bound_collisions = self.filter_bound_transitions(self.collisions)
+        return bound_collisions
 
     def _read_levels(self):
 

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -241,7 +241,7 @@ class GFALLReader(object):
 
     def extract_lines(self, gfall=None, levels=None, selected_columns=None):
         """
-        Extract lines from `gfall_df`
+        Extract lines from `gfall`
 
         Parameters
         ----------

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -121,22 +121,21 @@ class GFALLReader(object):
 
         return gfall
 
-    def parse_gfall(self, gfall=None):
+    def parse_gfall(self, gfall_raw=None):
         """
         Parse raw gfall DataFrame
 
         Parameters
         ----------
-        gfall: pandas.DataFrame
+        gfall_raw: pandas.DataFrame
 
         Returns
         -------
             pandas.DataFrame
                 a level DataFrame
         """
-        if gfall is None:
-            gfall = self.gfall_raw.copy()
-
+        gfall = gfall_raw if gfall_raw is not None else self.gfall_raw.copy()
+        
         double_columns = [item.replace('_first', '') for item in gfall.columns if
                           item.endswith('first')]
 

--- a/carsus/io/tests/test_base.py
+++ b/carsus/io/tests/test_base.py
@@ -15,11 +15,11 @@ from carsus.io.nist.weightscomp_grammar import AW_SD_COL, AW_VAL_COL
 ])
 def test_pyparser_load(test_input, expected, aw_pyparser):
     aw_pyparser.load(test_input)
-    assert_frame_equal(aw_pyparser.base_df,
+    assert_frame_equal(aw_pyparser.base,
         pd.DataFrame(data=expected, columns=[AW_VAL_COL, AW_SD_COL]), check_names=False)
 
 
 def test_pyparser_callable(aw_pyparser):
     aw_pyparser(input_data="atomic_weight = 6.8083492038(23)")
-    assert aw_pyparser.base_df.loc[0, AW_VAL_COL] == "6.8083492038"
-    assert aw_pyparser.base_df.loc[0, AW_SD_COL] == "23"
+    assert aw_pyparser.base.loc[0, AW_VAL_COL] == "6.8083492038"
+    assert aw_pyparser.base.loc[0, AW_SD_COL] == "23"

--- a/carsus/io/tests/test_chianti_io.py
+++ b/carsus/io/tests/test_chianti_io.py
@@ -23,17 +23,17 @@ def ch_ingester(memory_session):
 
 
 @pytest.mark.parametrize("ion_name", ["ne_2", "n_5"])
-def test_chianti_bound_levels_df(ion_name):
+def test_chianti_bound_levels(ion_name):
     ion_rdr = ChiantiIonReader(ion_name)
-    bound_levels_df = ion_rdr.bound_levels.reset_index()
-    assert bound_levels_df["level_index"].max() <= ion_rdr.last_bound_level
+    bound_levels = ion_rdr.bound_levels.reset_index()
+    assert bound_levels["level_index"].max() <= ion_rdr.last_bound_level
 
 
 @pytest.mark.parametrize("ion_name", ["ne_2", "n_5"])
-def test_chianti_bound_lines_df(ion_name):
+def test_chianti_bound_lines(ion_name):
     ion_rdr = ChiantiIonReader(ion_name)
-    bound_lines_df = ion_rdr.bound_lines.reset_index()
-    assert bound_lines_df["upper_level_index"].max() <= ion_rdr.last_bound_level
+    bound_lines = ion_rdr.bound_lines.reset_index()
+    assert bound_lines["upper_level_index"].max() <= ion_rdr.last_bound_level
 
 
 @pytest.mark.parametrize("level_index, energy, energy_theoretical",[

--- a/carsus/io/tests/test_chianti_io.py
+++ b/carsus/io/tests/test_chianti_io.py
@@ -25,14 +25,14 @@ def ch_ingester(memory_session):
 @pytest.mark.parametrize("ion_name", ["ne_2", "n_5"])
 def test_chianti_bound_levels_df(ion_name):
     ion_rdr = ChiantiIonReader(ion_name)
-    bound_levels_df = ion_rdr.bound_levels_df.reset_index()
+    bound_levels_df = ion_rdr.bound_levels.reset_index()
     assert bound_levels_df["level_index"].max() <= ion_rdr.last_bound_level
 
 
 @pytest.mark.parametrize("ion_name", ["ne_2", "n_5"])
 def test_chianti_bound_lines_df(ion_name):
     ion_rdr = ChiantiIonReader(ion_name)
-    bound_lines_df = ion_rdr.bound_lines_df.reset_index()
+    bound_lines_df = ion_rdr.bound_lines.reset_index()
     assert bound_lines_df["upper_level_index"].max() <= ion_rdr.last_bound_level
 
 
@@ -41,7 +41,7 @@ def test_chianti_bound_lines_df(ion_name):
     (21, 252953.5, 252954),
 ])
 def test_chianti_reader_read_levels(ch_ion_reader, level_index, energy, energy_theoretical):
-    row = ch_ion_reader.levels_df.loc[level_index]
+    row = ch_ion_reader.levels.loc[level_index]
     assert_almost_equal(row['energy'], energy)
     assert_almost_equal(row['energy_theoretical'], energy_theoretical)
 

--- a/carsus/io/tests/test_gfall.py
+++ b/carsus/io/tests/test_gfall.py
@@ -16,22 +16,22 @@ def gfall_rdr(gfall_fname):
 
 
 @pytest.fixture()
-def gfall_raw_df(gfall_rdr):
+def gfall_raw(gfall_rdr):
     return gfall_rdr.gfall_raw
 
 
 @pytest.fixture()
-def gfall_df(gfall_rdr):
-    return gfall_rdr.gfall_df
+def gfall(gfall_rdr):
+    return gfall_rdr.gfall
 
 
 @pytest.fixture()
-def levels_df(gfall_rdr):
-    return gfall_rdr.levels_df
+def levels(gfall_rdr):
+    return gfall_rdr.levels
 
 @pytest.fixture()
-def lines_df(gfall_rdr):
-    return gfall_rdr.lines_df
+def lines(gfall_rdr):
+    return gfall_rdr.lines
 
 
 @pytest.fixture()
@@ -43,8 +43,8 @@ def gfall_ingester(memory_session, gfall_fname):
     (14, 72.5537, 4.02, 983355.0, 1121184.0),
     (37, 2.4898, 7.05, 0.0, 4016390.0)
 ])
-def test_grall_reader_gfall_raw_df(gfall_raw_df, index, wavelength, element_code, e_first, e_second):
-    row = gfall_raw_df.loc[index]
+def test_grall_reader_gfall_raw(gfall_raw, index, wavelength, element_code, e_first, e_second):
+    row = gfall_raw.loc[index]
     assert_almost_equal(row["element_code"], element_code)
     assert_almost_equal(row["wavelength"], wavelength)
     assert_allclose([row["e_first"], row["e_second"]], [e_first, e_second])
@@ -56,9 +56,9 @@ def test_grall_reader_gfall_raw_df(gfall_raw_df, index, wavelength, element_code
     (17, 74.6230, 4, 2, 997455.000, 1131462.0, False, False),
     (41, 16.1220, 7, 5, 3385890.000, 4006160.0, False, True)
 ])
-def test_gfall_reader_gfall_df(gfall_df, index, wavelength, atomic_number, ion_charge,
+def test_gfall_reader_gfall(gfall, index, wavelength, atomic_number, ion_charge,
                                e_lower, e_upper, e_lower_predicted, e_upper_predicted):
-    row = gfall_df.loc[index]
+    row = gfall.loc[index]
     assert row["atomic_number"] == atomic_number
     assert row["ion_charge"] == ion_charge
     assert_allclose([row["wavelength"], row["e_lower"], row["e_upper"]],
@@ -67,15 +67,15 @@ def test_gfall_reader_gfall_df(gfall_df, index, wavelength, atomic_number, ion_c
     assert row["e_upper_predicted"] == e_upper_predicted
 
 
-def test_gfall_reader_gfall_df_ignore_labels(gfall_df):
+def test_gfall_reader_gfall_ignore_labels(gfall):
     ignored_labels = ["AVERAGE", "ENERGIES", "CONTINUUM"]
-    assert len(gfall_df.loc[(gfall_df["label_lower"].isin(ignored_labels)) |
-                                  (gfall_df["label_upper"].isin(ignored_labels))]) == 0
+    assert len(gfall.loc[(gfall["label_lower"].isin(ignored_labels)) |
+                         (gfall["label_upper"].isin(ignored_labels))]) == 0
 
 
-def test_gfall_reader_clean_levels_labels(levels_df):
+def test_gfall_reader_clean_levels_labels(levels):
     # One label for the ground level of Be III has an extra space
-    levels0402 = levels_df.loc[(4,2)]
+    levels0402 = levels.loc[(4, 2)]
     assert len(levels0402.loc[(np.isclose(levels0402["energy"], 0.0))]) == 1
 
 
@@ -85,9 +85,9 @@ def test_gfall_reader_clean_levels_labels(levels_df):
     (4, 2, 11, 1128300.0, 2.0, "meas"),
     (7, 5, 7, 4006160.0, 0.0,  "theor")
 ])
-def test_gfall_reader_levels_df(levels_df, atomic_number, ion_charge, level_index,
-                                energy, j, method):
-    row = levels_df.loc[(atomic_number, ion_charge, level_index)]
+def test_gfall_reader_levels(levels, atomic_number, ion_charge, level_index,
+                             energy, j, method):
+    row = levels.loc[(atomic_number, ion_charge, level_index)]
     assert_almost_equal(row["energy"], energy)
     assert_almost_equal(row["j"], j)
     assert row["method"] == method
@@ -98,9 +98,9 @@ def test_gfall_reader_levels_df(levels_df, atomic_number, ion_charge, level_inde
     (4, 2, 0, 16, 8.8309, 0.12705741),
     (4, 2, 6, 15, 74.6230, 2.1330449131)
 ])
-def test_gfall_reader_lines_df(lines_df, atomic_number, ion_charge,
-                               level_index_lower, level_index_upper, wavelength, gf):
-    row = lines_df.loc[(atomic_number, ion_charge, level_index_lower, level_index_upper)]
+def test_gfall_reader_lines(lines, atomic_number, ion_charge,
+                            level_index_lower, level_index_upper, wavelength, gf):
+    row = lines.loc[(atomic_number, ion_charge, level_index_lower, level_index_upper)]
     assert_almost_equal(row["wavelength"], wavelength)
     assert_almost_equal(row["gf"], gf)
 

--- a/carsus/io/tests/test_ionization.py
+++ b/carsus/io/tests/test_ionization.py
@@ -60,13 +60,13 @@ def ioniz_energies_parser():
 
 
 @pytest.fixture
-def ioniz_energies_df(ioniz_energies_parser):
-    return ioniz_energies_parser.prepare_ioniz_energies_df()
+def ioniz_energies(ioniz_energies_parser):
+    return ioniz_energies_parser.prepare_ioniz_energies()
 
 
 @pytest.fixture
-def ground_levels_df(ioniz_energies_parser):
-    return ioniz_energies_parser.prepare_ground_levels_df()
+def ground_levels(ioniz_energies_parser):
+    return ioniz_energies_parser.prepare_ground_levels()
 
 
 @pytest.fixture
@@ -93,18 +93,18 @@ def expected_series_ground_levels(request):
     return pd.Series(data=data, name=name, index=index)
 
 
-def test_prepare_ioniz_energies_df_null_values(ioniz_energies_df):
-    assert all(pd.notnull(ioniz_energies_df["ionization_energy_value"]))
+def test_prepare_ioniz_energies_null_values(ioniz_energies):
+    assert all(pd.notnull(ioniz_energies["ionization_energy_value"]))
 
 
-def test_prepare_ioniz_energies_df(ioniz_energies_df, expected_series_ioniz_energies):
-    series = ioniz_energies_df[expected_series_ioniz_energies.name]
+def test_prepare_ioniz_energies(ioniz_energies, expected_series_ioniz_energies):
+    series = ioniz_energies[expected_series_ioniz_energies.name]
     assert_series_equal(series, expected_series_ioniz_energies)
 
 
 
-def test_prepare_ground_levels_df(ground_levels_df, expected_series_ground_levels):
-    series = ground_levels_df[expected_series_ground_levels.name]
+def test_prepare_ground_levels(ground_levels, expected_series_ground_levels):
+    series = ground_levels[expected_series_ground_levels.name]
     assert_series_equal(series, expected_series_ground_levels)
 
 

--- a/carsus/io/tests/test_nist_weightscomp.py
+++ b/carsus/io/tests/test_nist_weightscomp.py
@@ -91,7 +91,7 @@ def test_weightscomp_pyparser_prepare_atomic_index(atomic):
     assert atomic.index.name == ATOM_NUM_COL
 
 
-def test_weightscomp_pyparser_prepare_atomic_df_(atomic, expected):
+def test_weightscomp_pyparser_prepare_atomic(atomic, expected):
     assert_frame_equal(atomic, expected, check_names=False)
 
 

--- a/carsus/io/tests/test_nist_weightscomp.py
+++ b/carsus/io/tests/test_nist_weightscomp.py
@@ -67,12 +67,12 @@ def weightscomp_pyparser():
     return NISTWeightsCompPyparser(input_data=test_input)
 
 @pytest.fixture
-def atomic_df(weightscomp_pyparser):
+def atomic(weightscomp_pyparser):
     return weightscomp_pyparser.prepare_atomic_dataframe()
 
 
 @pytest.fixture
-def expected_df():
+def expected():
     return pd.DataFrame(data=expected_dict, columns=[ATOM_NUM_COL, AW_VAL_COL, AW_SD_COL]).set_index(ATOM_NUM_COL)
 
 
@@ -83,16 +83,16 @@ def weightscomp_ingester(memory_session):
     return ingester
 
 
-def test_weightscomp_pyparser_base_df_index(weightscomp_pyparser):
-    assert weightscomp_pyparser.base_df.index.names == [ATOM_NUM_COL, MASS_NUM_COL]
+def test_weightscomp_pyparser_base_index(weightscomp_pyparser):
+    assert weightscomp_pyparser.base.index.names == [ATOM_NUM_COL, MASS_NUM_COL]
 
 
-def test_weightscomp_pyparser_prepare_atomic_df_index(atomic_df):
-    assert atomic_df.index.name == ATOM_NUM_COL
+def test_weightscomp_pyparser_prepare_atomic_index(atomic):
+    assert atomic.index.name == ATOM_NUM_COL
 
 
-def test_weightscomp_pyparser_prepare_atomic_df_(atomic_df, expected_df):
-    assert_frame_equal(atomic_df, expected_df, check_names=False)
+def test_weightscomp_pyparser_prepare_atomic_df_(atomic, expected):
+    assert_frame_equal(atomic, expected, check_names=False)
 
 
 @pytest.mark.parametrize("atomic_number, value, uncert", expected_tuples)

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -300,17 +300,17 @@ def test_levels_create_artificial_fully_ionized(levels, atomic_number):
 
 # ToDo: Implement real tests
 @with_test_db
-def test_create_collisions_df(collisions):
+def test_create_collisions(collisions):
     assert True
 
 
 @with_test_db
-def test_create_macro_atom_df(macro_atom):
+def test_create_macro_atom(macro_atom):
     assert True
 
 
 @with_test_db
-def test_create_macro_atom_ref_df(macro_atom_references):
+def test_create_macro_atom_ref(macro_atom_references):
     assert True
 
 


### PR DESCRIPTION
This PR removes the "_df" ending from all the attribute and variable names in Carsus. 