### PR TITLE
Quick fix for HDF5 hashes

### DIFF
--- a/carsus/io/output/tardis_.py
+++ b/carsus/io/output/tardis_.py
@@ -1177,5 +1177,5 @@ class AtomData(object):
 
             print("Signing AtomData: \nMD5: {}\nUUID1: {}".format(md5_hash.hexdigest(), uuid1))
 
-            store.root._v_attrs['md5'] = md5_hash.hexdigest()
-            store.root._v_attrs['uuid1'] = uuid1
+            store.root._v_attrs['md5'] = md5_hash.hexdigest().encode('ascii')
+            store.root._v_attrs['uuid1'] = uuid1.encode('ascii')


### PR DESCRIPTION
Example:

```python
from tardis.io.atom_data import AtomData
atom_data = AtomData.from_hdf('example_store.h5')
```

Fails when trying to ascii-decode MD5 and UUID1 with error `AttributeError: 'numpy.str_' object has no attribute 'decode'  ` 

My proposed solution is to force ascii encoding in `carsus/io/output/tardis_.py`.

Removing `.decode('ascii')` from TARDIS code will break compatibility with older atomic files (I assume).