### PR TITLE
Change create collisions

### DIFF
--- a/carsus/io/output/tardis_.py
+++ b/carsus/io/output/tardis_.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import hashlib
 import uuid
+import re
 
 from pandas import HDFStore
 from sqlalchemy import and_, case
@@ -792,12 +793,14 @@ class AtomData(object):
             collisions_prepared : pandas.DataFrame
                 DataFrame with:
                     index: atomic_number, ion_number, level_number_lower, level_number_upper;
-                    columns: e_col_id, delta_e, g_ratio, c_ul.
+                    columns: e_col_id, delta_e, g_ratio, [collision strengths].
         """
 
-        collisions_prepared = self.collisions.loc[:, ["atomic_number", "ion_number",
-                                                      "level_number_lower", "level_number_upper",
-                                                      "delta_e", "g_ratio", "c_ul"]].copy()
+        collisions_columns = ['atomic_number', 'ion_number', 'level_number_upper',
+                              'level_number_lower', 'g_ratio', 'delta_e'] + \
+                              sorted([col for col in self.collisions.columns if re.match('^t\d+$', col)])
+
+        collisions_prepared = self.collisions.loc[:, collisions_columns].copy()
 
         collisions_prepared = collisions_prepared.reset_index(drop=True)
 

--- a/carsus/io/output/tardis_.py
+++ b/carsus/io/output/tardis_.py
@@ -723,6 +723,9 @@ class AtomData(object):
         kb_ev = const.k_B.cgs.to('eV / K').value
         collisions["delta_e"] = (collisions["energy_upper"] - collisions["energy_lower"])/kb_ev
 
+        # Calculate g_ratio
+        collisions["g_ratio"] = collisions["g_l"] / collisions["g_u"]
+
         c_ul_temperature_cols = ['t{:06d}'.format(t) for t in temperatures]
 
         def calculate_collisional_strength(row, temperatures):
@@ -773,9 +776,6 @@ class AtomData(object):
 
         collisional_strengths = collisions.apply(calculate_collisional_strength, axis=1, args=(temperatures,))
         collisions = collisions.join(collisional_strengths)
-
-        # Calculate g_ratio
-        collisions["g_ratio"] = collisions["g_l"] / collisions["g_u"]
 
         return collisions
 

--- a/carsus/io/output/tardis_.py
+++ b/carsus/io/output/tardis_.py
@@ -726,6 +726,7 @@ class AtomData(object):
         # Calculate g_ratio
         collisions["g_ratio"] = collisions["g_l"] / collisions["g_u"]
 
+        # Derive columns for collisional strenghts
         c_ul_temperature_cols = ['t{:06d}'.format(t) for t in temperatures]
 
         def calculate_collisional_strength(row, temperatures):

--- a/carsus/io/output/tardis_.py
+++ b/carsus/io/output/tardis_.py
@@ -145,9 +145,9 @@ class AtomData(object):
         }
 
         if collisions_temperatures is None:
-            collisions_temperatures = np.linspace(2000, 50000, 20)
+            collisions_temperatures = np.linspace(2000, 50000, 20, dtype=np.int64)
         else:
-            collisions_temperatures = np.array(collisions_temperatures)
+            collisions_temperatures = np.array(collisions_temperatures, dtype=np.int64)
 
         self.collisions_param = {
             "temperatures": collisions_temperatures

--- a/carsus/io/output/tardis_.py
+++ b/carsus/io/output/tardis_.py
@@ -799,10 +799,11 @@ class AtomData(object):
                                                       "level_number_lower", "level_number_upper",
                                                       "delta_e", "g_ratio", "c_ul"]].copy()
 
-        # Set multiindex
-        collisions_prepared = collisions_prepared.reset_index()
-        collisions_prepared = collisions_prepared.set_index(["atomic_number", "ion_number",
-                                                             "level_number_lower", "level_number_upper"])
+        collisions_prepared = collisions_prepared.reset_index(drop=True)
+
+        # ToDo: maybe set multiindex
+        # collisions_prepared = collisions_prepared.set_index(["atomic_number", "ion_number",
+        #                                                      "level_number_lower", "level_number_upper"])
 
         return collisions_prepared
 

--- a/carsus/io/output/tardis_.py
+++ b/carsus/io/output/tardis_.py
@@ -1030,7 +1030,8 @@ class AtomData(object):
                 store.put("lines", self.lines_prepared)
 
             if store_collisions:
-                store.put("collisions", self.collisions_prepared)
+                store.put("collision_data", self.collisions_prepared)
+                store.put("collision_data_temperatures", pd.Series(self.collisions_param['temperatures']))
 
             if store_macro_atom:
                 store.put("macro_atom_data", self.macro_atom_prepared)


### PR DESCRIPTION
This PR changes the `create_collisions` method so that the collisional strengths are stored in separate columns that are derived from temperatures (`t004000`, `t006000` ... ). This is how they were stored in the legacy hdf files. The issue of  how to store the collisional strengths is still open for discussion.

The prepared method is also changed, so that the output dataframe has **exactly**  the same structure as the old one. 

Lastly, the temperatures are stored in the HDFStore as pd.Series (`collision_data_temperatures`). It is much more convenient to store them as an independent pd.Series object rather than as an attribute of the collisions DataFrame.

P.S.  `g_ratio` is now `g_l` / `g_u` - that is what TARDIS expects. It is **not** needed to flip `g_ratio` anymore in `create_collision_coefficient_matrix` (refer to `atomic.py`).
 