### PR TITLE
Remove store_macro_atom_reference argument 

### DIFF
--- a/carsus/io/output/tardis_.py
+++ b/carsus/io/output/tardis_.py
@@ -959,7 +959,7 @@ class AtomData(object):
 
     def to_hdf(self, hdf5_path, store_atom_masses=False, store_ionization_energies=False,
                store_levels=False, store_lines=False, store_collisions=False, store_macro_atom=False,
-               store_macro_atom_references=False, store_zeta_data=False):
+               store_zeta_data=False):
         """
             Store the dataframes in an HDF5 file
 
@@ -983,10 +983,8 @@ class AtomData(object):
                 Store the `collisions_prepared` DataFrame
                 (default: False)
             store_macro_atom: bool
-                Store the `macro_atom_prepared` DataFrame
-                (default: False)
-            store_macro_atom_references: bool
-                Store the `macro_atom_references_prepared` DataFrame
+                Store both the `macro_atom_prepared` DataFrame and
+                the `macro_atom_references_prepared` DataFrame
                 (default: False)
             store_zeta_data: bool
                 Store the `zeta_data` DataFrame
@@ -1013,8 +1011,6 @@ class AtomData(object):
 
             if store_macro_atom:
                 store.put("macro_atom_data", self.macro_atom_prepared)
-
-            if store_macro_atom_references:
                 store.put("macro_atom_references", self.macro_atom_references_prepared)
 
             if store_zeta_data:

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -336,4 +336,5 @@ def test_create_zeta_data(zeta_data):
 def test_atom_data_to_hdf(atom_data, hdf5_path):
     atom_data.to_hdf(hdf5_path, store_atom_masses=True, store_ionization_energies=True,
                      store_levels=True, store_lines=True, store_macro_atom=True,
-                     store_macro_atom_references=True, store_zeta_data=True, store_collisions=True)
+                     store_zeta_data=True, store_collisions=True)
+    


### PR DESCRIPTION
This PR removes the `store_macro_atom_reference` argument of `to_hdf()` that was used to store
the `macro_atom_reference` DataFrame. Instead, the `store_macro_atom` argument is used for both 
the `macro_atom_reference` DataFrame and  the `macro_atom_data` DataFrame.