### PR TITLE
Quick fixes for carsus_env3.yml

### DIFF
--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -50,4 +50,4 @@ dependencies:
   #- sphinxcontrib-bibtex
   #- sphinxcontrib-tikz
   #- nbsphinx
-  - chiantipy==0.8.5
+  - chiantipy==0.8.4

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -46,8 +46,8 @@ dependencies:
 # Pip
 - pip:
   - git+https://github.com/tardis-sn/tardis
+  - git+https://github.com/chianti-atomic/ChiantiPy.git@0.8.4
   #- sphinx_bootstrap_theme
   #- sphinxcontrib-bibtex
   #- sphinxcontrib-tikz
   #- nbsphinx
-  - chiantipy==0.8.4

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -8,7 +8,7 @@ dependencies:
 - python=3
 - numpy=1.15
 - pandas=0.22
-- astropy=3
+- astropy=3.1
 - Cython=0.29  # TARDIS dep
 - numexpr
 - ipyparallel
@@ -24,6 +24,7 @@ dependencies:
 - h5py
 - pytables
 - pyne=0.5     # TARDIS dep
+- tqdm         # TARDIS dep
 
 # Analysis
 - jupyter
@@ -49,5 +50,4 @@ dependencies:
   #- sphinxcontrib-bibtex
   #- sphinxcontrib-tikz
   #- nbsphinx
-  - chiantipy==0.8.4
-  - tqdm
+  - chiantipy==0.8.5


### PR DESCRIPTION
- Pinned `astropy` to 3.1 because 3.2 has a bug related to `numpy` <1.16 right now.
- Moved `tqdm` from pip to I/O dependencies.
- Pinned `chiantipy` to 0.8.5 because 0.8.4 was removed from PyPI.