### PR TITLE
Specify medium for wavelength everywhere

### DIFF
--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -12,7 +12,7 @@ from carsus.io.base import IngesterError
 from carsus.io.util import convert_species_tuple2chianti_str
 from carsus.util import convert_atomic_number2symbol, parse_selected_species
 from carsus.model import DataSource, Ion, Level, LevelEnergy,\
-    Line,LineGFValue, LineAValue, LineWavelength, \
+    Line,LineGFValue, LineAValue, LineWavelength, MEDIUM_VACUUM, \
     ECollision, ECollisionEnergy, ECollisionGFValue, ECollisionTempStrength
 
 if os.getenv('XUVTOP'):
@@ -388,6 +388,7 @@ class ChiantiIngester(object):
                     wavelengths=[
                         LineWavelength(quantity=row["wavelength"]*u.AA,
                                        data_source=self.data_source,
+                                       medium=MEDIUM_VACUUM,
                                        method=row["method"])
                     ],
                     a_values=[

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -6,13 +6,12 @@ from astropy import units as u
 from sqlalchemy import and_
 from pyparsing import ParseException
 from carsus.model import DataSource, Ion, Level, LevelEnergy,\
-    Line, LineWavelength, LineGFValue
+    Line, LineWavelength, LineGFValue, MEDIUM_VACUUM, MEDIUM_AIR
 from carsus.io.base import IngesterError
 from carsus.util import convert_atomic_number2symbol, parse_selected_species
 
+
 GFALL_AIR_THRESHOLD = 200  # [nm], wavelengths above this value are given in air
-MEDIUM_VACUUM = 0
-MEDIUM_AIR = 1
 
 
 class GFALLReader(object):

--- a/carsus/io/output/tardis_.py
+++ b/carsus/io/output/tardis_.py
@@ -13,7 +13,7 @@ from astropy import constants as const
 from astropy import units as u
 from scipy import interpolate
 from pyparsing import ParseException
-from carsus.model import Atom, Ion, Line, Level, DataSource, ECollision
+from carsus.model import Atom, Ion, Line, Level, DataSource, ECollision, MEDIUM_AIR, MEDIUM_VACUUM
 from carsus.model.meta import yield_limit, Base, IonListMixin
 from carsus.util import get_data_path, convert_camel2snake, convert_wavelength_air2vacuum,\
     convert_atomic_number2symbol, parse_selected_atoms, parse_selected_species

--- a/carsus/io/output/tardis_.py
+++ b/carsus/io/output/tardis_.py
@@ -23,9 +23,6 @@ P_EMISSION_DOWN = -1
 P_INTERNAL_DOWN = 0
 P_INTERNAL_UP = 1
 
-MEDIUM_VACUUM = 0
-MEDIUM_AIR = 1
-
 LINES_MAXRQ = 10000  # for yield_limit
 
 ZETA_DATAFILE = get_data_path("knox_long_recombination_zeta.dat")

--- a/carsus/model/__init__.py
+++ b/carsus/model/__init__.py
@@ -1,5 +1,6 @@
 from carsus.model.atomic import Atom, AtomQuantity, AtomWeight, DataSource,\
     Ion, IonQuantity, IonizationEnergy, LevelEnergy, Level, LevelQuantity,\
     Transition, Line, LineQuantity, LineAValue, LineWavelength, LineGFValue,\
-    ECollision, ECollisionQuantity, ECollisionGFValue, ECollisionEnergy, ECollisionTempStrength
+    ECollision, ECollisionQuantity, ECollisionGFValue, ECollisionEnergy, ECollisionTempStrength,\
+    MEDIUM_VACUUM, MEDIUM_AIR
 from carsus.model.meta import Base, setup

--- a/carsus/model/atomic.py
+++ b/carsus/model/atomic.py
@@ -7,6 +7,9 @@ from sqlalchemy.ext.associationproxy import association_proxy
 from astropy import units as u
 from carsus.model.meta import Base, UniqueMixin, QuantityMixin
 
+MEDIUM_VACUUM = 0
+MEDIUM_AIR = 1
+
 
 class Atom(Base):
     __tablename__ = "atom"
@@ -209,7 +212,7 @@ class LineWavelength(LineQuantity):
 
     unit = u.Angstrom
 
-    medium = Column(Integer, default=0)  # 0 - vacuum, 1 - air
+    medium = Column(Integer, default=MEDIUM_VACUUM)
     line = relationship("Line", back_populates="wavelengths")
 
     __mapper_args__ = {


### PR DESCRIPTION
This PR insures that the `medium` field is always specified when creating `LineWavelength`, even though its default value is `MEDIUM_VACUUM`. The reason for that is that sometimes the default values are not set for some reason. So it is safely to always specify them.

Also, this PR declares `MEDIUM_VACUUM` and `MEDIUM_AIR` variables in `model/atomic.py` and imports them from other modules (previously they were defined in each module).