### PR TITLE
Some fixes and improvements for CMFGEN output

### DIFF
--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -294,7 +294,7 @@ class CMFGENCollisionalDataParser(BaseParser):
         kwargs = {}
         kwargs['header'] = None
         kwargs['index_col'] = False
-        kwargs['sep'] = '\s*-?\s+-?|(?<=[^edED])-|(?<=Pe)-'  # TODO: this regex needs some review
+        kwargs['sep'] = '\s*-?\s+-?|(?<=[^edED])-|(?<=[FDP]e)-'  # TODO: this regex needs some review
         kwargs['skiprows'] = find_row(fname, "ransition\T", num_row=True)
 
         # FIXME: expensive solution for two files with more than one table

--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -189,9 +189,10 @@ class CMFGENEnergyLevelsParser(BaseParser):
         self.meta = meta
 
     def to_hdf(self, key='/energy_levels'):
-        with pd.HDFStore(self.fname + '.h5', 'a') as f:
-            f.append(key, self.base)
-            f.get_storer(key).attrs.metadata = self.meta
+        if not self.base.empty:
+            with pd.HDFStore(self.fname + '.h5', 'a') as f:
+                f.append(key, self.base)
+                f.get_storer(key).attrs.metadata = self.meta
 
 
 class CMFGENOscillatorStrengthsParser(BaseParser):
@@ -261,9 +262,10 @@ class CMFGENOscillatorStrengthsParser(BaseParser):
         self.meta = meta
 
     def to_hdf(self, key='/oscillator_strengths'):
-        with pd.HDFStore(self.fname + '.h5', 'a') as f:
-            f.append(key, self.base)
-            f.get_storer(key).attrs.metadata = self.meta
+        if not self.base.empty:
+            with pd.HDFStore(self.fname + '.h5', 'a') as f:
+                f.append(key, self.base)
+                f.get_storer(key).attrs.metadata = self.meta
 
 
 class CMFGENCollisionalDataParser(BaseParser):
@@ -329,9 +331,10 @@ class CMFGENCollisionalDataParser(BaseParser):
         self.meta = meta
 
     def to_hdf(self, key='/collisional_data'):
-        with pd.HDFStore(self.fname + '.h5', 'a') as f:
-            f.append(key, self.base)
-            f.get_storer(key).attrs.metadata = self.meta
+        if not self.base.empty:
+            with pd.HDFStore(self.fname + '.h5', 'a') as f:
+                f.append(key, self.base)
+                f.get_storer(key).attrs.metadata = self.meta
 
 
 class CMFGENPhotoionizationCrossSectionParser(BaseParser):
@@ -430,12 +433,12 @@ class CMFGENPhotoionizationCrossSectionParser(BaseParser):
         self.meta = meta
 
     def to_hdf(self, key='/photoionization_cross_sections'):
+        if len(self.base) > 0:
+            with pd.HDFStore(self.fname + '.h5', 'a') as f:
+                header = pd.Series(data=self.meta)  # FIXME: couldn't write this like `attr` metadata
+                f.put(key, header, format='table', data_columns=True)
 
-        with pd.HDFStore(self.fname + '.h5', 'a') as f:
-            header = pd.Series(data=self.meta)  # FIXME: couldn't write this like `attr` metadata
-            f.put(key, header, format='table', data_columns=True)
-
-            for i in range(1, len(self.base)-1):
-                subkey = key + '/' + str(i)
-                f.append(subkey, self.base[i], format='table', data_columns=True)
-                f.get_storer(subkey).attrs.metadata = self.base[i]._meta
+                for i in range(1, len(self.base)-1):
+                    subkey = key + '/' + str(i)
+                    f.append(subkey, self.base[i], format='table', data_columns=True)
+                    f.get_storer(subkey).attrs.metadata = self.base[i]._meta

--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -190,7 +190,7 @@ class CMFGENEnergyLevelsParser(BaseParser):
 
     def to_hdf(self, key='/energy_levels'):
         with pd.HDFStore(self.fname + '.h5', 'a') as f:
-            f.append(key, self.base, format='table', data_columns=self.columns)
+            f.append(key, self.base)
             f.get_storer(key).attrs.metadata = self.meta
 
 
@@ -262,7 +262,7 @@ class CMFGENOscillatorStrengthsParser(BaseParser):
 
     def to_hdf(self, key='/oscillator_strengths'):
         with pd.HDFStore(self.fname + '.h5', 'a') as f:
-            f.append(key, self.base, format='table', data_columns=self.columns)
+            f.append(key, self.base)
             f.get_storer(key).attrs.metadata = self.meta
 
 
@@ -330,7 +330,7 @@ class CMFGENCollisionalDataParser(BaseParser):
 
     def to_hdf(self, key='/collisional_data'):
         with pd.HDFStore(self.fname + '.h5', 'a') as f:
-            f.append(key, self.base, format='table', data_columns=self.columns)
+            f.append(key, self.base)
             f.get_storer(key).attrs.metadata = self.meta
 
 

--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -436,7 +436,7 @@ class CMFGENPhotoionizationCrossSectionParser(BaseParser):
         if len(self.base) > 0:
             with pd.HDFStore('{}.h5'.format(self.fname), 'a') as f:
 
-                for i in range(1, len(self.base)-1):
+                for i in range(0, len(self.base)-1):
                     subkey = '{0}/{1}'.format(key, i)
                     f.append(subkey, self.base[i])
                     f.get_storer(subkey).attrs.metadata = self.base[i]._meta

--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -190,7 +190,7 @@ class CMFGENEnergyLevelsParser(BaseParser):
 
     def to_hdf(self, key='/energy_levels'):
         if not self.base.empty:
-            with pd.HDFStore(self.fname + '.h5', 'a') as f:
+            with pd.HDFStore('{}.h5'.format(self.fname), 'a') as f:
                 f.append(key, self.base)
                 f.get_storer(key).attrs.metadata = self.meta
 
@@ -263,7 +263,7 @@ class CMFGENOscillatorStrengthsParser(BaseParser):
 
     def to_hdf(self, key='/oscillator_strengths'):
         if not self.base.empty:
-            with pd.HDFStore(self.fname + '.h5', 'a') as f:
+            with pd.HDFStore('{}.h5'.format(self.fname), 'a') as f:
                 f.append(key, self.base)
                 f.get_storer(key).attrs.metadata = self.meta
 
@@ -332,7 +332,7 @@ class CMFGENCollisionalDataParser(BaseParser):
 
     def to_hdf(self, key='/collisional_data'):
         if not self.base.empty:
-            with pd.HDFStore(self.fname + '.h5', 'a') as f:
+            with pd.HDFStore('{}.h5'.format(self.fname), 'a') as f:
                 f.append(key, self.base)
                 f.get_storer(key).attrs.metadata = self.meta
 
@@ -434,10 +434,10 @@ class CMFGENPhotoionizationCrossSectionParser(BaseParser):
 
     def to_hdf(self, key='/photoionization_cross_sections'):
         if len(self.base) > 0:
-            with pd.HDFStore(self.fname + '.h5', 'a') as f:
+            with pd.HDFStore('{}.h5'.format(self.fname), 'a') as f:
 
                 for i in range(1, len(self.base)-1):
-                    subkey = key + '/' + str(i)
+                    subkey = '{0}/{1}'.format(key, i)
                     f.append(subkey, self.base[i])
                     f.get_storer(subkey).attrs.metadata = self.base[i]._meta
 

--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -435,10 +435,10 @@ class CMFGENPhotoionizationCrossSectionParser(BaseParser):
     def to_hdf(self, key='/photoionization_cross_sections'):
         if len(self.base) > 0:
             with pd.HDFStore(self.fname + '.h5', 'a') as f:
-                header = pd.Series(data=self.meta)  # FIXME: couldn't write this like `attr` metadata
-                f.put(key, header, format='table', data_columns=True)
 
                 for i in range(1, len(self.base)-1):
                     subkey = key + '/' + str(i)
-                    f.append(subkey, self.base[i], format='table', data_columns=True)
+                    f.append(subkey, self.base[i])
                     f.get_storer(subkey).attrs.metadata = self.base[i]._meta
+
+                f.root._v_attrs['metadata'] = self.meta

--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -294,7 +294,7 @@ class CMFGENCollisionalDataParser(BaseParser):
         kwargs = {}
         kwargs['header'] = None
         kwargs['index_col'] = False
-        kwargs['sep'] = '\s*-?\s+-?|(?<=[^edED])-|(?<=[FDP]e)-'  # TODO: this regex needs some review
+        kwargs['sep'] = '\s*-?\s+-?|(?<=[^edED])-|(?<=[FDP]e)-'
         kwargs['skiprows'] = find_row(fname, "ransition\T", num_row=True)
 
         # FIXME: expensive solution for two files with more than one table


### PR DESCRIPTION
- [x] Not using `table` format anymore. Use standard binary output like the other Carsus modules
- [x] Skip dump to HDF if DataFrames are empty, otherwise will fail when trying to store metadata
- [x] Storing photoionization cross section metadata in `root` metadata (found how to do this in `carsus/io/output/tardis_.py`)
- [x] Ready for merge