### PR TITLE
Changes in the wheightscomp module

### DIFF
--- a/carsus/io/base.py
+++ b/carsus/io/base.py
@@ -32,7 +32,7 @@ class BaseParser(object):
     __metaclass__ = ABCMeta
 
     def __init__(self, input_data=None):
-        self.base = pd.DataFrame()
+        self.base = None
         if input_data is not None:
             self.load(input_data)
 

--- a/carsus/io/nist/weightscomp.py
+++ b/carsus/io/nist/weightscomp.py
@@ -42,7 +42,7 @@ def download_weightscomp(ascii='ascii', isotype='some'):
         Preformatted text data
 
     """
-    print "Downloading the data from {}".format(WEIGHTSCOMP_URL)
+    print "Downloading data from the NIST Atomic Weights and Isotopic Compositions database."
     r = requests.get(WEIGHTSCOMP_URL, params={'ascii': ascii, 'isotype': isotype})
     soup = BeautifulSoup(r.text, 'html5lib')
     pre_text_data = soup.pre.get_text()

--- a/carsus/io/nist/weightscomp.py
+++ b/carsus/io/nist/weightscomp.py
@@ -183,3 +183,4 @@ class NISTWeightsCompIngester(BaseIngester):
         if atomic_weights:
             self.ingest_atomic_weights()
             self.session.flush()
+            

--- a/carsus/io/nist/weightscomp.py
+++ b/carsus/io/nist/weightscomp.py
@@ -21,7 +21,7 @@ DEFAULT_PARAMS = {'ascii': 'ascii2', 'isotype': 'some'}
 NIST = "nist"
 
 
-def download_weightscomp(url=WEIGHTSCOMP_URL, params=DEFAULT_PARAMS):
+def download_weightscomp(params=DEFAULT_PARAMS):
     """
     Downloader function for the NIST Atomic Weights and Isotopic Compositions database
 
@@ -29,9 +29,6 @@ def download_weightscomp(url=WEIGHTSCOMP_URL, params=DEFAULT_PARAMS):
 
     Parameters
     ----------
-    url : str
-        The request url, (default="http://physics.nist.gov/cgi-bin/Compositions/stand_alone.pl")
-
     params : dict
         The GET request parameters (default={'ascii':'ascii2', 'isotype': 'some'})
 
@@ -41,7 +38,7 @@ def download_weightscomp(url=WEIGHTSCOMP_URL, params=DEFAULT_PARAMS):
         Preformatted text data
 
     """
-    print "Downloading the data from {}".format(url)
+    print "Downloading the data from {}".format(WEIGHTSCOMP_URL)
     r = requests.get(url, params=params)
     soup = BeautifulSoup(r.text, 'html5lib')
     pre_text_data = soup.pre.get_text()

--- a/carsus/io/nist/weightscomp.py
+++ b/carsus/io/nist/weightscomp.py
@@ -179,6 +179,9 @@ class NISTWeightsCompIngester(BaseIngester):
     def ingest(self, atomic_weights=True):
         """ *Only* ingests atomic weights *for now* """
 
+        if self.parser.base is None:
+            self.download()
+
         if atomic_weights:
             self.ingest_atomic_weights()
             self.session.flush()

--- a/carsus/io/nist/weightscomp.py
+++ b/carsus/io/nist/weightscomp.py
@@ -17,11 +17,9 @@ from carsus.io.nist.weightscomp_grammar import isotope, COLUMNS, ATOM_NUM_COL, M
 
 
 WEIGHTSCOMP_URL = "http://physics.nist.gov/cgi-bin/Compositions/stand_alone.pl"
-DEFAULT_PARAMS = {'ascii': 'ascii2', 'isotype': 'some'}
-NIST = "nist"
 
 
-def download_weightscomp(ascii='ascii', isotype='some'):
+def download_weightscomp(ascii='ascii2', isotype='some'):
     """
     Downloader function for the NIST Atomic Weights and Isotopic Compositions database
 

--- a/carsus/io/nist/weightscomp.py
+++ b/carsus/io/nist/weightscomp.py
@@ -21,7 +21,7 @@ DEFAULT_PARAMS = {'ascii': 'ascii2', 'isotype': 'some'}
 NIST = "nist"
 
 
-def download_weightscomp(params=DEFAULT_PARAMS):
+def download_weightscomp(ascii='ascii', isotype='some'):
     """
     Downloader function for the NIST Atomic Weights and Isotopic Compositions database
 
@@ -29,8 +29,12 @@ def download_weightscomp(params=DEFAULT_PARAMS):
 
     Parameters
     ----------
-    params : dict
-        The GET request parameters (default={'ascii':'ascii2', 'isotype': 'some'})
+    ascii: str
+        GET request parameter, refer to the NIST docs
+        (default: 'ascii')
+    isotype: str
+        GET request parameter, refer to the NIST docs
+        (default: 'some')
 
     Returns
     -------
@@ -39,7 +43,7 @@ def download_weightscomp(params=DEFAULT_PARAMS):
 
     """
     print "Downloading the data from {}".format(WEIGHTSCOMP_URL)
-    r = requests.get(url, params=params)
+    r = requests.get(WEIGHTSCOMP_URL, params={'ascii': ascii, 'isotype': isotype})
     soup = BeautifulSoup(r.text, 'html5lib')
     pre_text_data = soup.pre.get_text()
     pre_text_data = pre_text_data.replace(u'\xa0', u' ')  # replace non-breaking spaces with spaces

--- a/carsus/io/tests/test_nist_weightscomp.py
+++ b/carsus/io/tests/test_nist_weightscomp.py
@@ -106,7 +106,8 @@ def test_weightscomp_ingest_nonexisting_atomic_weights(atomic_number, value, unc
 
 
 @pytest.mark.remote_data
-def test_weightscomp_ingest_default_count(weightscomp_ingester, memory_session):
-    weightscomp_ingester.ingest()
+def test_weightscomp_ingest_default_count(memory_session):
+    weightscomp_ingester = NISTWeightsCompIngester(memory_session)
+    weightscomp_ingester.ingest(atomic_weights=True)
     assert memory_session.query(AtomWeight).\
                filter(AtomWeight.data_source==weightscomp_ingester.data_source).count() == 94

--- a/carsus/io/tests/test_nist_weightscomp.py
+++ b/carsus/io/tests/test_nist_weightscomp.py
@@ -107,7 +107,6 @@ def test_weightscomp_ingest_nonexisting_atomic_weights(atomic_number, value, unc
 
 @pytest.mark.remote_data
 def test_weightscomp_ingest_default_count(weightscomp_ingester, memory_session):
-    weightscomp_ingester.download()
     weightscomp_ingester.ingest()
     assert memory_session.query(AtomWeight).\
                filter(AtomWeight.data_source==weightscomp_ingester.data_source).count() == 94


### PR DESCRIPTION
This PR is similar to https://github.com/tardis-sn/carsus/pull/83 
Changes in `NISTWeightscompIngester`:
 - the `ingest_atomic_weights` method is created
- data is downloaded automatically if needed before the ingesting

Changes in `download_weightscomp`:
- `url` is removed from arguments
- the `params` dict is "unpacked"
