### PR TITLE
Small addition to NIST parser

### DIFF
--- a/carsus/io/nist/ionization.py
+++ b/carsus/io/nist/ionization.py
@@ -87,6 +87,8 @@ class NISTIonizationEnergiesParser(BaseParser):
         for line in text_data.split('\n')[2:]:
             if line.startswith('----'):
                 continue
+            if line.startswith('If'):
+                break
             if line.startswith('Notes'):
                 break
             line.strip('|')


### PR DESCRIPTION
When selecting only a few elements, the NIST query returns a more bare text. This PR addresses this, by adding a if: break statement in the NIST parser