### PR TITLE
New Kurucz line list parser with straight to HDF5 output

### DIFF
--- a/carsus/io/kurucz/__init__.py
+++ b/carsus/io/kurucz/__init__.py
@@ -1,1 +1,1 @@
-from .gfall import GFALLReader, GFALLIngester
+from .gfall import GFALLReader, GFALLIngester, GFALL

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -569,6 +569,7 @@ class GFALL(BaseParser):
         lines.loc[air_mask, 'wavelength'] = convert_wavelength_air2vacuum(
                 lines.loc[air_mask, 'wavelength'])
         lines.drop(columns=['medium'], inplace=True)
+        lines = lines[['lower_level_id', 'upper_level_id', 'wavelength', 'gf', 'loggf']]
 
         return lines
 

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -543,8 +543,8 @@ class GFALL(BaseParser):
         levels['energy'] = levels['energy'].apply(lambda x: x.value)
 
         levels = pd.concat([ground_levels, levels])
-        levels['line_id'] = range(1, len(levels)+1)
-        levels = levels.set_index('line_id')
+        levels['level_id'] = range(1, len(levels)+1)
+        levels = levels.set_index('level_id')
         levels = levels.drop_duplicates(keep='last')
 
         self.levels = levels

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -485,14 +485,13 @@ class GFALL(BaseParser):
         self.ions = parse_selected_species(ions)
         self.gfall_reader = GFALLReader(fname)
         self._create_ions_df()
-        self._get_all_levels_data()
-        self._get_all_lines_data()
+        self._prepare_levels()
 
     def _create_ions_df(self):
         ions_df = pd.DataFrame.from_records(self.ions, columns=["atomic_number", "ion_charge"])
         ions_df = ions_df.set_index(['atomic_number', 'ion_charge'])
         self.ions_df = ions_df
-    
+
     def _get_all_lines_data(self):
         gf = self.gfall_reader
         lines = gf.lines.reset_index().join(self.ions_df, how="inner", on=["atomic_number", "ion_charge"]).\
@@ -516,10 +515,10 @@ class GFALL(BaseParser):
                 lines.loc[air_mask, 'wavelength'])
         lines.drop(columns=['medium'], inplace=True)
 
-        self.lines = lines
-
+        return lines
 
     def _get_all_levels_data(self):
+        """ Returns the same output than `AtomData._get_all_levels_data()` """
         atoms = set([convert_atomic_number2symbol(i[0]) for i in self.ions])
         atoms = ', '.join(atoms)
         nist_parser = NISTIonizationEnergies(atoms)
@@ -547,4 +546,12 @@ class GFALL(BaseParser):
         levels = levels.set_index('level_id')
         levels = levels.drop_duplicates(keep='last')
 
-        self.levels = levels
+        return levels
+
+    def _prepare_levels(self):
+        """ Returns almost the same output than `AtomData.levels` (no metastable flags) """
+        self.levels_all = self._get_all_levels_data()
+
+
+
+        

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -915,5 +915,7 @@ class GFALL(BaseParser):
            Path to the HDF5 output file
         """
         with pd.HDFStore(fname, 'a') as f:
-            f.append('/levels', self.levels_prepared)
-            f.append('/lines', self.lines_prepared)
+            f.put('/levels', self.levels_prepared)
+            f.put('/lines', self.lines_prepared)
+            f.put('/macro_atom_data', self.macro_atom_prepared)
+            f.put('/macro_atom_references', self.macro_atom_references_prepared)

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -482,7 +482,9 @@ class GFALLIngester(object):
 
 class GFALL(BaseParser):
     """ Docstring """
-    def __init__(self, fname, ions):
+    def __init__(self, fname, ions, lines_loggf_threshold=-3, \
+        levels_metastable_loggf_threshold=-3):
+        
         self.ions = parse_selected_species(ions)
         self.gfall_reader = GFALLReader(fname)
         self._create_ionization_data()
@@ -614,7 +616,7 @@ class GFALL(BaseParser):
 
         return levels
 
-    def _create_levels_lines(self):
+    def _create_levels_lines(self, lines_loggf_threshold=-3, levels_metastable_loggf_threshold=-3):
         """ Returns almost the same output than `AtomData.create_levels_lines` method """
         levels_all = self._get_all_levels_data().reset_index()
         lines_all = self._get_all_lines_data(levels_all)
@@ -634,12 +636,13 @@ class GFALL(BaseParser):
             join(pd.DataFrame(index=levels.index), on="upper_level_id", how="inner")
 
         # Culling lines with low gf values
-        lines = lines.loc[lines["loggf"] > -3]
+        lines = lines.loc[lines["loggf"] > lines_loggf_threshold]
 
         # Do not clean levels that don't exist in lines
 
         # Create the metastable flags for levels
-        levels["metastable"] = self._create_metastable_flags(levels, lines_all, -3)
+        levels["metastable"] = self._create_metastable_flags(levels, lines_all, \
+            levels_metastable_loggf_threshold)
 
         # Create levels numbers
         levels = levels.sort_values(["atomic_number", "ion_number", "energy", "g"])

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -500,12 +500,17 @@ class GFALL(BaseParser):
     def __init__(self, fname, ions, lines_loggf_threshold=-3, \
         levels_metastable_loggf_threshold=-3):
 
+        self.levels_lines_param = {
+            "levels_metastable_loggf_threshold": levels_metastable_loggf_threshold,
+            "lines_loggf_threshold": lines_loggf_threshold
+        }
+
         self.ions = parse_selected_species(ions)
         self.gfall_reader = GFALLReader(fname)
         self._create_ionization_data()
         self.levels_all = self._get_all_levels_data().reset_index()
         self.lines_all = self._get_all_lines_data(self.levels_all)
-        self._create_levels_lines()
+        self._create_levels_lines(**self.levels_lines_param)
         self._create_macro_atom()
         self._create_macro_atom_references()
 

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -481,10 +481,21 @@ class GFALLIngester(object):
 
 
 class GFALL(BaseParser):
-    """ Docstring """
+    """
+    Attributes
+    ----------
+    levels_prepared : pandas.DataFrame
+    lines_prepared : pandas.DataFrame
+
+    Methods
+    -------
+    to_hdf(fname)
+        Dump `levels_prepared` and `lines_prepared` attributes into an HDF5 file
+
+    """
     def __init__(self, fname, ions, lines_loggf_threshold=-3, \
         levels_metastable_loggf_threshold=-3):
-        
+
         self.ions = parse_selected_species(ions)
         self.gfall_reader = GFALLReader(fname)
         self._create_ionization_data()
@@ -502,24 +513,23 @@ class GFALL(BaseParser):
 
     @staticmethod
     def _create_artificial_fully_ionized(levels):
-        """ Create artificial levels for fully ionized ions. """
+        """ Create artificial levels for fully ionized ions """
         fully_ionized_levels = list()
-    
+
         for atomic_number, _ in levels.groupby("atomic_number"):
             fully_ionized_levels.append(
                 (-1, atomic_number, atomic_number, 0, 0.0, 1, True)
             )
-    
+
         levels_columns = ["level_id", "atomic_number", "ion_number", "level_number", "energy", "g", "metastable"]
         fully_ionized_levels_dtypes = [(key, levels.dtypes[key]) for key in levels_columns]
-    
+
         fully_ionized_levels = np.array(fully_ionized_levels, dtype=fully_ionized_levels_dtypes)
-    
+
         return pd.DataFrame(data=fully_ionized_levels)
 
     @staticmethod
     def _create_metastable_flags(levels, lines, levels_metastable_loggf_threshold=-3):
-
         # Filter lines on the loggf threshold value
         metastable_lines = lines.loc[lines["loggf"] > levels_metastable_loggf_threshold]
 
@@ -537,8 +547,7 @@ class GFALL(BaseParser):
         return metastable_flags
 
     def _get_all_lines_data(self, levels):
-        """ Returns the same output than `AtomData._get_all_lines_data()` """  
-
+        """ Returns the same output than `AtomData._get_all_lines_data()` """
         gf = self.gfall_reader
         df_list = []
 
@@ -566,7 +575,7 @@ class GFALL(BaseParser):
             df['lower_level_id'] = pd.Series(lower_level_id)
             df['upper_level_id'] = pd.Series(upper_level_id)
             df_list.append(df)
-        
+
         lines = pd.concat(df_list)
         lines['line_id'] = range(1, len(lines)+1)
         lines['loggf'] = lines['gf'].apply(np.log10)

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -737,3 +737,16 @@ class GFALL(BaseParser):
                     "level_number_lower", "level_number_upper"], inplace=True)
 
         return lines_prepared
+
+
+    def to_hdf(self, fname):
+        """Dump the `base` attribute into an HDF5 file
+
+        Parameters
+        ----------
+        fname : path
+           Path to the HDF5 output file
+        """
+        with pd.HDFStore(fname, 'a') as f:
+            f.append('/levels', self.levels_prepared)
+            f.append('/lines', self.lines_prepared)

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -499,6 +499,8 @@ class GFALL(BaseParser):
         self.ions = parse_selected_species(ions)
         self.gfall_reader = GFALLReader(fname)
         self._create_ionization_data()
+        self.levels_all = self._get_all_levels_data().reset_index()
+        self.lines_all = self._get_all_lines_data(self.levels_all)
         self._create_levels_lines()
 
     def _create_ionization_data(self):
@@ -632,8 +634,8 @@ class GFALL(BaseParser):
 
     def _create_levels_lines(self, lines_loggf_threshold=-3, levels_metastable_loggf_threshold=-3):
         """ Returns almost the same output than `AtomData.create_levels_lines` method """
-        levels_all = self._get_all_levels_data().reset_index()
-        lines_all = self._get_all_lines_data(levels_all)
+        levels_all = self.levels_all
+        lines_all = self.lines_all
         ionization_energies = self.ionization_energies.reset_index()
         ionization_energies['ion_number'] -= 1
         

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -18,10 +18,6 @@ from carsus.io.nist.ionization import NISTIonizationEnergies
 
 GFALL_AIR_THRESHOLD = 200  # [nm], wavelengths above this value are given in air
 
-P_EMISSION_DOWN = -1
-P_INTERNAL_DOWN = 0
-P_INTERNAL_UP = 1
-
 logger = logging.getLogger(__name__)
 
 class GFALLReader(object):
@@ -511,8 +507,6 @@ class GFALL(BaseParser):
         self.levels_all = self._get_all_levels_data().reset_index()
         self.lines_all = self._get_all_lines_data(self.levels_all)
         self._create_levels_lines(**self.levels_lines_param)
-        self._create_macro_atom()
-        self._create_macro_atom_references()
 
     def _create_ionization_data(self):
         atoms = set([convert_atomic_number2symbol(i[0]) for i in self.ions])
@@ -768,149 +762,6 @@ class GFALL(BaseParser):
 
         return lines_prepared
 
-    def _create_macro_atom(self):
-        """
-            Create a DataFrame containing *macro atom* data.
-
-            Returns
-            -------
-            macro_atom: pandas.DataFrame
-                DataFrame with:
-                    index: none;
-                    columns: atomic_number, ion_number, source_level_number, target_level_number,
-                        transition_line_id, transition_type, transition_probability.
-
-            Notes:
-                Refer to the docs: http://tardis.readthedocs.io/en/latest/physics/plasma/macroatom.html
-
-        """
-        # Exclude artificially created levels from levels
-        levels = self.levels.loc[self.levels["level_id"] != -1].set_index("level_id")
-
-        lvl_energy_lower = levels.rename(columns={"energy": "energy_lower"}).loc[:, ["energy_lower"]]
-        lvl_energy_upper = levels.rename(columns={"energy": "energy_upper"}).loc[:, ["energy_upper"]]
-
-        lines = self.lines.set_index("line_id")
-        lines = lines.join(lvl_energy_lower, on="lower_level_id").join(lvl_energy_upper, on="upper_level_id")
-
-        macro_atom = list()
-        macro_atom_dtype = [("atomic_number", np.int), ("ion_number", np.int),
-                            ("source_level_number", np.int), ("target_level_number", np.int),
-                            ("transition_line_id", np.int), ("transition_type", np.int), ("transition_probability", np.float)]
-
-        for line_id, row in lines.iterrows():
-            atomic_number, ion_number = row["atomic_number"], row["ion_number"]
-            level_number_lower, level_number_upper = row["level_number_lower"], row["level_number_upper"]
-            nu = row["nu"]
-            f_ul, f_lu = row["f_ul"], row["f_lu"]
-            e_lower, e_upper = row["energy_lower"], row["energy_upper"]
-
-            transition_probabilities_dict = dict()  # type : probability
-            transition_probabilities_dict[P_EMISSION_DOWN] = 2 * nu**2 * f_ul / const.c.cgs.value**2 * (e_upper - e_lower)
-            transition_probabilities_dict[P_INTERNAL_DOWN] = 2 * nu**2 * f_ul / const.c.cgs.value**2 * e_lower
-            transition_probabilities_dict[P_INTERNAL_UP] = f_lu * e_lower / (const.h.cgs.value * nu)
-
-            macro_atom.append((atomic_number, ion_number, level_number_upper, level_number_lower,
-                                    line_id, P_EMISSION_DOWN, transition_probabilities_dict[P_EMISSION_DOWN]))
-            macro_atom.append((atomic_number, ion_number, level_number_upper, level_number_lower,
-                                    line_id, P_INTERNAL_DOWN, transition_probabilities_dict[P_INTERNAL_DOWN]))
-            macro_atom.append((atomic_number, ion_number, level_number_lower, level_number_upper,
-                                    line_id, P_INTERNAL_UP, transition_probabilities_dict[P_INTERNAL_UP]))
-
-        macro_atom = np.array(macro_atom, dtype=macro_atom_dtype)
-        macro_atom = pd.DataFrame(macro_atom)
-
-        macro_atom = macro_atom.sort_values(["atomic_number", "ion_number", "source_level_number"])
-
-        self.macro_atom = macro_atom
-
-    @property
-    def macro_atom_prepared(self):
-        """
-            Prepare the DataFrame with macro atom data for TARDIS
-            Returns
-            -------
-            macro_atom_prepared : pandas.DataFrame
-                DataFrame with the *macro atom data* with:
-                    index: none;
-                    columns: atomic_number, ion_number, source_level_number, destination_level_number,
-                        transition_line_id, transition_type, transition_probability.
-            Notes:
-                Refer to the docs: http://tardis.readthedocs.io/en/latest/physics/plasma/macroatom.html
-        """
-
-        macro_atom_prepared = self.macro_atom.loc[:, [
-            "atomic_number",
-            "ion_number", "source_level_number", "target_level_number",
-            "transition_type", "transition_probability",
-            "transition_line_id"]].copy()
-
-        # ToDo: choose between `target_level_number` and
-        # `destination_level_number` Rename `target_level_number` to
-        # `destination_level_number` used in TARDIS Personally, I think
-        # `target_level_number` is better so I use it in Carsus.
-        macro_atom_prepared = macro_atom_prepared.rename(columns={
-            "target_level_number": "destination_level_number"})
-
-        macro_atom_prepared = macro_atom_prepared.reset_index(drop=True)
-
-        return macro_atom_prepared
-
-    def _create_macro_atom_references(self):
-        """
-            Create a DataFrame containing *macro atom reference* data.
-
-            Returns
-            -------
-            macro_atom_reference : pandas.DataFrame
-                DataFrame with:
-                index: no index;
-                and columns: atomic_number, ion_number, source_level_number, count_down, count_up, count_total
-        """
-        macro_atom_references = self.levels.rename(columns={"level_number": "source_level_number"}).\
-                                       loc[:, ["atomic_number", "ion_number", "source_level_number", "level_id"]]
-
-        count_down = self.lines.groupby("upper_level_id").size()
-        count_down.name = "count_down"
-
-        count_up = self.lines.groupby("lower_level_id").size()
-        count_up.name = "count_up"
-
-        macro_atom_references = macro_atom_references.join(count_down, on="level_id").join(count_up, on="level_id")
-        macro_atom_references = macro_atom_references.drop("level_id", axis=1)
-
-        macro_atom_references = macro_atom_references.fillna(0)
-        macro_atom_references["count_total"] = 2*macro_atom_references["count_down"] + macro_atom_references["count_up"]
-
-        # Convert to int
-        macro_atom_references["count_down"] = macro_atom_references["count_down"].astype(np.int)
-        macro_atom_references["count_up"] = macro_atom_references["count_up"].astype(np.int)
-        macro_atom_references["count_total"] = macro_atom_references["count_total"].astype(np.int)
-
-        self.macro_atom_references = macro_atom_references
-
-    @property
-    def macro_atom_references_prepared(self):
-        """
-            Prepare the DataFrame with macro atom references for TARDIS
-
-            Returns
-            -------
-            macro_atom_references_prepared : pandas.DataFrame
-                DataFrame with:
-                    index: none;
-                    columns: atomic_number, ion_number, source_level_number, count_down, count_up, count_total.
-        """
-        macro_atom_references_prepared = self.macro_atom_references.loc[:, [
-            "atomic_number", "ion_number", "source_level_number", "count_down",
-            "count_up", "count_total"]].copy()
-
-        macro_atom_references_prepared.set_index(
-                ['atomic_number', 'ion_number', 'source_level_number'],
-                inplace=True)
-
-        return macro_atom_references_prepared
-
     def to_hdf(self, fname):
         """Dump the `base` attribute into an HDF5 file
 
@@ -922,5 +773,3 @@ class GFALL(BaseParser):
         with pd.HDFStore(fname, 'a') as f:
             f.put('/levels', self.levels_prepared)
             f.put('/lines', self.lines_prepared)
-            f.put('/macro_atom_data', self.macro_atom_prepared)
-            f.put('/macro_atom_references', self.macro_atom_references_prepared)

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -521,9 +521,18 @@ class GFALL(BaseParser):
         return pd.DataFrame(data=fully_ionized_levels)
 
     def _get_all_lines_data(self):
+        """ Returns the same output than `AtomData._get_all_lines_data()` """  
         gf = self.gfall_reader
-        lines = gf.lines.reset_index().join(self.ions_df, how="inner", on=["atomic_number", "ion_charge"]).\
-                                          set_index(["atomic_number", "ion_charge"])
+
+        df_list = []
+        for ion in self.ions:
+            df = gf.lines.loc[ion]
+            df = df.reset_index()
+            df['level_index_lower'] = 0  # FIXME: we need levels data
+            df['level_index_upper'] = 1  # FIXME: we need levels data
+            df_list.append(df)
+        
+        lines = pd.concat(df_list)
         lines['line_id'] = range(1, len(lines)+1)
         lines['loggf'] = lines['gf'].apply(np.log10)
 

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -688,3 +688,52 @@ class GFALL(BaseParser):
 
         self.lines = lines
         self.levels = levels
+
+    @property
+    def levels_prepared(self):
+        """
+        Prepare the DataFrame with levels for TARDIS
+
+        Returns
+        -------
+        levels_prepared: pandas.DataFrame
+            DataFrame with:
+                index: none;
+                columns: atomic_number, ion_number, level_number, energy[eV], g[1], metastable.
+        """
+
+        levels_prepared = self.levels.loc[:, [
+            "atomic_number", "ion_number", "level_number",
+            "energy", "g", "metastable"]].copy()
+
+        # Set index
+        levels_prepared.set_index(
+                ["atomic_number", "ion_number", "level_number"], inplace=True)
+
+        return levels_prepared
+
+    @property
+    def lines_prepared(self):
+        """
+            Prepare the DataFrame with lines for TARDIS
+
+            Returns
+            -------
+            lines_prepared : pandas.DataFrame
+                DataFrame with:
+                    index: none;
+                    columns: line_id, atomic_number, ion_number, level_number_lower, level_number_upper,
+                             wavelength[angstrom], nu[Hz], f_lu[1], f_ul[1], B_ul[?], B_ul[?], A_ul[1/s].
+        """
+
+        lines_prepared = self.lines.loc[:, [
+            "line_id", "wavelength", "atomic_number", "ion_number",
+            "f_ul", "f_lu", "level_number_lower", "level_number_upper",
+            "nu", "B_lu", "B_ul", "A_ul"]].copy()
+
+        # Set the index
+        lines_prepared.set_index([
+                    "atomic_number", "ion_number",
+                    "level_number_lower", "level_number_upper"], inplace=True)
+
+        return lines_prepared

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -485,7 +485,7 @@ class GFALL(BaseParser):
         self.ions = parse_selected_species(ions)
         self.gfall_reader = GFALLReader(fname)
         self._create_ionization_data()
-        self._prepare_levels()
+        self._create_levels_lines()
 
     def _create_ionization_data(self):
         atoms = set([convert_atomic_number2symbol(i[0]) for i in self.ions])
@@ -594,8 +594,8 @@ class GFALL(BaseParser):
 
         return levels
 
-    def _prepare_levels(self):
-        """ Returns almost the same output than `AtomData.levels` (no metastable flags) """
+    def _create_levels_lines(self):
+        """ Returns almost the same output than `AtomData.create_levels_lines` method """
         levels_all = self._get_all_levels_data().reset_index()
         ionization_energies = self.ionization_energies.reset_index()
         ionization_energies['ion_number'] -= 1

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -484,15 +484,9 @@ class GFALL(BaseParser):
     def __init__(self, fname, ions):
         self.ions = parse_selected_species(ions)
         self.gfall_reader = GFALLReader(fname)
-        self._create_ions_df()
         self._create_ionization_data()
         self._prepare_levels()
 
-    def _create_ions_df(self):
-        ions_df = pd.DataFrame.from_records(self.ions, columns=["atomic_number", "ion_charge"])
-        ions_df = ions_df.set_index(['atomic_number', 'ion_charge'])
-        self.ions_df = ions_df
-    
     def _create_ionization_data(self):
         atoms = set([convert_atomic_number2symbol(i[0]) for i in self.ions])
         atoms = ', '.join(atoms)
@@ -579,7 +573,9 @@ class GFALL(BaseParser):
         gf.levels['g'] = 2*gf.levels['j'] + 1
         gf.levels['g'] = gf.levels['g'].map(np.int)
 
-        levels = gf.levels.reset_index().join(self.ions_df, how="inner", on=["atomic_number", "ion_charge"]).\
+        ions_df = pd.DataFrame.from_records(self.ions, columns=["atomic_number", "ion_charge"])
+        ions_df = ions_df.set_index(['atomic_number', 'ion_charge'])
+        levels = gf.levels.reset_index().join(ions_df, how="inner", on=["atomic_number", "ion_charge"]).\
                                           set_index(["atomic_number", "ion_charge"])
         levels = levels.drop(columns=['j', 'label', 'method'])
         levels['level_id'] = range(1, len(levels)+1)

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -552,9 +552,14 @@ class GFALL(BaseParser):
         df_list = []
 
         for ion in self.ions:
-            df = gf.lines.loc[ion]
-            df = df.reset_index()
 
+            try: 
+                df = gf.lines.loc[ion]
+
+            except (KeyError, TypeError) as e:
+                continue
+
+            df = df.reset_index()
             lvl_index2id = levels.set_index(['atomic_number', 'ion_number']).loc[ion]
             lvl_index2id = lvl_index2id.reset_index()
             lvl_index2id = lvl_index2id[['level_id']]

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -604,7 +604,10 @@ class GFALL(BaseParser):
         levels_w_ionization_energies = pd.merge(levels_all, ionization_energies, how='left', \
             on=["atomic_number", "ion_number"])
         mask = levels_w_ionization_energies["energy"] < levels_w_ionization_energies["ionization_energy"]
+
         levels = levels_w_ionization_energies[mask].copy()
+        levels = levels.set_index('level_id').sort_values(by=['atomic_number', 'ion_number'])
+        levels = levels.drop(columns='ionization_energy')
 
         # Creating levels numbers
         levels = levels.sort_values(["atomic_number", "ion_number", "energy", "g"])
@@ -614,9 +617,10 @@ class GFALL(BaseParser):
 
         # Create `metastable` column with False as default
         levels['metastable'] = False
-        levels = levels[['atomic_number', 'energy', 'g', 'ion_number', 'level_id', \
+        levels = levels[['atomic_number', 'energy', 'g', 'ion_number', \
             'level_number', 'metastable']]
 
+        levels = levels.reset_index()
         # Create and append artificial levels for fully ionized ions
         artificial_fully_ionized_levels = self._create_artificial_fully_ionized(levels)
         levels = levels.append(artificial_fully_ionized_levels, ignore_index=True)

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -18,6 +18,10 @@ from carsus.io.nist.ionization import NISTIonizationEnergies
 
 GFALL_AIR_THRESHOLD = 200  # [nm], wavelengths above this value are given in air
 
+P_EMISSION_DOWN = -1
+P_INTERNAL_DOWN = 0
+P_INTERNAL_UP = 1
+
 logger = logging.getLogger(__name__)
 
 class GFALLReader(object):
@@ -502,6 +506,8 @@ class GFALL(BaseParser):
         self.levels_all = self._get_all_levels_data().reset_index()
         self.lines_all = self._get_all_lines_data(self.levels_all)
         self._create_levels_lines()
+        self._create_macro_atom()
+        self._create_macro_atom_references()
 
     def _create_ionization_data(self):
         atoms = set([convert_atomic_number2symbol(i[0]) for i in self.ions])
@@ -757,6 +763,148 @@ class GFALL(BaseParser):
 
         return lines_prepared
 
+    def _create_macro_atom(self):
+        """
+            Create a DataFrame containing *macro atom* data.
+
+            Returns
+            -------
+            macro_atom: pandas.DataFrame
+                DataFrame with:
+                    index: none;
+                    columns: atomic_number, ion_number, source_level_number, target_level_number,
+                        transition_line_id, transition_type, transition_probability.
+
+            Notes:
+                Refer to the docs: http://tardis.readthedocs.io/en/latest/physics/plasma/macroatom.html
+
+        """
+        # Exclude artificially created levels from levels
+        levels = self.levels.loc[self.levels["level_id"] != -1].set_index("level_id")
+
+        lvl_energy_lower = levels.rename(columns={"energy": "energy_lower"}).loc[:, ["energy_lower"]]
+        lvl_energy_upper = levels.rename(columns={"energy": "energy_upper"}).loc[:, ["energy_upper"]]
+
+        lines = self.lines.set_index("line_id")
+        lines = lines.join(lvl_energy_lower, on="lower_level_id").join(lvl_energy_upper, on="upper_level_id")
+
+        macro_atom = list()
+        macro_atom_dtype = [("atomic_number", np.int), ("ion_number", np.int),
+                            ("source_level_number", np.int), ("target_level_number", np.int),
+                            ("transition_line_id", np.int), ("transition_type", np.int), ("transition_probability", np.float)]
+
+        for line_id, row in lines.iterrows():
+            atomic_number, ion_number = row["atomic_number"], row["ion_number"]
+            level_number_lower, level_number_upper = row["level_number_lower"], row["level_number_upper"]
+            nu = row["nu"]
+            f_ul, f_lu = row["f_ul"], row["f_lu"]
+            e_lower, e_upper = row["energy_lower"], row["energy_upper"]
+
+            transition_probabilities_dict = dict()  # type : probability
+            transition_probabilities_dict[P_EMISSION_DOWN] = 2 * nu**2 * f_ul / const.c.cgs.value**2 * (e_upper - e_lower)
+            transition_probabilities_dict[P_INTERNAL_DOWN] = 2 * nu**2 * f_ul / const.c.cgs.value**2 * e_lower
+            transition_probabilities_dict[P_INTERNAL_UP] = f_lu * e_lower / (const.h.cgs.value * nu)
+
+            macro_atom.append((atomic_number, ion_number, level_number_upper, level_number_lower,
+                                    line_id, P_EMISSION_DOWN, transition_probabilities_dict[P_EMISSION_DOWN]))
+            macro_atom.append((atomic_number, ion_number, level_number_upper, level_number_lower,
+                                    line_id, P_INTERNAL_DOWN, transition_probabilities_dict[P_INTERNAL_DOWN]))
+            macro_atom.append((atomic_number, ion_number, level_number_lower, level_number_upper,
+                                    line_id, P_INTERNAL_UP, transition_probabilities_dict[P_INTERNAL_UP]))
+
+        macro_atom = np.array(macro_atom, dtype=macro_atom_dtype)
+        macro_atom = pd.DataFrame(macro_atom)
+
+        macro_atom = macro_atom.sort_values(["atomic_number", "ion_number", "source_level_number"])
+
+        self.macro_atom = macro_atom
+
+    @property
+    def macro_atom_prepared(self):
+        """
+            Prepare the DataFrame with macro atom data for TARDIS
+            Returns
+            -------
+            macro_atom_prepared : pandas.DataFrame
+                DataFrame with the *macro atom data* with:
+                    index: none;
+                    columns: atomic_number, ion_number, source_level_number, destination_level_number,
+                        transition_line_id, transition_type, transition_probability.
+            Notes:
+                Refer to the docs: http://tardis.readthedocs.io/en/latest/physics/plasma/macroatom.html
+        """
+
+        macro_atom_prepared = self.macro_atom.loc[:, [
+            "atomic_number",
+            "ion_number", "source_level_number", "target_level_number",
+            "transition_type", "transition_probability",
+            "transition_line_id"]].copy()
+
+        # ToDo: choose between `target_level_number` and
+        # `destination_level_number` Rename `target_level_number` to
+        # `destination_level_number` used in TARDIS Personally, I think
+        # `target_level_number` is better so I use it in Carsus.
+        macro_atom_prepared = macro_atom_prepared.rename(columns={
+            "target_level_number": "destination_level_number"})
+
+        macro_atom_prepared = macro_atom_prepared.reset_index(drop=True)
+
+        return macro_atom_prepared
+
+    def _create_macro_atom_references(self):
+        """
+            Create a DataFrame containing *macro atom reference* data.
+
+            Returns
+            -------
+            macro_atom_reference : pandas.DataFrame
+                DataFrame with:
+                index: no index;
+                and columns: atomic_number, ion_number, source_level_number, count_down, count_up, count_total
+        """
+        macro_atom_references = self.levels.rename(columns={"level_number": "source_level_number"}).\
+                                       loc[:, ["atomic_number", "ion_number", "source_level_number", "level_id"]]
+
+        count_down = self.lines.groupby("upper_level_id").size()
+        count_down.name = "count_down"
+
+        count_up = self.lines.groupby("lower_level_id").size()
+        count_up.name = "count_up"
+
+        macro_atom_references = macro_atom_references.join(count_down, on="level_id").join(count_up, on="level_id")
+        macro_atom_references = macro_atom_references.drop("level_id", axis=1)
+
+        macro_atom_references = macro_atom_references.fillna(0)
+        macro_atom_references["count_total"] = 2*macro_atom_references["count_down"] + macro_atom_references["count_up"]
+
+        # Convert to int
+        macro_atom_references["count_down"] = macro_atom_references["count_down"].astype(np.int)
+        macro_atom_references["count_up"] = macro_atom_references["count_up"].astype(np.int)
+        macro_atom_references["count_total"] = macro_atom_references["count_total"].astype(np.int)
+
+        self.macro_atom_references = macro_atom_references
+
+    @property
+    def macro_atom_references_prepared(self):
+        """
+            Prepare the DataFrame with macro atom references for TARDIS
+
+            Returns
+            -------
+            macro_atom_references_prepared : pandas.DataFrame
+                DataFrame with:
+                    index: none;
+                    columns: atomic_number, ion_number, source_level_number, count_down, count_up, count_total.
+        """
+        macro_atom_references_prepared = self.macro_atom_references.loc[:, [
+            "atomic_number", "ion_number", "source_level_number", "count_down",
+            "count_up", "count_total"]].copy()
+
+        macro_atom_references_prepared.set_index(
+                ['atomic_number', 'ion_number', 'source_level_number'],
+                inplace=True)
+
+        return macro_atom_references_prepared
 
     def to_hdf(self, fname):
         """Dump the `base` attribute into an HDF5 file


### PR DESCRIPTION
Trying to get the same DataFrames obtained with the old SQL-based classes.

- [x] Match `_get_all_levels_data` with `AtomData` method of the same name
- [x] Match `_get_all_lines_data` with `AtomData` method of the same name
- [x] Match `levels` attribute with `AtomData` attribute of the same name
- [x] Match `lines` attribute with `AtomData` attribute of the same name
- [x] Match `levels_prepared` match with `AtomData` attribute of the same name
- [x] Match `lines_prepared` match with `AtomData` attribute of the same name

https://nbviewer.jupyter.org/gist/epassaro/82be42e2491511c07bb566354927a780?flush_cache=true

- [x] Add `to_hdf` method
- [x] Fix for missing ions in `gfall.dat`
- [x] Figure out issue with `He I`. Why `.drop_duplicates()` is not dropping level 3?
- [x] Add docstrings
- [ ] Ready to merge