### PR TITLE
Create functions to convert atomic number 2 symbol and vv 2

### DIFF
--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -10,7 +10,7 @@ from sqlalchemy import and_
 from pyparsing import ParseException
 from carsus.io.base import IngesterError
 from carsus.io.util import convert_species_tuple2chianti_str
-from carsus.util import atomic_number2symbol, parse_selected_species
+from carsus.util import convert_atomic_number2symbol, parse_selected_species
 from carsus.model import DataSource, Ion, Level, LevelEnergy,\
     Line,LineGFValue, LineAValue, LineWavelength, \
     ECollision, ECollisionEnergy, ECollisionGFValue, ECollisionTempStrength
@@ -322,10 +322,10 @@ class ChiantiIngester(object):
             try:
                 bound_levels = rdr.bound_levels
             except ChiantiIonReaderError:
-                print("Levels not found for ion {} {}".format(atomic_number2symbol[atomic_number], ion_charge))
+                print("Levels not found for ion {} {}".format(convert_atomic_number2symbol(atomic_number), ion_charge))
                 continue
 
-            print("Ingesting levels for {} {}".format(atomic_number2symbol[atomic_number], ion_charge))
+            print("Ingesting levels for {} {}".format(convert_atomic_number2symbol(atomic_number), ion_charge))
 
             # ToDo: Determine parity from configuration
 
@@ -361,10 +361,10 @@ class ChiantiIngester(object):
             try:
                 bound_lines = rdr.bound_lines
             except ChiantiIonReaderError:
-                print("Lines not found for ion {} {}".format(atomic_number2symbol[atomic_number], ion_charge))
+                print("Lines not found for ion {} {}".format(convert_atomic_number2symbol(atomic_number), ion_charge))
                 continue
 
-            print("Ingesting lines for {} {}".format(atomic_number2symbol[atomic_number], ion_charge))
+            print("Ingesting lines for {} {}".format(convert_atomic_number2symbol(atomic_number), ion_charge))
 
             lvl_index2id = self.get_lvl_index2id(ion)
 
@@ -416,10 +416,10 @@ class ChiantiIngester(object):
             try:
                 bound_collisions = rdr.bound_collisions
             except ChiantiIonReaderError:
-                print("Collisions not found for ion {} {}".format(atomic_number2symbol[atomic_number], ion_charge))
+                print("Collisions not found for ion {} {}".format(convert_atomic_number2symbol(atomic_number), ion_charge))
                 continue
 
-            print("Ingesting collisions for {} {}".format(atomic_number2symbol[atomic_number], ion_charge))
+            print("Ingesting collisions for {} {}".format(convert_atomic_number2symbol(atomic_number), ion_charge))
 
             lvl_index2id = self.get_lvl_index2id(ion)
 

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -8,7 +8,7 @@ from pyparsing import ParseException
 from carsus.model import DataSource, Ion, Level, LevelEnergy,\
     Line, LineWavelength, LineGFValue
 from carsus.io.base import IngesterError
-from carsus.util import atomic_number2symbol, parse_selected_species
+from carsus.util import convert_atomic_number2symbol, parse_selected_species
 
 GFALL_AIR_THRESHOLD = 200  # [nm], wavelengths above this value are given in air
 MEDIUM_VACUUM = 0
@@ -359,7 +359,7 @@ class GFALLIngester(object):
             atomic_number, ion_charge = ion_index
             ion = Ion.as_unique(self.session, atomic_number=atomic_number, ion_charge=ion_charge)
 
-            print("Ingesting levels for {} {}".format(atomic_number2symbol[atomic_number], ion_charge))
+            print("Ingesting levels for {} {}".format(convert_atomic_number2symbol(atomic_number), ion_charge))
 
             for index, row in ion_levels.iterrows():
 
@@ -395,7 +395,7 @@ class GFALLIngester(object):
             atomic_number, ion_charge = ion_index
             ion = Ion.as_unique(self.session, atomic_number=atomic_number, ion_charge=ion_charge)
 
-            print("Ingesting lines for {} {}".format(atomic_number2symbol[atomic_number], ion_charge))
+            print("Ingesting lines for {} {}".format(convert_atomic_number2symbol(atomic_number), ion_charge))
 
             lvl_index2id = self.get_lvl_index2id(ion)
 

--- a/carsus/io/output/tardis_.py
+++ b/carsus/io/output/tardis_.py
@@ -16,7 +16,7 @@ from pyparsing import ParseException
 from carsus.model import Atom, Ion, Line, Level, DataSource, ECollision
 from carsus.model.meta import yield_limit, Base, IonListMixin
 from carsus.util import data_path, convert_camel2snake, convert_wavelength_air2vacuum,\
-    atomic_number2symbol, parse_selected_atoms, parse_selected_species
+    convert_atomic_number2symbol, parse_selected_atoms, parse_selected_species
 
 
 P_EMISSION_DOWN = -1
@@ -307,7 +307,7 @@ class AtomData(object):
                 ionization_energy = ion.ionization_energies[0].quantity
             except IndexError:
                 print "No ionization energy is available for ion {0} {1}".format(
-                    atomic_number2symbol[ion.atomic_number], ion.ion_charge
+                    convert_atomic_number2symbol(ion.atomic_number), ion.ion_charge
                 )
                 continue
             ionization_energies.append((ion.atomic_number, ion.ion_charge, ionization_energy.value))

--- a/carsus/io/util.py
+++ b/carsus/io/util.py
@@ -1,5 +1,5 @@
 from pyparsing import ParseResults
-from carsus.util import atomic_number2symbol
+from carsus.util import convert_atomic_number2symbol
 
 def to_flat_dict(tokens, parent_key='', sep='_'):
     """
@@ -72,5 +72,5 @@ def convert_species_tuple2chianti_str(species):
 
     """
     atomic_number, ion_number = species
-    chianti_ion_name = atomic_number2symbol[atomic_number].lower() + '_' + str(ion_number + 1)
+    chianti_ion_name = convert_atomic_number2symbol(atomic_number).lower() + '_' + str(ion_number + 1)
     return chianti_ion_name

--- a/carsus/util/__init__.py
+++ b/carsus/util/__init__.py
@@ -1,4 +1,4 @@
 from carsus.util.helpers import convert_camel2snake, \
-    atomic_number2symbol, symbol2atomic_number, \
+    convert_atomic_number2symbol, convert_symbol2atomic_number, \
     convert_wavelength_air2vacuum, convert_wavelength_vacuum2air, data_path
 from carsus.util.selected import parse_selected_atoms, parse_selected_species

--- a/carsus/util/helpers.py
+++ b/carsus/util/helpers.py
@@ -11,13 +11,13 @@ def data_path(fname):
         os.path.dirname(carsus.__file__), 'data', fname
     )
 
-atomic_symbols_data = np.recfromtxt(data_path('basic_atomic_data.csv'), skip_header=1,
+ATOMIC_SYMBOLS_DATA = np.recfromtxt(data_path('basic_atomic_data.csv'), skip_header=1,
                                     delimiter=',', usecols=(0, 1), names=['atomic_number', 'symbol'])
 
-symbol2atomic_number = OrderedDict(zip(atomic_symbols_data['symbol'],
-                                       atomic_symbols_data['atomic_number']))
-atomic_number2symbol = OrderedDict(zip(atomic_symbols_data['atomic_number'],
-                                       atomic_symbols_data['symbol']))
+SYMBOL2ATOMIC_NUMBER = OrderedDict(zip(ATOMIC_SYMBOLS_DATA['symbol'],
+                                       ATOMIC_SYMBOLS_DATA['atomic_number']))
+ATOMIC_NUMBER2SYMBOL = OrderedDict(zip(ATOMIC_SYMBOLS_DATA['atomic_number'],
+                                       ATOMIC_SYMBOLS_DATA['symbol']))
 
 
 def convert_camel2snake(name):
@@ -66,3 +66,11 @@ def convert_wavelength_air2vacuum(wavelength_air):
     fact = 1.0 + 5.792105e-2/(238.0185 - sigma2) + 1.67917e-3/(57.362 - sigma2)
 
     return wavelength_air * fact
+
+
+def convert_atomic_number2symbol(atomic_number):
+    return ATOMIC_NUMBER2SYMBOL[atomic_number]
+
+
+def convert_symbol2atomic_number(symbol):
+    return SYMBOL2ATOMIC_NUMBER[symbol]

--- a/carsus/util/selected.py
+++ b/carsus/util/selected.py
@@ -15,7 +15,7 @@ species_entry =  selected_atoms + [ion_numbers]
 selected_species = species_entry + [';' + species_entry]*
 """
 
-from helpers import symbol2atomic_number
+from helpers import convert_symbol2atomic_number
 from pyparsing import Literal, Suppress, delimitedList,\
     Word, alphas, nums, Optional, Group
 
@@ -27,7 +27,7 @@ def parse_element(tokens):
     symbol = tokens[0]
     symbol = symbol[:1].upper() + symbol[1:].lower()
     try:
-        atomic_number = symbol2atomic_number[symbol]
+        atomic_number = convert_symbol2atomic_number(symbol)
     except KeyError:
         raise ValueError("Unrecognized atomic symbol {}".format(symbol))
 

--- a/carsus/util/tests/test_helpers.py
+++ b/carsus/util/tests/test_helpers.py
@@ -1,7 +1,7 @@
 import pytest
 
 from carsus.util.helpers import convert_camel2snake, \
-    atomic_number2symbol, symbol2atomic_number
+    convert_atomic_number2symbol, convert_symbol2atomic_number
 
 
 @pytest.mark.parametrize("input_camel_case, expected_snake_case", [
@@ -19,8 +19,8 @@ def test_convert_camel2snake(input_camel_case, expected_snake_case):
     (30, "Zn"),
     (118, "Uuo")
 ])
-def test_atomic_number2symbol(atomic_number, expected_symbol):
-    assert atomic_number2symbol[atomic_number] == expected_symbol
+def test_convert_atomic_number2symbol(atomic_number, expected_symbol):
+    assert convert_atomic_number2symbol(atomic_number) == expected_symbol
 
 
 @pytest.mark.parametrize("symbol, expected_atomic_number", [
@@ -29,5 +29,5 @@ def test_atomic_number2symbol(atomic_number, expected_symbol):
     ("Zn", 30),
     ("Uuo", 118)
 ])
-def test_symbol2atomic_number(symbol, expected_atomic_number):
-    assert symbol2atomic_number[symbol] == expected_atomic_number
+def test_convert_symbol2atomic_number(symbol, expected_atomic_number):
+    assert convert_symbol2atomic_number(symbol) == expected_atomic_number


### PR DESCRIPTION
This PR introduces two functions: `convert_atomic_number2symbol` and `convert_symbol2atomic_number`. These functions reside in the `util` package and other modules should use them instead of the ordered dicts. 

The PR also corrects  usages of the dicts in other modules. 