### PR TITLE
Replace url with file name in init_db

### DIFF
--- a/carsus/base.py
+++ b/carsus/base.py
@@ -8,15 +8,16 @@ basic_atomic_data_fname = os.path.join(carsus.__path__[0], 'data',
                                        'basic_atomic_data.csv')
 
 
-def init_db(url, **kwargs):
+def init_db(fname=None, **kwargs):
     """
     Initializes the database.
     If the database is empty ingests basic atomic data (atomic numbers, symbols, etc.)
 
     Parameters
     ----------
-    url : str
-        The database url
+    fname : str
+        Path to the database file. If set to None create memory session.
+        (default: None)
 
     kwargs
         Additional keyword arguments that can be passed to the `create_engine` function (e.g. echo=True)
@@ -27,6 +28,8 @@ def init_db(url, **kwargs):
 
     """
     print "Initializing the database"
+
+    url = "sqlite:////" + fname if fname is not None else "sqlite://"
     session = setup(url, **kwargs)
 
     if session.query(Atom).count() == 0:

--- a/carsus/conftest.py
+++ b/carsus/conftest.py
@@ -52,7 +52,7 @@ def pytest_addoption(parser):
 
 @pytest.fixture
 def memory_session():
-    session = init_db(url="sqlite://")
+    session = init_db()
     session.commit()
     return session
 

--- a/carsus/tests/create_test_db.py
+++ b/carsus/tests/create_test_db.py
@@ -25,9 +25,8 @@ def create_test_db(test_db_fname=TEST_DB_FNAME, gfall_fname=GFALL_FNAME):
 
     test_db_f = open(test_db_fname, "w")
     test_db_f.close()
-    test_db_url = "sqlite:///" + test_db_fname
 
-    session = init_db(url=test_db_url)
+    session = init_db(test_db_fname)
     session.commit()
 
     # Ingest atomic weights


### PR DESCRIPTION
This PR replaces the `url` argument with more convenient `fname`. Because only SQLite is used at the moment, there is no need to type `init_db("sqlite:////" + fname)` every time. You can just do `init_db(fname)` and to create a memory session invoke it without arguments `init_db()`.  