### PR TITLE
Add `selected_atoms` parameter to `AtomData`

### DIFF
--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -157,13 +157,6 @@ def test_create_atom_masses(atom_masses, atomic_number, exp_mass):
 
 
 @with_test_db
-def test_create_atom_masses_max_atomic_number(test_session):
-    atom_data = AtomData(test_session, selected_atoms="He, Be, B, N, Zn", atom_masses_max_atomic_number=15)
-    atom_masses = atom_data.atom_masses
-    assert atom_masses["atomic_number"].max() == 15
-
-
-@with_test_db
 @pytest.mark.parametrize("atomic_number, ion_number, exp_ioniz_energy", [
     (2, 1,  54.41776311 * u.eV),
     (4, 2, 153.896198 * u.eV),

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -24,7 +24,7 @@ def atom_data(test_session):
 
 
 @pytest.fixture
-def atom_data_only_be(test_session):
+def atom_data_be(test_session):
     atom_data = AtomData(test_session, selected_atoms="Be")
     return atom_data
 
@@ -105,15 +105,20 @@ def test_atom_data_chianti_ions_subset(memory_session):
                              chianti_ions=["He II", "N VI", "Si II"])
 
 
-def test_atom_data_wo_chianti_ions_attributes(atom_data_only_be, test_session):
-    assert atom_data_only_be.chianti_ions == list()
-    assert test_session.query(atom_data_only_be.chianti_ions_table).count() == 0
+def test_atom_data_wo_chianti_ions_attributes(atom_data_be, test_session):
+    assert atom_data_be.chianti_ions == list()
+    assert test_session.query(atom_data_be.chianti_ions_table).count() == 0
 
 
-def test_atom_data_wo_chianti_ions_levels(atom_data_only_be):
-    levels_be = atom_data_only_be.levels
-    atomic_numbers = levels_be["atomic_number"].values.tolist()
-    assert all([atomic_number == 4 for atomic_number in atomic_numbers])
+def test_atom_data_only_be(atom_data_be):
+    assert all([atomic_number == 4 for atomic_number in
+                atom_data_be.atom_masses["atomic_number"].values.tolist()])
+    assert all([atomic_number == 4 for atomic_number in
+                atom_data_be.ionization_energies["atomic_number"].values.tolist()])
+    assert all([atomic_number == 4 for atomic_number in
+                atom_data_be.levels["atomic_number"].values.tolist()])
+    assert all([atomic_number == 4 for atomic_number in
+                atom_data_be.lines["atomic_number"].values.tolist()])
 
 
 @with_test_db

--- a/carsus/tests/test_util.py
+++ b/carsus/tests/test_util.py
@@ -1,6 +1,7 @@
 import pytest
 
-from carsus.util import convert_camel2snake, atomic_number2symbol, symbol2atomic_number
+from carsus.util import convert_camel2snake, atomic_number2symbol, symbol2atomic_number,\
+    parse_selected_atoms
 
 
 @pytest.mark.parametrize("input_camel_case, expected_snake_case", [
@@ -30,3 +31,14 @@ def test_atomic_number2symbol(atomic_number, expected_symbol):
 ])
 def test_symbol2atomic_number(symbol, expected_atomic_number):
     assert symbol2atomic_number[symbol] == expected_atomic_number
+
+
+@pytest.mark.parametrize("selected_atoms, expected_list", [
+    ("H", [1]),
+    ("H-Li", [1, 2, 3]),
+    ("H, Be-B", [1, 4, 5]),
+    ("h, be-b", [1, 4, 5]),
+    (" h ,  be - b ", [1, 4, 5])
+])
+def test_parse_selected_atoms(selected_atoms, expected_list):
+    assert parse_selected_atoms(selected_atoms) == expected_list

--- a/carsus/util.py
+++ b/carsus/util.py
@@ -65,3 +65,62 @@ def convert_wavelength_air2vacuum(wavelength_air):
     fact = 1.0 + 5.792105e-2/(238.0185 - sigma2) + 1.67917e-3/(57.362 - sigma2)
 
     return wavelength_air * fact
+
+
+def parse_selected_atoms(selected_atoms):
+    """
+    Parse the sting specifying selected atoms to the list of atomic numbers.
+
+    Parameters
+    ----------
+    selected_atoms: str
+        Sting that specifies selected atoms. It should consist of comma-separated entries
+        that are either single atoms (e.g. "H") or ranges (indicated by using a hyphen between, e.g "H-Zn").
+        Element symbols need **not** to be capitalized.
+
+    Returns
+    -------
+    list of int
+        List of atomic numbers
+
+    Examples
+    --------
+
+    >>> parse_selected_atoms("H")
+    [1]
+
+    >>> parse_selected_atoms("H, Li-N")
+    [1, 3, 4, 5, 6, 7]
+
+    >>> parse_selected_atoms("H, Li-N, Si, S")
+    [1, 3, 4, 5, 6, 7, 14, 16]
+
+    """
+    selected_atomic_numbers = list()
+    selected_atoms = [_.strip() for _ in selected_atoms.split(',')]
+
+    for entry in selected_atoms:
+        # Case when `entry` is a single atom
+        if "-" not in entry:
+            entry = entry[:1].upper() + entry[1:].lower()
+            try:
+                entry_atomic_number = symbol2atomic_number[entry]
+            except:
+                raise ValueError
+            selected_atomic_numbers.append(entry_atomic_number)
+
+        # Case when `entry` is a range of atoms
+        else:
+            lower, upper = tuple(_.strip() for _ in entry.split('-'))
+            lower, upper = map(lambda _: _[:1].upper() + _[1:].lower(), [lower, upper])
+            try:
+                lower_atomic_number = symbol2atomic_number[lower]
+                upper_atomic_number = symbol2atomic_number[upper]
+            except:
+                raise ValueError
+            selected_atomic_numbers += range(lower_atomic_number, upper_atomic_number + 1)
+
+    # Get rid of duplicate numbers if any
+    selected_atomic_numbers = list(set(selected_atomic_numbers))
+
+    return selected_atomic_numbers


### PR DESCRIPTION
This PR introduces a new argument for `AtomData` - `selected_atoms`.  It defines which atoms are going to the output DataFrames. `selected_atoms` replaces the former `ions` argument that was used for the same purpose. 

`selected_atoms` is a string that should  consist of comma-separated entries that are either single atoms (e.g. "H") or ranges of atoms (indicated by using a hyphen between, e.g "H-Zn"). Element symbols need **not** to be capitalized. `selected_atoms` is parsed with a special function `parse_selected_atoms`:
```
>>> parse_selected_atoms("H")
[1]
 >>> parse_selected_atoms("H, Li-N")
[1, 3, 4, 5, 6, 7]
>>> parse_selected_atoms("H, Li-N, Si, S")
[1, 3, 4, 5, 6, 7, 14, 16]
```

The `ions_table` attribute (a temporary table that is used for filtering on ions)  of `AtomData` is removed. We don't need to create a temporary table for atoms because we can just do `filter(Level.atomic_number.in_(self.selected_atomic_numbers))`. We can't use `in_()` for filtering ions because then we would have to filter on both atomic number and ion number; that is we would have to use a composite IN statement, and SQLite doesn't support them. 

