### PR TITLE
Change default for store_ args to False

### DIFF
--- a/carsus/io/output/tardis_.py
+++ b/carsus/io/output/tardis_.py
@@ -957,9 +957,9 @@ class AtomData(object):
                             index=pd.MultiIndex.from_arrays(zeta_data[:, :2].transpose().astype(int)),
                             columns=t_rads)
 
-    def to_hdf(self, hdf5_path, store_atom_masses=True, store_ionization_energies=True,
-               store_levels=True, store_lines=True, store_collisions=True, store_macro_atom=True,
-               store_macro_atom_references=True, store_zeta_data=True):
+    def to_hdf(self, hdf5_path, store_atom_masses=False, store_ionization_energies=False,
+               store_levels=False, store_lines=False, store_collisions=False, store_macro_atom=False,
+               store_macro_atom_references=False, store_zeta_data=False):
         """
             Store the dataframes in an HDF5 file
 
@@ -969,28 +969,28 @@ class AtomData(object):
                 The path of the HDF5 file
             store_atom_masses: bool
                 Store the `atom_masses_prepared` DataFrame
-                (default: True)
+                (default: False)
             store_ionization_energies: bool
                 Store the `ionization_energies_prepared` DataFrame
-                (default: True)
+                (default: False)
             store_levels: bool
                 Store the `levels_prepared` DataFrame
-                (default: True)
+                (default: False)
             store_lines: bool
                 Store the `lines_prepared` DataFrame
-                (default: True)
+                (default: False)
             store_collisions: bool
                 Store the `collisions_prepared` DataFrame
-                (default: True)
+                (default: False)
             store_macro_atom: bool
                 Store the `macro_atom_prepared` DataFrame
-                (default: True)
+                (default: False)
             store_macro_atom_references: bool
                 Store the `macro_atom_references_prepared` DataFrame
-                (default: True)
+                (default: False)
             store_zeta_data: bool
                 Store the `zeta_data` DataFrame
-                (default: True)
+                (default: False)
         """
 
         with HDFStore(hdf5_path) as store:

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -334,4 +334,6 @@ def test_create_zeta_data(zeta_data):
 
 @with_test_db
 def test_atom_data_to_hdf(atom_data, hdf5_path):
-    atom_data.to_hdf(hdf5_path)
+    atom_data.to_hdf(hdf5_path, store_atom_masses=True, store_ionization_energies=True,
+                     store_levels=True, store_lines=True, store_macro_atom=True,
+                     store_macro_atom_references=True, store_zeta_data=True, store_collisions=True)


### PR DESCRIPTION
This PR changes the default value for the "store_something" keyword arguments in the `AtomData.to_hdf()` method to False. The rationale for this change is that it is more clear what gets stored to the file this way.