### PR TITLE
Setting up build documentation pipeline using Azure

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -19,9 +19,14 @@ that section, and options therein, determine the next step taken:  If it
 contains an option called ``auto_use`` with a value of ``True``, it will
 automatically call the main function of this module called
 `use_astropy_helpers` (see that function's docstring for full details).
-Otherwise no further action is taken (however,
-``ah_bootstrap.use_astropy_helpers`` may be called manually from within the
-setup.py script).
+Otherwise no further action is taken and by default the system-installed version
+of astropy-helpers will be used (however, ``ah_bootstrap.use_astropy_helpers``
+may be called manually from within the setup.py script).
+
+This behavior can also be controlled using the ``--auto-use`` and
+``--no-auto-use`` command-line flags. For clarity, an alias for
+``--no-auto-use`` is ``--use-system-astropy-helpers``, and we recommend using
+the latter if needed.
 
 Additional options in the ``[ah_boostrap]`` section of setup.cfg have the same
 names as the arguments to `use_astropy_helpers`, and can be used to configure
@@ -33,7 +38,6 @@ latest version of this module.
 
 import contextlib
 import errno
-import imp
 import io
 import locale
 import os
@@ -41,54 +45,45 @@ import re
 import subprocess as sp
 import sys
 
+__minimum_python_version__ = (3, 5)
+
+if sys.version_info < __minimum_python_version__:
+    print("ERROR: Python {} or later is required by astropy-helpers".format(
+        __minimum_python_version__))
+    sys.exit(1)
+
 try:
     from ConfigParser import ConfigParser, RawConfigParser
 except ImportError:
     from configparser import ConfigParser, RawConfigParser
 
 
-if sys.version_info[0] < 3:
-    _str_types = (str, unicode)
-    _text_type = unicode
-    PY3 = False
-else:
-    _str_types = (str, bytes)
-    _text_type = str
-    PY3 = True
+_str_types = (str, bytes)
 
 
 # What follows are several import statements meant to deal with install-time
 # issues with either missing or misbehaving pacakges (including making sure
 # setuptools itself is installed):
 
+# Check that setuptools 1.0 or later is present
+from distutils.version import LooseVersion
 
-# Some pre-setuptools checks to ensure that either distribute or setuptools >=
-# 0.7 is used (over pre-distribute setuptools) if it is available on the path;
-# otherwise the latest setuptools will be downloaded and bootstrapped with
-# ``ez_setup.py``.  This used to be included in a separate file called
-# setuptools_bootstrap.py; but it was combined into ah_bootstrap.py
 try:
-    import pkg_resources
-    _setuptools_req = pkg_resources.Requirement.parse('setuptools>=0.7')
-    # This may raise a DistributionNotFound in which case no version of
-    # setuptools or distribute is properly installed
-    _setuptools = pkg_resources.get_distribution('setuptools')
-    if _setuptools not in _setuptools_req:
-        # Older version of setuptools; check if we have distribute; again if
-        # this results in DistributionNotFound we want to give up
-        _distribute = pkg_resources.get_distribution('distribute')
-        if _setuptools != _distribute:
-            # It's possible on some pathological systems to have an old version
-            # of setuptools and distribute on sys.path simultaneously; make
-            # sure distribute is the one that's used
-            sys.path.insert(1, _distribute.location)
-            _distribute.activate()
-            imp.reload(pkg_resources)
-except:
-    # There are several types of exceptions that can occur here; if all else
-    # fails bootstrap and use the bootstrapped version
-    from ez_setup import use_setuptools
-    use_setuptools()
+    import setuptools
+    assert LooseVersion(setuptools.__version__) >= LooseVersion('1.0')
+except (ImportError, AssertionError):
+    print("ERROR: setuptools 1.0 or later is required by astropy-helpers")
+    sys.exit(1)
+
+# typing as a dependency for 1.6.1+ Sphinx causes issues when imported after
+# initializing submodule with ah_boostrap.py
+# See discussion and references in
+# https://github.com/astropy/astropy-helpers/issues/302
+
+try:
+    import typing   # noqa
+except ImportError:
+    pass
 
 
 # Note: The following import is required as a workaround to
@@ -97,7 +92,7 @@ except:
 # later cause the TemporaryDirectory class defined in it to stop working when
 # used later on by setuptools
 try:
-    import setuptools.py31compat
+    import setuptools.py31compat   # noqa
 except ImportError:
     pass
 
@@ -126,7 +121,6 @@ import pkg_resources
 
 from setuptools import Distribution
 from setuptools.package_index import PackageIndex
-from setuptools.sandbox import run_setup
 
 from distutils import log
 from distutils.debug import DEBUG
@@ -135,6 +129,7 @@ from distutils.debug import DEBUG
 # TODO: Maybe enable checking for a specific version of astropy_helpers?
 DIST_NAME = 'astropy-helpers'
 PACKAGE_NAME = 'astropy_helpers'
+UPPER_VERSION_EXCLUSIVE = None
 
 # Defaults for other options
 DOWNLOAD_IF_NEEDED = True
@@ -166,7 +161,7 @@ class _Bootstrapper(object):
         if not (isinstance(path, _str_types) or path is False):
             raise TypeError('path must be a string or False')
 
-        if PY3 and not isinstance(path, _text_type):
+        if not isinstance(path, str):
             fs_encoding = sys.getfilesystemencoding()
             path = path.decode(fs_encoding)  # path to unicode
 
@@ -275,6 +270,18 @@ class _Bootstrapper(object):
         if '--offline' in argv:
             config['offline'] = True
             argv.remove('--offline')
+
+        if '--auto-use' in argv:
+            config['auto_use'] = True
+            argv.remove('--auto-use')
+
+        if '--no-auto-use' in argv:
+            config['auto_use'] = False
+            argv.remove('--no-auto-use')
+
+        if '--use-system-astropy-helpers' in argv:
+            config['auto_use'] = False
+            argv.remove('--use-system-astropy-helpers')
 
         return config
 
@@ -409,7 +416,7 @@ class _Bootstrapper(object):
     def get_index_dist(self):
         if not self.download:
             log.warn('Downloading {0!r} disabled.'.format(DIST_NAME))
-            return False
+            return None
 
         log.warn(
             "Downloading {0!r}; run setup.py with the --offline option to "
@@ -453,9 +460,10 @@ class _Bootstrapper(object):
             # setup.py exists we can generate it
             setup_py = os.path.join(path, 'setup.py')
             if os.path.isfile(setup_py):
-                with _silence():
-                    run_setup(os.path.join(path, 'setup.py'),
-                              ['egg_info'])
+                # We use subprocess instead of run_setup from setuptools to
+                # avoid segmentation faults - see the following for more details:
+                # https://github.com/cython/cython/issues/2104
+                sp.check_output([sys.executable, 'setup.py', 'egg_info'], cwd=path)
 
                 for dist in pkg_resources.find_distributions(path, True):
                     # There should be only one...
@@ -490,16 +498,32 @@ class _Bootstrapper(object):
         if version:
             req = '{0}=={1}'.format(DIST_NAME, version)
         else:
-            req = DIST_NAME
+            if UPPER_VERSION_EXCLUSIVE is None:
+                req = DIST_NAME
+            else:
+                req = '{0}<{1}'.format(DIST_NAME, UPPER_VERSION_EXCLUSIVE)
 
         attrs = {'setup_requires': [req]}
 
+        # NOTE: we need to parse the config file (e.g. setup.cfg) to make sure
+        # it honours the options set in the [easy_install] section, and we need
+        # to explicitly fetch the requirement eggs as setup_requires does not
+        # get honored in recent versions of setuptools:
+        # https://github.com/pypa/setuptools/issues/1273
+
         try:
-            if DEBUG:
-                _Distribution(attrs=attrs)
-            else:
-                with _silence():
-                    _Distribution(attrs=attrs)
+
+            context = _verbose if DEBUG else _silence
+            with context():
+                dist = _Distribution(attrs=attrs)
+                try:
+                    dist.parse_config_files(ignore_option_errors=True)
+                    dist.fetch_build_eggs(req)
+                except TypeError:
+                    # On older versions of setuptools, ignore_option_errors
+                    # doesn't exist, and the above two lines are not needed
+                    # so we can just continue
+                    pass
 
             # If the setup_requires succeeded it will have added the new dist to
             # the main working_set
@@ -702,7 +726,7 @@ class _Bootstrapper(object):
             if self.offline:
                 cmd.append('--no-fetch')
         elif status == 'U':
-            raise _AHBoostrapSystemExit(
+            raise _AHBootstrapSystemExit(
                 'Error: Submodule {0} contains unresolved merge conflicts.  '
                 'Please complete or abandon any changes in the submodule so that '
                 'it is in a usable state, then try again.'.format(submodule))
@@ -763,7 +787,7 @@ def run_cmd(cmd):
             msg = 'Command not found: `{0}`'.format(' '.join(cmd))
             raise _CommandNotFound(msg, cmd)
         else:
-            raise _AHBoostrapSystemExit(
+            raise _AHBootstrapSystemExit(
                 'An unexpected error occurred when running the '
                 '`{0}` command:\n{1}'.format(' '.join(cmd), str(e)))
 
@@ -780,9 +804,9 @@ def run_cmd(cmd):
         stdio_encoding = 'latin1'
 
     # Unlikely to fail at this point but even then let's be flexible
-    if not isinstance(stdout, _text_type):
+    if not isinstance(stdout, str):
         stdout = stdout.decode(stdio_encoding, 'replace')
-    if not isinstance(stderr, _text_type):
+    if not isinstance(stderr, str):
         stderr = stderr.decode(stdio_encoding, 'replace')
 
     return (p.returncode, stdout, stderr)
@@ -836,6 +860,10 @@ class _DummyFile(object):
 
 
 @contextlib.contextmanager
+def _verbose():
+    yield
+
+@contextlib.contextmanager
 def _silence():
     """A context manager that silences sys.stdout and sys.stderr."""
 
@@ -876,46 +904,6 @@ class _AHBootstrapSystemExit(SystemExit):
         msg += '\n' + _err_help_msg
 
         super(_AHBootstrapSystemExit, self).__init__(msg, *args[1:])
-
-
-if sys.version_info[:2] < (2, 7):
-    # In Python 2.6 the distutils log does not log warnings, errors, etc. to
-    # stderr so we have to wrap it to ensure consistency at least in this
-    # module
-    import distutils
-
-    class log(object):
-        def __getattr__(self, attr):
-            return getattr(distutils.log, attr)
-
-        def warn(self, msg, *args):
-            self._log_to_stderr(distutils.log.WARN, msg, *args)
-
-        def error(self, msg):
-            self._log_to_stderr(distutils.log.ERROR, msg, *args)
-
-        def fatal(self, msg):
-            self._log_to_stderr(distutils.log.FATAL, msg, *args)
-
-        def log(self, level, msg, *args):
-            if level in (distutils.log.WARN, distutils.log.ERROR,
-                         distutils.log.FATAL):
-                self._log_to_stderr(level, msg, *args)
-            else:
-                distutils.log.log(level, msg, *args)
-
-        def _log_to_stderr(self, level, msg, *args):
-            # This is the only truly 'public' way to get the current threshold
-            # of the log
-            current_threshold = distutils.log.set_threshold(distutils.log.WARN)
-            distutils.log.set_threshold(current_threshold)
-            if level >= current_threshold:
-                if args:
-                    msg = msg % args
-                sys.stderr.write('%s\n' % msg)
-                sys.stderr.flush()
-
-    log = log()
 
 
 BOOTSTRAPPER = _Bootstrapper.main()

--- a/azure-pipelines/doc-build.yml
+++ b/azure-pipelines/doc-build.yml
@@ -1,0 +1,68 @@
+# Specify which branches you want to trigger for continuous deployment and/or applicable for pull requests
+# Otherwise it triggers all of them
+trigger:
+- master
+
+pr:
+- none
+
+# Variables we can reference later
+variables:
+  system.debug: 'true'
+
+jobs:
+# Title of job
+# Virtual machine selected from the available pools
+- job: 'Build_Documentation'
+  pool:
+    vmImage: 'Ubuntu-16.04'
+
+  steps:
+# When setting up the azure pipeline for the first time, generate a ssh key locally
+# and add the generated public key to github as a deploy key through forked_repo_home/settings/deploy_key
+# Use steps listed from: https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys
+
+# Secure files stored in the azure server are encryped and again decrypted by the azure task that uses the file
+# Download a secure file to a temporary location in the virtual machine
+  - task: DownloadSecureFile@1
+    inputs: 
+      secureFile: 'id_carsus_rsa'
+# Make sure you've added the generated private key file (named 'id_azure_rsa' here) to library & authorize it for all pipelines
+# by using: https://docs.microsoft.com/en-us/azure/devops/pipelines/library/secure-files?view=azure-devops#how-do-i-authorize-a-secure-file-for-use-in-all-pipelines
+
+# Install an SSH key prior to a build or release
+# This is needed to give azure access to deploy to github
+# hostName is the line that was added to ~/.ssh/known_hosts when you added the RSA host key. (Output of ssh-keyscan should look something like: [1]As3..=ssh-rsa ..)
+# sshPublicKey should be a string value of what is inside your .pub file (i.e: rsa-key Axddd... username@server)
+# sshKeySecureFile is the downloaded secure file you generated
+  - task: InstallSSHKey@0
+    inputs:
+     knownHostsEntry: $(gh_host)
+     sshPublicKey: $(public_key)
+     #sshPassphrase: # Optional - leave empty if it was left empty while generating the key
+     sshKeySecureFile: 'id_carsus_rsa'
+# For more details, see: http://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/install-ssh-key?view=azure-devops#example-setup-using-github
+# You can mask hostName & sshPublicKey values under secret variables (i.e. gh_host & public_key here) in your azure pipeline build page
+# Follow these steps: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#secret-variables
+
+# ##vso[task.prependpath] is a built-in logging command to add paths
+# Add conda to the list of paths available from the terminal
+  - bash: |
+          echo "##vso[task.prependpath]$CONDA/bin"        
+    displayName: Add conda to PATH
+# Make the vm user the owner of the conda path
+# Update conda without asking for confirmation
+  - bash: |
+      sudo chown -R $USER $CONDA
+      conda update -y conda    
+    displayName: Updating conda and activating
+# Install the conda environment made for Carsus
+  - bash: |
+        conda env create -f carsus_env3.yml
+    displayName: 'Install Carsus env'
+# Activate the environment, use sphinx to make the html documentation of the build, and deploy to gh-pages
+  - bash: |
+        source activate carsus
+        bash deploy_docs.sh
+    displayName: 'Carsus build and deployment to gh-pages'
+# See github.com/tardis-sn/carsus for the contents of these files

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
 - python=3
 - numpy=1.15
-- pandas=0.22
+- pandas=0.24
 - astropy=3.2
 - Cython=0.29  # TARDIS dep
 - numexpr
@@ -17,7 +17,7 @@ dependencies:
 
 # I/O
 - beautifulsoup4
-- pyparsing=2.1.10
+- pyparsing=2.4.0
 - html5lib
 - SQLAlchemy=1.0.19
 - PyYAMl
@@ -31,9 +31,16 @@ dependencies:
 - matplotlib
 
 # Documentation
-- sphinx=1.5.6
+- sphinx
+- nbconvert
 - numpydoc
 - docutils
+- nbformat
+- sphinx_bootstrap_theme
+- sphinxcontrib-bibtex
+- sphinx_rtd_theme
+- nbsphinx
+- recommonmark
 
 # Test/Coverage requirements
 - coverage
@@ -47,7 +54,3 @@ dependencies:
 - pip:
   - git+https://github.com/tardis-sn/tardis
   - git+https://github.com/chianti-atomic/ChiantiPy.git@0.8.4
-  #- sphinx_bootstrap_theme
-  #- sphinxcontrib-bibtex
-  #- sphinxcontrib-tikz
-  #- nbsphinx

--- a/deploy_docs.sh
+++ b/deploy_docs.sh
@@ -1,0 +1,59 @@
+# Modified from https://github.com/AMReX-Codes/amrex/blob/master/build_and_deploy.sh
+# and licensed according to BSD-3-Clause-LBNL (https://github.com/AMReX-Codes/amrex/blob/master/LICENSE).
+
+#!/bin/bash
+set -e # Exit with nonzero exit code if anything fails
+
+# Build the documentation from the SOURCE_BRANCH
+# and push it to TARGET_BRANCH.
+SOURCE_BRANCH="master"
+TARGET_BRANCH="gh-pages"
+
+# Save some useful information
+REPO=`git config remote.origin.url`
+SSH_REPO=${REPO/https:\/\/github.com\//git@github.com:}
+SHA=`git rev-parse --verify HEAD`
+
+# Clone the existing gh-pages for this repo into out/
+git clone $REPO out
+cd out
+
+# Create a new empty branch if gh-pages doesn't exist yet (should only happen on first deploy)
+git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
+
+# Clean out existing contents
+git rm -rf . || exit 0
+cd ..
+
+# Pull from SOURCE_BRANCH again
+git pull $SSH_REPO $SOURCE_BRANCH
+
+# Build the Sphinx documentation
+cd docs
+make html
+cd ../  
+
+# Move it to the gh-pages branch
+mv -f docs/_build/html/* out/
+touch out/.nojekyll
+
+# Now let's go have some fun with the cloned repo
+cd out
+git config --local user.name "Azure Pipelines"
+git config --local user.email "azuredevops@microsoft.com"
+
+echo "doing git add/commit/push"
+
+# Commit the "changes", i.e. the new version.
+# The delta will show diffs between new and old versions.
+git add --all
+
+# Exit if there are no docs changes
+if git diff --staged --quiet; then
+   echo "exiting with no docs changes"
+   exit 0
+fi
+
+# Otherwise, commit and push
+git commit -m "Deploy to GitHub Pages: ${SHA}"
+git push $SSH_REPO $TARGET_BRANCH


### PR DESCRIPTION
- [x] Proof reading

Merging this update will cause: **RecursionError: maximum recursion depth exceeded while calling a Python object** during our tests.

**Update**: Error resolved in https://github.com/python/typing/issues/582

**Update**: A solution in the following PR, is to update carsus fully for python 3.0, starting with the ah_bootstrap.py file and making our tests compatible with pandas. 

This PR is for setting up our second azure pipeline, for building and publishing documentation to gh-pages using azure services. 
Once this PR is merged, the pipeline can be added on azure. 

Included files:

1st commit:

`azure-pipelines/doc-build.yml:`
This is the yaml file that is run on the azure server.
It downloads the secure key, adds it so we can push to gh-pages, updates conda, installs and activates the tardis environment, then runs the deploy-docs.shell file.

`deploy_docs.sh:`
This is the script that specifies the source and target branch for documentating the build and deploying.
1- It makes the build for the master branch and documents it using Sphinx in the master branch.
2- Configures the username and password for azure.
3- Moves it to an empty directory in the gh-pages branch.
4- Then commits and pushes.

2nd commit:

**Modified** `carsus_env.yml:`
Added dependencies needed for making the documentation. 

3rd commit: 

**Modified** `ah_bootstrap.py:`
Updated file for newer astropy_helpers version.