### PR TITLE
Changes in NISTIonizationEnergiesIngester

### DIFF
--- a/carsus/io/base.py
+++ b/carsus/io/base.py
@@ -31,7 +31,7 @@ class BaseParser(object):
     __metaclass__ = ABCMeta
 
     def __init__(self, input_data=None):
-        self.base = pd.DataFrame()
+        self.base = None
         if input_data is not None:
             self.load(input_data)
 

--- a/carsus/io/nist/ionization.py
+++ b/carsus/io/nist/ionization.py
@@ -192,10 +192,12 @@ class NISTIonizationEnergiesIngester(BaseIngester):
         data = self.downloader(spectra=self.spectra)
         self.parser(data)
 
-    def ingest_ionization_energies(self):
-        print("Ingesting ionization energies from {}".format(self.data_source.short_name))
+    def ingest_ionization_energies(self, ioniz_energies=None):
 
-        ioniz_energies = self.parser.prepare_ioniz_energies()
+        if ioniz_energies is None:
+            ioniz_energies = self.parser.prepare_ioniz_energies()
+
+        print("Ingesting ionization energies from {}".format(self.data_source.short_name))
 
         for index, row in ioniz_energies.iterrows():
             atomic_number, ion_charge = index
@@ -212,10 +214,12 @@ class NISTIonizationEnergiesIngester(BaseIngester):
             # No need to add ion to the session, because
             # that was done in `as_unique`
 
-    def ingest_ground_levels(self):
-        print("Ingesting ground levels from {}".format(self.data_source.short_name))
+    def ingest_ground_levels(self, ground_levels=None):
 
-        ground_levels = self.parser.prepare_ground_levels()
+        if ground_levels is None:
+            ground_levels = self.parser.prepare_ground_levels()
+
+        print("Ingesting ground levels from {}".format(self.data_source.short_name))
 
         for index, row in ground_levels.iterrows():
             atomic_number, ion_charge = index

--- a/carsus/io/nist/ionization.py
+++ b/carsus/io/nist/ionization.py
@@ -258,8 +258,6 @@ class NISTIonizationEnergiesIngester(BaseIngester):
         if self.parser.base is None:
             self.download()
 
-        print("Ingesting data from {}".format(self.data_source.short_name))
-
         if ionization_energies:
             self.ingest_ionization_energies()
 

--- a/carsus/io/nist/ionization.py
+++ b/carsus/io/nist/ionization.py
@@ -254,6 +254,10 @@ class NISTIonizationEnergiesIngester(BaseIngester):
 
     def ingest(self, ionization_energies=True, ground_levels=True):
 
+        # Download data if needed
+        if self.parser.base is None:
+            self.download()
+
         print("Ingesting data from {}".format(self.data_source.short_name))
 
         if ionization_energies:

--- a/carsus/io/nist/ionization.py
+++ b/carsus/io/nist/ionization.py
@@ -260,6 +260,8 @@ class NISTIonizationEnergiesIngester(BaseIngester):
 
         if ionization_energies:
             self.ingest_ionization_energies()
+            self.session.flush()
 
         if ground_levels:
             self.ingest_ground_levels()
+            self.session.flush()

--- a/carsus/io/nist/ionization.py
+++ b/carsus/io/nist/ionization.py
@@ -40,7 +40,7 @@ def download_ionization_energies(spectra='h-uuh', e_out=0, e_unit=1, format_=1, 
 
     data = {k: v for k, v in data.iteritems() if v is not False}
 
-    print "Downloading ionization energies data from http://physics.nist.gov/PhysRefData/ASD/ionEnergy.html"
+    print "Downloading ionization energies from the NIST Atomic Spectra Database"
     r = requests.post(IONIZATION_ENERGIES_URL, data=data)
     return r.text
 

--- a/carsus/io/nist/ionization.py
+++ b/carsus/io/nist/ionization.py
@@ -168,6 +168,8 @@ class NISTIonizationEnergiesIngester(BaseIngester):
 
         downloader : function
             (default value = download_ionization_energies)
+        spectra: str
+            (default value = 'h-uuh')
 
         Methods
         -------
@@ -177,16 +179,17 @@ class NISTIonizationEnergiesIngester(BaseIngester):
             Persists the downloaded data into the database
         """
 
-    def __init__(self, session, ds_short_name="nist-asd", downloader=None, parser=None):
+    def __init__(self, session, ds_short_name="nist-asd", downloader=None, parser=None, spectra="h-uuh"):
         if parser is None:
             parser = NISTIonizationEnergiesParser()
         if downloader is None:
             downloader = download_ionization_energies
+        self.spectra = spectra
         super(NISTIonizationEnergiesIngester, self). \
             __init__(session, ds_short_name=ds_short_name, parser=parser, downloader=downloader)
 
-    def download(self, spectra='h-uuh'):
-        data = self.downloader(spectra=spectra)
+    def download(self):
+        data = self.downloader(spectra=self.spectra)
         self.parser(data)
 
     def ingest_ionization_energies(self):

--- a/carsus/io/tests/test_ionization.py
+++ b/carsus/io/tests/test_ionization.py
@@ -136,6 +136,5 @@ def test_ingest_ground_levels(index, exp_j, memory_session, ioniz_energies_inges
 
 @pytest.mark.remote_data
 def test_ingest_nist_asd_ion_data(memory_session):
-    ingester = NISTIonizationEnergiesIngester(memory_session)
-    ingester.download('h-uuh')
+    ingester = NISTIonizationEnergiesIngester(memory_session, spectra="h-uuh")
     ingester.ingest(ionization_energies=True, ground_levels=True)


### PR DESCRIPTION
This PR:
- sets the `base`attribute no `None` instead of empty DataFrame in `BaseIngester`
- adds the `spectra` argument to `NISTIonizationEnergiesIngester`
- downloads data before ingesting

The purpose of the PR is to download data before ingesting automatically. That is, instead of doing this:
```
    ioniz_energies_ingester = NISTIonizationEnergiesIngester(session)
    ioniz_energies_ingester.download(spectra="h-zn")
    ioniz_energies_ingester.ingest(ionization_energies=True, ground_levels=True)
    session.commit()
```
the user can just do:
```
    ioniz_energies_ingester = NISTIonizationEnergiesIngester(session, spectra="h-zn")
    ioniz_energies_ingester.ingest(ionization_energies=True, ground_levels=True)
    session.commit()
```
This follows the general pattern of downloading and ingesting data in Carsus.