### PR TITLE
Pin astropy to 3.2 in env build

### DIFF
--- a/carsus/conftest.py
+++ b/carsus/conftest.py
@@ -2,7 +2,8 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
-from astropy.tests.plugins.config import *
+import pytest
+import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from carsus import init_db

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -8,7 +8,7 @@ dependencies:
 - python=3
 - numpy=1.15
 - pandas=0.22
-- astropy=3.1
+- astropy=3.2
 - Cython=0.29  # TARDIS dep
 - numexpr
 - ipyparallel


### PR DESCRIPTION
**Not ready for merge, testing currently fails, with errors in the conftest file**

This PR is for upgrading astropy to 3.2 in our carsus environment. 

Included files:

**Modified** `carsus_env3.yml:`
Changed astropy pin from 3.1 to 3.2

**Modified** `carsus/conftest.py:`
Removed import from within astropy, as module is no longer available: astropy.tests.plugins.config
Added importing of pytest
Added importing of os
