### PR TITLE
Chianti levels and lines for the new API

### DIFF
--- a/carsus/io/chianti_/__init__.py
+++ b/carsus/io/chianti_/__init__.py
@@ -1,1 +1,3 @@
-from carsus.io.chianti_.chianti_ import ChiantiIonReader, ChiantiIngester
+from carsus.io.chianti_.chianti_ import (ChiantiIonReader,
+                                         ChiantiIngester, 
+                                         ChiantiReader)

--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -1,3 +1,4 @@
+import logging
 import pandas as pd
 import numpy as np
 import pickle
@@ -14,6 +15,8 @@ from carsus.util import convert_atomic_number2symbol, parse_selected_species
 from carsus.model import DataSource, Ion, Level, LevelEnergy,\
     Line, LineGFValue, LineAValue, LineWavelength, MEDIUM_VACUUM, \
     ECollision, ECollisionEnergy, ECollisionGFValue, ECollisionTempStrength
+
+logger = logging.getLogger(__name__)
 
 # Compatibility with older versions and pip versions:
 try:
@@ -547,7 +550,13 @@ class ChiantiReader:
             ch_ion = convert_species_tuple2chianti_str(ion)
             reader = ChiantiIonReader(ch_ion)
 
-            lvl = reader.levels
+            try:
+                lvl = reader.levels
+
+            except ChiantiIonReaderError:
+                logger.info('No level data for {}'.format(ch_ion))
+                continue
+
             lvl['atomic_number'] = ion[0]
             lvl['ion_number'] = ion[1]
 

--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -12,7 +12,7 @@ from carsus.io.base import IngesterError
 from carsus.io.util import convert_species_tuple2chianti_str
 from carsus.util import convert_atomic_number2symbol, parse_selected_species
 from carsus.model import DataSource, Ion, Level, LevelEnergy,\
-    Line,LineGFValue, LineAValue, LineWavelength, MEDIUM_VACUUM, \
+    Line, LineGFValue, LineAValue, LineWavelength, MEDIUM_VACUUM, \
     ECollision, ECollisionEnergy, ECollisionGFValue, ECollisionTempStrength
 
 # Compatibility with older versions and pip versions:
@@ -136,8 +136,10 @@ class ChiantiIonReader(object):
 
     @property
     def last_bound_level(self):
-        ionization_potential = u.eV.to(u.Unit("cm-1"), value=self.ion.Ip, equivalencies=u.spectral())
-        last_row = self.levels.loc[self.levels['energy'] < ionization_potential].tail(1)
+        ionization_potential = u.eV.to(
+            u.Unit("cm-1"), value=self.ion.Ip, equivalencies=u.spectral())
+        last_row = self.levels.loc[self.levels['energy']
+                                   < ionization_potential].tail(1)
         return last_row.index[0]
 
     @property
@@ -151,8 +153,10 @@ class ChiantiIonReader(object):
             but due to some bug in pandas out-of-range rows are included in the resulting DataFrame.
         """
         transitions = transitions.reset_index()
-        transitions = transitions.loc[transitions["upper_level_index"] <= self.last_bound_level]
-        transitions = transitions.set_index(["lower_level_index", "upper_level_index"])
+        transitions = transitions.loc[transitions["upper_level_index"]
+                                      <= self.last_bound_level]
+        transitions = transitions.set_index(
+            ["lower_level_index", "upper_level_index"])
         transitions = transitions.sort_index()
         return transitions
 
@@ -171,7 +175,8 @@ class ChiantiIonReader(object):
         try:
             elvlc = self.ion.Elvlc
         except AttributeError:
-            raise ChiantiIonReaderError("No levels data is available for ion {}".format(self.ion.Spectroscopic))
+            raise ChiantiIonReaderError(
+                "No levels data is available for ion {}".format(self.ion.Spectroscopic))
 
         levels_dict = {}
 
@@ -188,10 +193,12 @@ class ChiantiIonReader(object):
         levels = pd.DataFrame(levels_dict)
 
         # Replace empty labels with NaN
-        levels.loc[:, "label"] = levels["label"].replace(r'\s+', np.nan, regex=True)
+        levels.loc[:, "label"] = levels["label"].replace(
+            r'\s+', np.nan, regex=True)
 
         # Extract configuration and term from the "pretty" column
-        levels[["term", "configuration"]] = levels["pretty"].str.rsplit(' ', expand=True, n=1)
+        levels[["term", "configuration"]] = levels["pretty"].str.rsplit(
+            ' ', expand=True, n=1)
         levels = levels.drop("pretty", axis=1)
 
         levels = levels.set_index("level_index")
@@ -204,7 +211,8 @@ class ChiantiIonReader(object):
         try:
             wgfa = self.ion.Wgfa
         except AttributeError:
-            raise ChiantiIonReaderError("No lines data is available for ion {}".format(self.ion.Spectroscopic))
+            raise ChiantiIonReaderError(
+                "No lines data is available for ion {}".format(self.ion.Spectroscopic))
 
         lines_dict = {}
 
@@ -238,7 +246,8 @@ class ChiantiIonReader(object):
         try:
             scups = self.ion.Scups
         except AttributeError:
-            raise ChiantiIonReaderError("No collision data is available for ion {}".format(self.ion.Spectroscopic))
+            raise ChiantiIonReaderError(
+                "No collision data is available for ion {}".format(self.ion.Spectroscopic))
 
         collisions_dict = {}
 
@@ -247,7 +256,8 @@ class ChiantiIonReader(object):
 
         collisions = pd.DataFrame(collisions_dict)
 
-        collisions = collisions.set_index(["lower_level_index", "upper_level_index"])
+        collisions = collisions.set_index(
+            ["lower_level_index", "upper_level_index"])
         collisions = collisions.sort_index()
 
         return collisions
@@ -283,8 +293,8 @@ class ChiantiIngester(object):
     def __init__(self, session, ions=None, ds_short_name=None):
         if ds_short_name is None:
             ds_short_name = '{}_v{}'.format(
-                    self.ds_prefix,
-                    masterlist_version)
+                self.ds_prefix,
+                masterlist_version)
 
         self.session = session
         # ToDo write a parser for Spectral Notation
@@ -295,7 +305,8 @@ class ChiantiIngester(object):
             try:
                 ions = parse_selected_species(ions)
             except ParseException:
-                raise ValueError('Input is not a valid species string {}'.format(ions))
+                raise ValueError(
+                    'Input is not a valid species string {}'.format(ions))
             self.ions = [convert_species_tuple2chianti_str(_) for _ in ions]
         else:
             self.ions = masterlist_ions
@@ -306,7 +317,8 @@ class ChiantiIngester(object):
             else:
                 print("Ion {0} is not available".format(ion))
 
-        self.data_source = DataSource.as_unique(self.session, short_name=ds_short_name)
+        self.data_source = DataSource.as_unique(
+            self.session, short_name=ds_short_name)
         # To get the id if a new data source was created
         if self.data_source.data_source_id is None:
             self.session.flush()
@@ -336,17 +348,20 @@ class ChiantiIngester(object):
         for rdr in self.ion_readers:
 
             atomic_number = rdr.ion.Z
-            ion_charge = rdr.ion.Ion -1
+            ion_charge = rdr.ion.Ion - 1
 
-            ion = Ion.as_unique(self.session, atomic_number=atomic_number, ion_charge=ion_charge)
+            ion = Ion.as_unique(
+                self.session, atomic_number=atomic_number, ion_charge=ion_charge)
 
             try:
                 bound_levels = rdr.bound_levels
             except ChiantiIonReaderError:
-                print("Levels not found for ion {} {}".format(convert_atomic_number2symbol(atomic_number), ion_charge))
+                print("Levels not found for ion {} {}".format(
+                    convert_atomic_number2symbol(atomic_number), ion_charge))
                 continue
 
-            print("Ingesting levels for {} {}".format(convert_atomic_number2symbol(atomic_number), ion_charge))
+            print("Ingesting levels for {} {}".format(
+                convert_atomic_number2symbol(atomic_number), ion_charge))
 
             # ToDo: Determine parity from configuration
 
@@ -377,15 +392,18 @@ class ChiantiIngester(object):
             atomic_number = rdr.ion.Z
             ion_charge = rdr.ion.Ion - 1
 
-            ion = Ion.as_unique(self.session, atomic_number=atomic_number, ion_charge=ion_charge)
+            ion = Ion.as_unique(
+                self.session, atomic_number=atomic_number, ion_charge=ion_charge)
 
             try:
                 bound_lines = rdr.bound_lines
             except ChiantiIonReaderError:
-                print("Lines not found for ion {} {}".format(convert_atomic_number2symbol(atomic_number), ion_charge))
+                print("Lines not found for ion {} {}".format(
+                    convert_atomic_number2symbol(atomic_number), ion_charge))
                 continue
 
-            print("Ingesting lines for {} {}".format(convert_atomic_number2symbol(atomic_number), ion_charge))
+            print("Ingesting lines for {} {}".format(
+                convert_atomic_number2symbol(atomic_number), ion_charge))
 
             lvl_index2id = self.get_lvl_index2id(ion)
 
@@ -426,22 +444,26 @@ class ChiantiIngester(object):
 
     def ingest_collisions(self):
 
-        print("Ingesting collisions from {}".format(self.data_source.short_name))
+        print("Ingesting collisions from {}".format(
+            self.data_source.short_name))
 
         for rdr in self.ion_readers:
 
             atomic_number = rdr.ion.Z
             ion_charge = rdr.ion.Ion - 1
 
-            ion = Ion.as_unique(self.session, atomic_number=atomic_number, ion_charge=ion_charge)
+            ion = Ion.as_unique(
+                self.session, atomic_number=atomic_number, ion_charge=ion_charge)
 
             try:
                 bound_collisions = rdr.bound_collisions
             except ChiantiIonReaderError:
-                print("Collisions not found for ion {} {}".format(convert_atomic_number2symbol(atomic_number), ion_charge))
+                print("Collisions not found for ion {} {}".format(
+                    convert_atomic_number2symbol(atomic_number), ion_charge))
                 continue
 
-            print("Ingesting collisions for {} {}".format(convert_atomic_number2symbol(atomic_number), ion_charge))
+            print("Ingesting collisions for {} {}".format(
+                convert_atomic_number2symbol(atomic_number), ion_charge))
 
             lvl_index2id = self.get_lvl_index2id(ion)
 
@@ -477,7 +499,7 @@ class ChiantiIngester(object):
                 e_col.temp_strengths = [
                     ECollisionTempStrength(temp=temp, strength=strength)
                     for temp, strength in zip(row["temperatures"], row["collision_strengths"])
-                    ]
+                ]
 
                 self.session.add(e_col)
 
@@ -495,8 +517,24 @@ class ChiantiIngester(object):
             self.ingest_collisions()
             self.session.flush()
 
+
 class ChiantiReader:
+    """
+        Class for extracting lines and levels data from Chianti.
+        Mimics the GFALLReader class.
+
+        Attributes
+        ----------
+        levels: DataFrame
+        lines: DataFrame
+    """
+
     def __init__(self, ions):
+        """
+        Parameters
+        ----------
+        ions : string
+        """
         self.ions = parse_selected_species(ions)
         self._get_levels_lines()
 
@@ -527,28 +565,29 @@ class ChiantiReader:
         levels = levels.rename(columns={'J': 'j'})
         levels['method'] = None
         levels = levels.reset_index()
-        levels = levels.set_index(['atomic_number', 'ion_number', 'level_index'])
+        levels = levels.set_index(
+            ['atomic_number', 'ion_number', 'level_index'])
         levels = levels[['energy', 'j', 'label', 'method']]
 
         lines = pd.concat(lns_list, sort=True)
         lines = lines.reset_index()
-        lines = lines.rename(columns={'lower_level_index': 'level_index_lower' , 
+        lines = lines.rename(columns={'lower_level_index': 'level_index_lower',
                                       'upper_level_index': 'level_index_upper',
                                       'gf_value': 'gf'})
 
         # I'm not sure why we need this workaround.
         # Kurucz levels starts from zero, Chianti from 1.
-        lines['level_index_lower'] = lines['level_index_lower'] -1
-        lines['level_index_upper'] = lines['level_index_upper'] -1
+        lines['level_index_lower'] = lines['level_index_lower'] - 1
+        lines['level_index_upper'] = lines['level_index_upper'] - 1
 
-        lines = lines.set_index(['atomic_number', 'ion_charge', 
+        lines = lines.set_index(['atomic_number', 'ion_charge',
                                  'level_index_lower', 'level_index_upper'])
         lines['energy_upper'] = None
         lines['energy_lower'] = None
         lines['j_upper'] = None
         lines['j_lower'] = None
         lines = lines[['energy_upper', 'j_upper', 'energy_lower', 'j_lower',
-                      'wavelength', 'gf']]
+                       'wavelength', 'gf']]
 
         self.levels = levels
         self.lines = lines

--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -558,7 +558,7 @@ class ChiantiReader:
                 continue
 
             lvl['atomic_number'] = ion[0]
-            lvl['ion_number'] = ion[1]
+            lvl['ion_charge'] = ion[1]
 
             # Index must start from zero
             lvl.index = range(0, len(lvl))
@@ -575,7 +575,7 @@ class ChiantiReader:
         levels['method'] = None
         levels = levels.reset_index()
         levels = levels.set_index(
-            ['atomic_number', 'ion_number', 'level_index'])
+            ['atomic_number', 'ion_charge', 'level_index'])
         levels = levels[['energy', 'j', 'label', 'method']]
 
         lines = pd.concat(lns_list, sort=True)

--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -542,6 +542,7 @@ class ChiantiReader:
         self.priority = priority
         self._get_levels_lines()
 
+    # TODO: write docstring
     def _get_levels_lines(self):
 
         lvl_list = []

--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -532,13 +532,14 @@ class ChiantiReader:
         lines: DataFrame
     """
 
-    def __init__(self, ions):
+    def __init__(self, ions, priority=10):
         """
         Parameters
         ----------
         ions : string
         """
         self.ions = parse_selected_species(ions)
+        self.priority = priority
         self._get_levels_lines()
 
     def _get_levels_lines(self):
@@ -573,10 +574,11 @@ class ChiantiReader:
         levels = pd.concat(lvl_list, sort=True)
         levels = levels.rename(columns={'J': 'j'})
         levels['method'] = None
+        levels['priority'] = self.priority
         levels = levels.reset_index()
         levels = levels.set_index(
             ['atomic_number', 'ion_charge', 'level_index'])
-        levels = levels[['energy', 'j', 'label', 'method']]
+        levels = levels[['energy', 'j', 'label', 'method', 'priority']]
 
         lines = pd.concat(lns_list, sort=True)
         lines = lines.reset_index()

--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -528,8 +528,8 @@ class ChiantiReader:
 
         Attributes
         ----------
-        levels: DataFrame
-        lines: DataFrame
+        levels : DataFrame
+        lines : DataFrame
     """
 
     def __init__(self, ions, priority=10):

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -278,8 +278,9 @@ class GFALLReader(object):
                 df_list.append(df)
 
             levels = pd.concat(df_list, sort=True)
-            levels.set_index(["atomic_number", "ion_charge",
-                              "level_index"], inplace=True)
+
+        levels.set_index(["atomic_number", "ion_charge",
+                          "level_index"], inplace=True)
 
         return levels
 
@@ -349,8 +350,9 @@ class GFALLReader(object):
                 df_list.append(df)
 
             lines = pd.concat(df_list, sort=True)
-            lines.set_index(['atomic_number', 'ion_charge',
-                             'level_index_lower', 'level_index_upper'], inplace=True)
+
+        lines.set_index(['atomic_number', 'ion_charge',
+                         'level_index_lower', 'level_index_upper'], inplace=True)
 
         return lines
 

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -51,7 +51,7 @@ class GFALLReader(object):
 
     default_unique_level_identifier = ['energy', 'j']
 
-    def __init__(self, fname, ions=None, unique_level_identifier=None):
+    def __init__(self, fname, ions=None, priority=10, unique_level_identifier=None):
         """
 
         Parameters
@@ -82,6 +82,8 @@ class GFALLReader(object):
 
         else:
             self.ions = None
+
+        self.priority = priority
 
     @property
     def gfall_raw(self):
@@ -281,6 +283,8 @@ class GFALLReader(object):
 
         levels.set_index(["atomic_number", "ion_charge",
                           "level_index"], inplace=True)
+
+        levels['priority'] = self.priority
 
         return levels
 

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -348,6 +348,7 @@ class GFALLReader(object):
         lines_upper_idx['level_index_upper'] = levels_unique_idxed['level_index']
         lines = lines_upper_idx.reset_index()
 
+        #TODO: move to staticmethod
         if self.ions is not None:
             df_list = []
             for ion in self.ions:

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -1,4 +1,5 @@
-import re, logging
+import re
+import logging
 
 import numpy as np
 import pandas as pd
@@ -12,9 +13,11 @@ from carsus.io.base import IngesterError
 from carsus.util import convert_atomic_number2symbol, parse_selected_species
 
 
-GFALL_AIR_THRESHOLD = 200  # [nm], wavelengths above this value are given in air
+# [nm], wavelengths above this value are given in air
+GFALL_AIR_THRESHOLD = 200
 
 logger = logging.getLogger(__name__)
+
 
 class GFALLReader(object):
     """
@@ -32,21 +35,22 @@ class GFALLReader(object):
     """
 
     gfall_fortran_format = ('F11.4,F7.3,F6.2,F12.3,F5.2,1X,A10,F12.3,F5.2,1X,'
-                             'A10,F6.2,F6.2,F6.2,A4,I2,I2,I3,F6.3,I3,F6.3,I5,I5,'
-                             '1X,I1,A1,1X,I1,A1,I1,A3,I5,I5,I6')
+                            'A10,F6.2,F6.2,F6.2,A4,I2,I2,I3,F6.3,I3,F6.3,I5,I5,'
+                            '1X,I1,A1,1X,I1,A1,I1,A3,I5,I5,I6')
 
     gfall_columns = ['wavelength', 'loggf', 'element_code', 'e_first', 'j_first',
-               'blank1', 'label_first', 'e_second', 'j_second', 'blank2',
-               'label_second', 'log_gamma_rad', 'log_gamma_stark',
-               'log_gamma_vderwaals', 'ref', 'nlte_level_no_first',
-               'nlte_level_no_second', 'isotope', 'log_f_hyperfine',
-               'isotope2', 'log_iso_abundance', 'hyper_shift_first',
-               'hyper_shift_second', 'blank3', 'hyperfine_f_first',
-               'hyperfine_note_first', 'blank4', 'hyperfine_f_second',
-               'hyperfine_note_second', 'line_strength_class', 'line_code',
-               'lande_g_first', 'lande_g_second', 'isotopic_shift']
+                     'blank1', 'label_first', 'e_second', 'j_second', 'blank2',
+                     'label_second', 'log_gamma_rad', 'log_gamma_stark',
+                     'log_gamma_vderwaals', 'ref', 'nlte_level_no_first',
+                     'nlte_level_no_second', 'isotope', 'log_f_hyperfine',
+                     'isotope2', 'log_iso_abundance', 'hyper_shift_first',
+                     'hyper_shift_second', 'blank3', 'hyperfine_f_first',
+                     'hyperfine_note_first', 'blank4', 'hyperfine_f_second',
+                     'hyperfine_note_second', 'line_strength_class', 'line_code',
+                     'lande_g_first', 'lande_g_second', 'isotopic_shift']
 
     default_unique_level_identifier = ['energy', 'j']
+
     def __init__(self, fname, unique_level_identifier=None):
         """
 
@@ -69,7 +73,6 @@ class GFALLReader(object):
                         'the gfall data has not been given. Defaulting to '
                         '["energy", "j"].')
             self.unique_level_identifier = self.default_unique_level_identifier
-
 
     @property
     def gfall_raw(self):
@@ -118,7 +121,6 @@ class GFALLReader(object):
         # FORMAT(F11.4,F7.3,F6.2,F12.3,F5.2,1X,A10,F12.3,F5.2,1X,A10,
         # 3F6.2,A4,2I2,I3,F6.3,I3,F6.3,2I5,1X,A1,A1,1X,A1,A1,i1,A3,2I5,I6)
 
-
         number_match = re.compile(r'\d+(\.\d+)?')
         type_match = re.compile(r'[FIXA]')
         type_dict = {'F': np.float64, 'I': np.int64, 'X': str, 'A': str}
@@ -128,10 +130,11 @@ class GFALLReader(object):
         field_widths = type_match.sub('', self.gfall_fortran_format)
         field_widths = map(int, re.sub(r'\.\d+', '', field_widths).split(','))
 
-        field_type_dict = {col:dtype for col, dtype in zip(self.gfall_columns, field_types)}
+        field_type_dict = {col: dtype for col,
+                           dtype in zip(self.gfall_columns, field_types)}
         gfall = pd.read_fwf(fname, widths=field_widths, skip_blank_lines=True,
                             names=self.gfall_columns, dtypes=field_type_dict)
-        #remove empty lines
+        # remove empty lines
         gfall = gfall[~gfall.isnull().all(axis=1)].reset_index(drop=True)
 
         return gfall
@@ -150,10 +153,9 @@ class GFALLReader(object):
                 a level DataFrame
         """
 
-
         gfall = gfall_raw if gfall_raw is not None else self.gfall_raw.copy()
-        gfall = gfall.rename(columns={'e_first':'energy_first',
-                                      'e_second':'energy_second'})
+        gfall = gfall.rename(columns={'e_first': 'energy_first',
+                                      'e_second': 'energy_second'})
         double_columns = [item.replace('_first', '') for item in gfall.columns if
                           item.endswith('first')]
 
@@ -167,7 +169,7 @@ class GFALLReader(object):
 
             gfall['{0}_lower'.format(column)] = data
 
-            data = pd.concat([gfall['{0}_first'.format(column)][~order_lower_upper], \
+            data = pd.concat([gfall['{0}_first'.format(column)][~order_lower_upper],
                               gfall['{0}_second'.format(column)][order_lower_upper]])
 
             gfall['{0}_upper'.format(column)] = data
@@ -238,7 +240,8 @@ class GFALLReader(object):
 
         levels = pd.concat([e_lower_levels[selected_columns],
                             e_upper_levels[selected_columns]])
-        unique_level_id = ['atomic_number', 'ion_charge'] + self.unique_level_identifier
+        unique_level_id = ['atomic_number', 'ion_charge'] + \
+            self.unique_level_identifier
 
         levels.drop_duplicates(unique_level_id, inplace=True)
         levels = levels.sort_values(['atomic_number', 'ion_charge', 'energy',
@@ -257,7 +260,8 @@ class GFALLReader(object):
         # levels["configuration"] = levels["configuration"].str.strip()
         # levels["term"] = levels["term"].str.strip()
 
-        levels.set_index(["atomic_number", "ion_charge", "level_index"], inplace=True)
+        levels.set_index(["atomic_number", "ion_charge",
+                          "level_index"], inplace=True)
         return levels
 
     def extract_lines(self, gfall=None, levels=None, selected_columns=None):
@@ -284,13 +288,16 @@ class GFALLReader(object):
 
         if selected_columns is None:
             selected_columns = ['atomic_number', 'ion_charge']
-            selected_columns += [item + '_lower' for item in self.unique_level_identifier]
-            selected_columns += [item + '_upper' for item in self.unique_level_identifier]
+            selected_columns += [item +
+                                 '_lower' for item in self.unique_level_identifier]
+            selected_columns += [item +
+                                 '_upper' for item in self.unique_level_identifier]
             selected_columns += ['wavelength', 'loggf']
 
-
-        logger.info('Extracting line data: {0}'.format(', '.join(selected_columns)))
-        unique_level_id = ['atomic_number', 'ion_charge'] + self.unique_level_identifier
+        logger.info('Extracting line data: {0}'.format(
+            ', '.join(selected_columns)))
+        unique_level_id = ['atomic_number', 'ion_charge'] + \
+            self.unique_level_identifier
         levels_idx = levels.reset_index()
         levels_idx = levels_idx.set_index(unique_level_id)
 
@@ -300,7 +307,8 @@ class GFALLReader(object):
 
         # Assigning levels to lines
 
-        levels_unique_idxed = self.levels.reset_index().set_index(['atomic_number', 'ion_charge'] + self.unique_level_identifier)
+        levels_unique_idxed = self.levels.reset_index().set_index(
+            ['atomic_number', 'ion_charge'] + self.unique_level_identifier)
 
         lines_lower_unique_idx = (['atomic_number', 'ion_charge'] +
                                   [item + '_lower' for item in self.unique_level_identifier])
@@ -328,7 +336,7 @@ class GFALLReader(object):
         with pd.HDFStore(fname, 'a') as f:
             if raw:
                 f.put(key, self.gfall_raw)
-            
+
             else:
                 f.put(key, self.gfall)
 
@@ -355,6 +363,7 @@ class GFALLIngester(object):
         ingest(session)
             Persists data into the database
     """
+
     def __init__(self, session, fname, ions=None, ds_short_name="ku_latest"):
         self.session = session
         self.gfall_reader = GFALLReader(fname)
@@ -362,13 +371,16 @@ class GFALLIngester(object):
             try:
                 ions = parse_selected_species(ions)
             except ParseException:
-                raise ValueError('Input is not a valid species string {}'.format(ions))
-            ions = pd.DataFrame.from_records(ions, columns=["atomic_number", "ion_charge"])
+                raise ValueError(
+                    'Input is not a valid species string {}'.format(ions))
+            ions = pd.DataFrame.from_records(
+                ions, columns=["atomic_number", "ion_charge"])
             self.ions = ions.set_index(['atomic_number', 'ion_charge'])
         else:
             self.ions = None
 
-        self.data_source = DataSource.as_unique(self.session, short_name=ds_short_name)
+        self.data_source = DataSource.as_unique(
+            self.session, short_name=ds_short_name)
         if self.data_source.data_source_id is None:  # To get the id if a new data source was created
             self.session.flush()
 
@@ -398,22 +410,25 @@ class GFALLIngester(object):
         # Select ions
         if self.ions is not None:
             levels = levels.reset_index().\
-                                  join(self.ions, how="inner",
-                                       on=["atomic_number", "ion_charge"]).\
-                                  set_index(["atomic_number", "ion_charge", "level_index"])
+                join(self.ions, how="inner",
+                     on=["atomic_number", "ion_charge"]).\
+                set_index(["atomic_number", "ion_charge", "level_index"])
 
         print("Ingesting levels from {}".format(self.data_source.short_name))
 
         for ion_index, ion_levels in levels.groupby(level=["atomic_number", "ion_charge"]):
 
             atomic_number, ion_charge = ion_index
-            ion = Ion.as_unique(self.session, atomic_number=atomic_number, ion_charge=ion_charge)
+            ion = Ion.as_unique(
+                self.session, atomic_number=atomic_number, ion_charge=ion_charge)
 
-            print("Ingesting levels for {} {}".format(convert_atomic_number2symbol(atomic_number), ion_charge))
+            print("Ingesting levels for {} {}".format(
+                convert_atomic_number2symbol(atomic_number), ion_charge))
 
             for index, row in ion_levels.iterrows():
 
-                level_index = index[2]  # index: (atomic_number, ion_charge, level_index)
+                # index: (atomic_number, ion_charge, level_index)
+                level_index = index[2]
 
                 ion.levels.append(
                     Level(level_index=level_index,
@@ -436,16 +451,19 @@ class GFALLIngester(object):
             lines = lines.reset_index(). \
                 join(self.ions, how="inner",
                      on=["atomic_number", "ion_charge"]). \
-                set_index(["atomic_number", "ion_charge", "level_index_lower", "level_index_upper"])
+                set_index(["atomic_number", "ion_charge",
+                           "level_index_lower", "level_index_upper"])
 
         print("Ingesting lines from {}".format(self.data_source.short_name))
 
         for ion_index, ion_lines in lines.groupby(level=["atomic_number", "ion_charge"]):
 
             atomic_number, ion_charge = ion_index
-            ion = Ion.as_unique(self.session, atomic_number=atomic_number, ion_charge=ion_charge)
+            ion = Ion.as_unique(
+                self.session, atomic_number=atomic_number, ion_charge=ion_charge)
 
-            print("Ingesting lines for {} {}".format(convert_atomic_number2symbol(atomic_number), ion_charge))
+            print("Ingesting lines for {} {}".format(
+                convert_atomic_number2symbol(atomic_number), ion_charge))
 
             lvl_index2id = self.get_lvl_index2id(ion)
 
@@ -490,4 +508,3 @@ class GFALLIngester(object):
         if lines:
             self.ingest_lines()
             self.session.flush()
-

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -51,7 +51,7 @@ class GFALLReader(object):
 
     default_unique_level_identifier = ['energy', 'j']
 
-    def __init__(self, fname, ions, unique_level_identifier=None):
+    def __init__(self, fname, ions=None, unique_level_identifier=None):
         """
 
         Parameters
@@ -79,8 +79,9 @@ class GFALLReader(object):
 
         if ions is not None:
             self.ions = parse_selected_species(ions)
+
         else:
-            self.ions = []
+            self.ions = None
 
     @property
     def gfall_raw(self):
@@ -268,16 +269,17 @@ class GFALLReader(object):
         # levels["configuration"] = levels["configuration"].str.strip()
         # levels["term"] = levels["term"].str.strip()
 
-        df_list = []
-        for ion in self.ions:
-            mask = (levels['atomic_number'] == ion[0]) & (
-                levels['ion_charge'] == ion[1])
-            df = levels[mask]
-            df_list.append(df)
+        if self.ions is not None:
+            df_list = []
+            for ion in self.ions:
+                mask = (levels['atomic_number'] == ion[0]) & (
+                    levels['ion_charge'] == ion[1])
+                df = levels[mask]
+                df_list.append(df)
 
-        levels = pd.concat(df_list, sort=True)
-        levels.set_index(["atomic_number", "ion_charge",
-                          "level_index"], inplace=True)
+            levels = pd.concat(df_list, sort=True)
+            levels.set_index(["atomic_number", "ion_charge",
+                              "level_index"], inplace=True)
 
         return levels
 
@@ -338,16 +340,17 @@ class GFALLReader(object):
         lines_upper_idx['level_index_upper'] = levels_unique_idxed['level_index']
         lines = lines_upper_idx.reset_index()
 
-        df_list = []
-        for ion in self.ions:
-            mask = (lines['atomic_number'] == ion[0]) & (
-                lines['ion_charge'] == ion[1])
-            df = lines[mask]
-            df_list.append(df)
+        if self.ions is not None:
+            df_list = []
+            for ion in self.ions:
+                mask = (lines['atomic_number'] == ion[0]) & (
+                    lines['ion_charge'] == ion[1])
+                df = lines[mask]
+                df_list.append(df)
 
-        lines = pd.concat(df_list, sort=True)
-        lines.set_index(['atomic_number', 'ion_charge',
-                         'level_index_lower', 'level_index_upper'], inplace=True)
+            lines = pd.concat(df_list, sort=True)
+            lines.set_index(['atomic_number', 'ion_charge',
+                             'level_index_lower', 'level_index_upper'], inplace=True)
 
         return lines
 

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -51,7 +51,8 @@ class GFALLReader(object):
 
     default_unique_level_identifier = ['energy', 'j']
 
-    def __init__(self, fname, ions=None, priority=10, unique_level_identifier=None):
+    def __init__(self, fname='http://kurucz.harvard.edu/linelists/gfall/gfall.dat', 
+                    ions=None, priority=10, unique_level_identifier=None):
         """
 
         Parameters

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -51,8 +51,9 @@ class GFALLReader(object):
 
     default_unique_level_identifier = ['energy', 'j']
 
-    def __init__(self, fname='http://kurucz.harvard.edu/linelists/gfall/gfall.dat', 
-                    ions=None, priority=10, unique_level_identifier=None):
+    def __init__(self, ions=None, 
+                 fname='http://kurucz.harvard.edu/linelists/gfall/gfall.dat',
+                 priority=10, unique_level_identifier=None):
         """
 
         Parameters
@@ -404,7 +405,7 @@ class GFALLIngester(object):
 
     def __init__(self, session, fname, ions=None, ds_short_name="ku_latest"):
         self.session = session
-        self.gfall_reader = GFALLReader(fname)
+        self.gfall_reader = GFALLReader(ions, fname)
         if ions is not None:
             try:
                 ions = parse_selected_species(ions)

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -268,9 +268,6 @@ class GFALLReader(object):
         # levels["configuration"] = levels["configuration"].str.strip()
         # levels["term"] = levels["term"].str.strip()
 
-        # levels.set_index(["atomic_number", "ion_charge",
-        #                  "level_index"], inplace=True)
-
         df_list = []
         for ion in self.ions:
             mask = (levels['atomic_number'] == ion[0]) & (
@@ -336,10 +333,21 @@ class GFALLReader(object):
                                   [item + '_upper' for item in self.unique_level_identifier])
         lines_lower_idx = lines.set_index(lines_lower_unique_idx)
         lines_lower_idx['level_index_lower'] = levels_unique_idxed['level_index']
-        lines_upper_idx = lines_lower_idx.reset_index().set_index(lines_upper_unique_idx)
+        lines_upper_idx = lines_lower_idx.reset_index().set_index(
+            lines_upper_unique_idx)
         lines_upper_idx['level_index_upper'] = levels_unique_idxed['level_index']
-        lines = lines_upper_idx.reset_index().set_index(
-            ['atomic_number', 'ion_charge', 'level_index_lower', 'level_index_upper'])
+        lines = lines_upper_idx.reset_index()
+
+        df_list = []
+        for ion in self.ions:
+            mask = (lines['atomic_number'] == ion[0]) & (
+                lines['ion_charge'] == ion[1])
+            df = lines[mask]
+            df_list.append(df)
+
+        lines = pd.concat(df_list, sort=True)
+        lines.set_index(['atomic_number', 'ion_charge',
+                         'level_index_lower', 'level_index_upper'], inplace=True)
 
         return lines
 

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -271,8 +271,9 @@ class GFALLReader(object):
         # ToDo: The commented block below does not work with all lines. Find a way to parse it.
         # levels[["configuration", "term"]] = levels["label"].str.split(expand=True)
         # levels["configuration"] = levels["configuration"].str.strip()
-        # levels["term"] = levels["term"].str.strip()
-
+        # levels["term"] = levels["term"].s
+        
+        # TODO: move to a staticmethod
         if self.ions is not None:
             df_list = []
             for ion in self.ions:

--- a/carsus/io/nist/weightscomp.py
+++ b/carsus/io/nist/weightscomp.py
@@ -202,7 +202,7 @@ class NISTWeightsComp(BaseParser):
         Dump the `base` attribute into an HDF5 file
 
     """
-    def __init__(self, atoms='H-U'):
+    def __init__(self, atoms='H-Pu'):
         input_data = download_weightscomp()
         self.parser = NISTWeightsCompPyparser(input_data=input_data)
         self._prepare_data(atoms)

--- a/carsus/io/nist/weightscomp.py
+++ b/carsus/io/nist/weightscomp.py
@@ -202,7 +202,7 @@ class NISTWeightsComp(BaseParser):
         Dump the `base` attribute into an HDF5 file
 
     """
-    def __init__(self, atoms=('H-Uuo')):
+    def __init__(self, atoms='H-Uuo'):
         input_data = download_weightscomp()
         self.parser = NISTWeightsCompPyparser(input_data=input_data)
         self._prepare_data(atoms)

--- a/carsus/io/nist/weightscomp.py
+++ b/carsus/io/nist/weightscomp.py
@@ -202,7 +202,7 @@ class NISTWeightsComp(BaseParser):
         Dump the `base` attribute into an HDF5 file
 
     """
-    def __init__(self, atoms):
+    def __init__(self, atoms=('H-Uuo')):
         input_data = download_weightscomp()
         self.parser = NISTWeightsCompPyparser(input_data=input_data)
         self._prepare_data(atoms)

--- a/carsus/io/nist/weightscomp.py
+++ b/carsus/io/nist/weightscomp.py
@@ -202,7 +202,7 @@ class NISTWeightsComp(BaseParser):
         Dump the `base` attribute into an HDF5 file
 
     """
-    def __init__(self, atoms='H-Uuo'):
+    def __init__(self, atoms='H-U'):
         input_data = download_weightscomp()
         self.parser = NISTWeightsCompPyparser(input_data=input_data)
         self._prepare_data(atoms)

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -39,7 +39,7 @@ class TARDISAtomData:
     def __init__(self,
                  ionization_energies,
                  gfall_reader,
-                 ions,
+                 gfall_ions,
                  chianti_reader=None,
                  chianti_ions=None,
                  lines_loggf_threshold=-3,
@@ -52,7 +52,7 @@ class TARDISAtomData:
             "lines_loggf_threshold": lines_loggf_threshold
         }
 
-        self.ions = parse_selected_species(ions)
+        self.gfall_ions = parse_selected_species(gfall_ions)
         self.ionization_energies = ionization_energies.base
 
         logger.info('Ingesting ground levels from NIST')
@@ -136,7 +136,7 @@ class TARDISAtomData:
 
         gf_list = []
         logger.info('Ingesting levels from GFALL')
-        for ion in self.ions:
+        for ion in self.gfall_ions:
             try:
                 df = gf.levels.loc[ion].copy()
 
@@ -222,7 +222,7 @@ class TARDISAtomData:
         start = 1
         gf_list = []
         logger.info('Ingesting lines from GFALL')
-        for ion in self.ions:
+        for ion in self.gfall_ions:
 
             try:
                 df = gf.lines.loc[ion]

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -56,6 +56,7 @@ class TARDISAtomData:
         self.ionization_energies = ionization_energies
         self.ground_levels = ionization_energies.get_ground_levels()
 
+        # TODO: make this piece of code more readable 
         gfall_ions = gfall_reader.levels.index.tolist()
         # Remove last element from tuple (MultiIndex has 3 elements)
         gfall_ions = [x[:-1] for x in gfall_ions]

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -77,6 +77,7 @@ class TARDISAtomData:
             mask = chianti_lvls.index.get_level_values(
                 'priority') > self.gfall_reader.priority
 
+            # TODO: make this piece of code more readable
             chianti_lvls = chianti_lvls[mask]
             chianti_ions = chianti_lvls.index.tolist()
             chianti_ions = [x[:-1] for x in chianti_ions]

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import pandas as pd
 import hashlib
@@ -14,6 +15,8 @@ GFALL_AIR_THRESHOLD = 200
 P_EMISSION_DOWN = -1
 P_INTERNAL_DOWN = 0
 P_INTERNAL_UP = 1
+
+logger = logging.getLogger(__name__)
 
 
 class TARDISAtomData:
@@ -51,6 +54,8 @@ class TARDISAtomData:
 
         self.ions = parse_selected_species(ions)
         self.ionization_energies = ionization_energies.base
+
+        logger.info('Ingesting ground levels from NIST')
         self.ground_levels = ionization_energies.get_ground_levels()
         self.gfall_reader = gfall_reader
 
@@ -130,6 +135,7 @@ class TARDISAtomData:
         ch = self.chianti_reader
 
         gf_list = []
+        logger.info('Ingesting levels from GFALL')
         for ion in self.ions:
             try:
                 df = gf.levels.loc[ion].copy()
@@ -143,6 +149,7 @@ class TARDISAtomData:
             gf_list.append(df)
 
         ch_list = []
+        logger.info('Ingesting levels from Chianti')
         for ion in self.chianti_ions:
             try:
                 df = ch.levels.loc[ion].copy()
@@ -214,6 +221,7 @@ class TARDISAtomData:
 
         start = 1
         gf_list = []
+        logger.info('Ingesting lines from GFALL')
         for ion in self.ions:
 
             try:
@@ -259,6 +267,7 @@ class TARDISAtomData:
             gf_list.append(df)
 
         ch_list = []
+        logger.info('Ingesting lines from Chianti')
         for ion in self.chianti_ions:
 
             try:

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -127,8 +127,9 @@ class TARDISAtomData:
     def _get_all_levels_data(self):
         """ Returns the same output than `AtomData._get_all_levels_data()` """
         gf = self.gfall_reader
-        gf_list = []
+        ch = self.chianti_reader
 
+        gf_list = []
         for ion in self.ions:
             try:
                 df = gf.levels.loc[ion].copy()
@@ -141,7 +142,6 @@ class TARDISAtomData:
             df['source'] = 'gfall'
             gf_list.append(df)
 
-        ch = self.chianti_reader
         ch_list = []
         ch_ions = []
         for ion in self.chianti_ions:
@@ -179,6 +179,7 @@ class TARDISAtomData:
             columns={'ion_charge': 'ion_number'}, inplace=True)
         ground_levels['source'] = 'nist'
 
+        # TODO: delete this block after creating a script that fixes GFALL typos
         # Fixes Ar II duplicated ground level. For Kurucz, ground state
         # has g=2, for NIST has g=4. We keep Kurucz.
 
@@ -210,17 +211,19 @@ class TARDISAtomData:
     def _get_all_lines_data(self, levels):
         """ Returns the same output than `AtomData._get_all_lines_data()` """
         gf = self.gfall_reader
-        gf_list = []
+        ch = self.chianti_reader
 
         gf_ions = [item for item in self.ions if item not in self.chianti_ions]
+        gf_list = []
         for ion in gf_ions:
 
             try:
                 df = gf.lines.loc[ion]
-                df['source'] = 'gfall'
 
             except (KeyError, TypeError):
                 continue
+
+            df['source'] = 'gfall'
 
             # TODO: move this piece of code to a staticmethod
             df = df.reset_index()
@@ -246,17 +249,16 @@ class TARDISAtomData:
             df['upper_level_id'] = pd.Series(upper_level_id)
             gf_list.append(df)
 
-        ch = self.chianti_reader
         ch_list = []
         for ion in self.chianti_ions:
 
             try:
                 df = ch.lines.loc[ion]
-                df['source'] = 'chianti'
 
             except (KeyError, TypeError):
                 continue
 
+            df['source'] = 'chianti'
             # TODO: move this piece of code to a staticmethod      
             df = df.reset_index()
             lvl_index2id = levels.set_index(

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -179,12 +179,13 @@ class TARDISAtomData:
         levels['level_id'] = range(1, len(levels)+1)
         levels = levels.set_index('level_id')
 
-        # Drop duplicated levels
-        mask = levels[['atomic_number', 'ion_number',	
-                       'energy', 'g']].duplicated(keep='last')	
+        # Deliberately keep the duplicated Chianti levelss
+        mask = (levels['source'] != 'chianti') & (	
+            levels[['atomic_number', 'ion_number',	
+                    'energy', 'g']].duplicated(keep='last'))	
         levels = levels[~mask]
 
-        # Keep higher priority levels over GFALLL: if levels with
+        # Keep higher priority levels over GFALL: if levels with
         # different source than 'gfall' made to this point should
         # be kept.
         for ion in self.chianti_ions:

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -184,7 +184,9 @@ class TARDISAtomData:
                        'energy', 'g']].duplicated(keep='last')	
         levels = levels[~mask]
 
-        # Keep Chianti levels over GFALL.
+        # Keep higher priority levels over GFALLL: if levels with
+        # different source than 'gfall' made to this point should
+        # be kept.
         for ion in self.chianti_ions:
             mask = (levels['source'] == 'gfall') & (
                 levels['atomic_number'] == ion[0]) & (

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -179,6 +179,11 @@ class TARDISAtomData:
         levels['level_id'] = range(1, len(levels)+1)
         levels = levels.set_index('level_id')
 
+        # Drop duplicated levels
+        mask = levels[['atomic_number', 'ion_number',	
+                       'energy', 'g']].duplicated(keep='last')	
+        levels = levels[~mask]
+
         # Keep Chianti levels over GFALL.
         for ion in self.chianti_ions:
             mask = (levels['source'] == 'gfall') & (

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -179,13 +179,6 @@ class TARDISAtomData:
         levels['level_id'] = range(1, len(levels)+1)
         levels = levels.set_index('level_id')
 
-        # Deliberately keep the duplicated Chianti levels
-        # until we finish this feature:
-        mask = (levels['source'] != 'chianti') & (
-            levels[['atomic_number', 'ion_number',
-                    'energy', 'g']].duplicated(keep='last'))
-        levels = levels[~mask]
-
         # Keep Chianti levels over GFALL.
         for ion in self.chianti_ions:
             mask = (levels['source'] == 'gfall') & (

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -305,18 +305,27 @@ class TARDISAtomData:
                             'j_lower', 'level_index_lower',
                             'level_index_upper'], inplace=True)
 
+
         lines.loc[lines['wavelength'] <=
                   GFALL_AIR_THRESHOLD, 'medium'] = MEDIUM_VACUUM
         lines.loc[lines['wavelength'] >
                   GFALL_AIR_THRESHOLD, 'medium'] = MEDIUM_AIR
-        lines['wavelength'] = lines['wavelength'].apply(lambda x: x*u.nm)
+
+        air_mask = lines['medium'] == MEDIUM_AIR
+        gfall_mask = lines['source'] == 'gfall'
+        chianti_mask = lines['source'] == 'chianti'
+
+        lines.loc[gfall_mask, 'wavelength'] = lines.loc[gfall_mask, 'wavelength'].apply(lambda x: x*u.nm)
+        lines.loc[chianti_mask, 'wavelength'] = lines.loc[chianti_mask, 'wavelength'].apply(lambda x: x*u.angstrom)
         lines['wavelength'] = lines['wavelength'].apply(
             lambda x: x.to('angstrom'))
         lines['wavelength'] = lines['wavelength'].apply(lambda x: x.value)
 
-        air_mask = lines['medium'] == MEDIUM_AIR
-        lines.loc[air_mask, 'wavelength'] = convert_wavelength_air2vacuum(
+
+        # Why not Chianti?
+        lines.loc[air_mask & gfall_mask, 'wavelength'] = convert_wavelength_air2vacuum(
             lines.loc[air_mask, 'wavelength'])
+
         lines.drop(columns=['medium'], inplace=True)
         lines = lines[['lower_level_id', 'upper_level_id',
                        'wavelength', 'gf', 'loggf', 'source']]

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -183,7 +183,7 @@ class TARDISAtomData:
             columns={'ion_charge': 'ion_number'}, inplace=True)
         ground_levels['source'] = 'nist'
 
-        # TODO: delete after creating a script that fixes GFALL typos
+        # TODO: delete after creating a script that fixes GFALL typos.
         # Fixes Ar II duplicated ground level. For Kurucz, ground state
         # has g=2, for NIST has g=4. We keep Kurucz.
 
@@ -227,7 +227,8 @@ class TARDISAtomData:
             try:
                 df = gf.lines.loc[ion]
 
-                # To match `line_id` field with the old API
+                # To match `line_id` field with the old API we keep
+                # track of how many GFALL lines we are skipping.
                 if ion in self.chianti_ions:
                     df['line_id'] = range(start, len(df) + start)
                     start += len(df)
@@ -305,7 +306,6 @@ class TARDISAtomData:
 
         df_list = gf_list + ch_list
         lines = pd.concat(df_list, sort=True)
-        # lines['line_id'] = range(1, len(lines)+1)
         lines['loggf'] = lines['gf'].apply(np.log10)
 
         lines.set_index('line_id', inplace=True)
@@ -330,7 +330,7 @@ class TARDISAtomData:
             lambda x: x.to('angstrom'))
         lines['wavelength'] = lines['wavelength'].apply(lambda x: x.value)
 
-        # Why not Chianti?
+        # Why not for Chianti?
         lines.loc[air_mask & gfall_mask,
                   'wavelength'] = convert_wavelength_air2vacuum(
             lines.loc[air_mask, 'wavelength'])

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -67,6 +67,7 @@ class TARDISAtomData:
         self.zeta_data = zeta_data
 
         # TODO: priorities should not be managed by the `init` method.
+        self.chianti_reader = chianti_reader
         if chianti_reader is not None:
             chianti_lvls = chianti_reader.levels.reset_index()
             chianti_lvls = chianti_lvls.set_index(
@@ -79,7 +80,6 @@ class TARDISAtomData:
             chianti_ions = chianti_lvls.index.tolist()
             chianti_ions = [x[:-1] for x in chianti_ions]
             chianti_ions = sorted(list(set(chianti_ions)))
-            self.chianti_reader = chianti_reader
             self.chianti_ions = chianti_ions
 
         else:
@@ -150,8 +150,11 @@ class TARDISAtomData:
         gf_levels = self.gfall_reader.levels.reset_index()
         gf_levels['source'] = 'gfall'
 
-        ch_levels = self.chianti_reader.levels.reset_index()
-        ch_levels['source'] = 'chianti'
+        if self.chianti_reader is not None:
+            ch_levels = self.chianti_reader.levels.reset_index()
+            ch_levels['source'] = 'chianti'
+        else:
+            ch_levels = pd.DataFrame(columns=gf_levels.columns)
 
         levels = pd.concat([gf_levels, ch_levels], sort=True)
         levels['g'] = 2*levels['j'] + 1

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -175,13 +175,6 @@ class TARDISAtomData:
             columns={'ion_charge': 'ion_number'}, inplace=True)
         ground_levels['source'] = 'nist'
 
-        # TODO: delete after creating a script that fixes GFALL typos.
-        # Fixes Ar II duplicated ground level. For Kurucz, ground state
-        # has g=2, for NIST has g=4. We keep NIST.
-        mask = (ground_levels['atomic_number'] == 18) & (
-            ground_levels['ion_number'] == 1)
-        ground_levels.loc[mask, 'g'] = 4
-
         levels = pd.concat([ground_levels, levels], sort=True)
         levels['level_id'] = range(1, len(levels)+1)
         levels = levels.set_index('level_id')

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -179,9 +179,13 @@ class TARDISAtomData:
         levels['level_id'] = range(1, len(levels)+1)
         levels = levels.set_index('level_id')
 
-        # Deliberately keep the duplicated Chianti levelss
-        mask = (levels['source'] != 'chianti') & (	
-            levels[['atomic_number', 'ion_number',	
+        # Deliberately keep the "duplicated" Chianti levels.
+        # These levels are not strictly duplicated: same energy
+        # for different configurations. 
+        # 
+        # e.g. ChiantiIonReader('h_1')
+        mask = (levels['source'] != 'chianti') & (
+            levels[['atomic_number', 'ion_number',
                     'energy', 'g']].duplicated(keep='last'))	
         levels = levels[~mask]
 

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -37,9 +37,11 @@ class TARDISAtomData:
     """
 
     def __init__(self,
+                 atomic_weights,
                  ionization_energies,
                  gfall_reader,
                  gfall_ions,
+                 zeta_data,
                  chianti_reader=None,
                  lines_loggf_threshold=-3,
                  levels_metastable_loggf_threshold=-3):
@@ -51,10 +53,12 @@ class TARDISAtomData:
             "lines_loggf_threshold": lines_loggf_threshold
         }
 
-        self.ionization_energies = ionization_energies.base
+        self.atomic_weights = atomic_weights
+        self.ionization_energies = ionization_energies
         self.ground_levels = ionization_energies.get_ground_levels()
         self.gfall_reader = gfall_reader
         self.gfall_ions = parse_selected_species(gfall_ions)
+        self.zeta_data = zeta_data
 
         # By the moment Chianti ions are optional
         if chianti_reader is not None:
@@ -331,7 +335,7 @@ class TARDISAtomData:
         `AtomData.create_levels_lines` method """
         levels_all = self.levels_all
         lines_all = self.lines_all
-        ionization_energies = self.ionization_energies.reset_index()
+        ionization_energies = self.ionization_energies.base.reset_index()
         ionization_energies['ion_number'] -= 1
 
         # Culling autoionization levels
@@ -642,6 +646,10 @@ class TARDISAtomData:
         fname : path
            Path to the HDF5 output file
         """
+
+        self.atomic_weights.to_hdf(fname)
+        self.ionization_energies.to_hdf(fname)
+        self.zeta_data.to_hdf(fname)
 
         with pd.HDFStore(fname, 'a') as f:
             f.put('/levels', self.levels_prepared)

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -213,12 +213,22 @@ class TARDISAtomData:
         gf = self.gfall_reader
         ch = self.chianti_reader
 
-        gf_ions = [item for item in self.ions if item not in self.chianti_ions]
+        start = 1
         gf_list = []
-        for ion in gf_ions:
+        for ion in self.ions:
 
             try:
                 df = gf.lines.loc[ion]
+
+                # To match `line_id` field with the old API
+                if ion in self.chianti_ions:
+                    df['line_id'] = range(start, len(df) + start)
+                    start += len(df)
+                    continue
+
+                else:
+                    df['line_id'] = range(start, len(df) + start)
+                    start += len(df)
 
             except (KeyError, TypeError):
                 continue
@@ -254,6 +264,8 @@ class TARDISAtomData:
 
             try:
                 df = ch.lines.loc[ion]
+                df['line_id'] = range(start, len(df) + start)
+                start = len(df) + start
 
             except (KeyError, TypeError):
                 continue
@@ -285,7 +297,7 @@ class TARDISAtomData:
 
         df_list = gf_list + ch_list
         lines = pd.concat(df_list, sort=True)
-        lines['line_id'] = range(1, len(lines)+1)
+        #lines['line_id'] = range(1, len(lines)+1)
         lines['loggf'] = lines['gf'].apply(np.log10)
 
         lines.set_index('line_id', inplace=True)

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -173,11 +173,11 @@ class TARDISAtomData:
 
         # TODO: delete after creating a script that fixes GFALL typos.
         # Fixes Ar II duplicated ground level. For Kurucz, ground state
-        # has g=2, for NIST has g=4. We keep Kurucz.
+        # has g=2, for NIST has g=4. We keep NIST.
 
         mask = (ground_levels['atomic_number'] == 18) & (
             ground_levels['ion_number'] == 1)
-        ground_levels.loc[mask, 'g'] = 2
+        ground_levels.loc[mask, 'g'] = 4
 
         levels = pd.concat([ground_levels, levels], sort=True)
         levels['level_id'] = range(1, len(levels)+1)
@@ -190,7 +190,7 @@ class TARDISAtomData:
                     'energy', 'g']].duplicated(keep='last'))
         levels = levels[~mask]
 
-        # We keep only Chianti levels for the selected ions
+        # Keep Chianti levels over GFALL.
         for ion in self.chianti_ions:
             mask = (levels['source'] == 'gfall') & (
                 levels['atomic_number'] == ion[0]) & (

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -150,7 +150,7 @@ class TARDISAtomData:
         gf_levels = self.gfall_reader.levels.reset_index()
         gf_levels['source'] = 'gfall'
 
-        if self.chianti_reader is not None:
+        if len(self.chianti_ions) > 0:
             ch_levels = self.chianti_reader.levels.reset_index()
             ch_levels['source'] = 'chianti'
         else:

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -184,6 +184,14 @@ class TARDISAtomData:
         # for different configurations. 
         # 
         # e.g. ChiantiIonReader('h_1')
+        #
+        # In fact, the following code should only remove the du-
+        # plicated ground levels. Other duplicated levels should
+        # be removed at the reader stage.
+        #
+        # TODO: a more clear way to get the same result could be: 
+        # "keep only zero energy levels from NIST source".
+
         mask = (levels['source'] != 'chianti') & (
             levels[['atomic_number', 'ion_number',
                     'energy', 'g']].duplicated(keep='last'))	

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import hashlib
 import uuid
-from carsus.util import parse_selected_species, convert_wavelength_air2vacuum
+from carsus.util import convert_wavelength_air2vacuum
 from carsus.model import MEDIUM_VACUUM, MEDIUM_AIR
 from astropy import units as u
 from astropy import constants as const
@@ -40,7 +40,6 @@ class TARDISAtomData:
                  atomic_weights,
                  ionization_energies,
                  gfall_reader,
-                 gfall_ions,
                  zeta_data,
                  chianti_reader=None,
                  lines_loggf_threshold=-3,
@@ -56,16 +55,21 @@ class TARDISAtomData:
         self.atomic_weights = atomic_weights
         self.ionization_energies = ionization_energies
         self.ground_levels = ionization_energies.get_ground_levels()
+
+        gfall_ions = gfall_reader.levels.index.tolist()
+        # Remove last element from tuple (MultiIndex has 3 elements)
+        gfall_ions = [x[:-1] for x in gfall_ions]
+        # Keep unique tuples, list and sort them
+        gfall_ions = sorted(list(set(gfall_ions)))
         self.gfall_reader = gfall_reader
-        self.gfall_ions = parse_selected_species(gfall_ions)
+        self.gfall_ions = gfall_ions
+
         self.zeta_data = zeta_data
 
         # By the moment Chianti ions are optional
         if chianti_reader is not None:
             chianti_ions = chianti_reader.levels.index.tolist()
-            # Remove last element from tuple (MultiIndex has 3 elements)
             chianti_ions = [x[:-1] for x in chianti_ions]
-            # Keep unique tuples, list and sort them
             chianti_ions = sorted(list(set(chianti_ions)))
             self.chianti_reader = chianti_reader
             self.chianti_ions = chianti_ions

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -66,9 +66,17 @@ class TARDISAtomData:
 
         self.zeta_data = zeta_data
 
-        # By the moment Chianti ions are optional
+        # TODO: priorities should not be managed by the `init` method.
         if chianti_reader is not None:
-            chianti_ions = chianti_reader.levels.index.tolist()
+            chianti_lvls = chianti_reader.levels.reset_index()
+            chianti_lvls = chianti_lvls.set_index(
+                ['atomic_number', 'ion_charge', 'priority'])
+
+            mask = chianti_lvls.index.get_level_values(
+                'priority') > self.gfall_reader.priority
+
+            chianti_lvls = chianti_lvls[mask]
+            chianti_ions = chianti_lvls.index.tolist()
             chianti_ions = [x[:-1] for x in chianti_ions]
             chianti_ions = sorted(list(set(chianti_ions)))
             self.chianti_reader = chianti_reader

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -143,13 +143,9 @@ class TARDISAtomData:
             gf_list.append(df)
 
         ch_list = []
-        ch_ions = []
         for ion in self.chianti_ions:
             try:
                 df = ch.levels.loc[ion].copy()
-                # Save for later use the selected AND existing
-                # ions in Chianti.
-                ch_ions.append(ion)
 
             except (KeyError, TypeError):
                 continue
@@ -200,12 +196,11 @@ class TARDISAtomData:
         levels = levels[~mask]
 
         # We keep only Chianti levels for the selected ions
-        if ch_ions:
-            for ion in ch_ions:
-                mask = (levels['source'] == 'gfall') & (
-                    levels['atomic_number'] == ion[0]) & (
-                        levels['ion_number'] == ion[1])
-                levels.drop(levels[mask].index, inplace=True)
+        for ion in self.chianti_ions:
+            mask = (levels['source'] == 'gfall') & (
+                levels['atomic_number'] == ion[0]) & (
+                    levels['ion_number'] == ion[1])
+            levels.drop(levels[mask].index, inplace=True)
 
         levels = levels[['atomic_number',
                          'ion_number', 'g', 'energy', 'source']]

--- a/carsus/io/tests/test_gfall.py
+++ b/carsus/io/tests/test_gfall.py
@@ -10,7 +10,7 @@ from carsus.model import Ion, Level, LevelEnergy, DataSource, Line
 
 @pytest.fixture()
 def gfall_rdr(gfall_fname):
-    return GFALLReader(gfall_fname)
+    return GFALLReader(fname=gfall_fname)
 
 
 @pytest.fixture()

--- a/carsus/io/zeta.py
+++ b/carsus/io/zeta.py
@@ -1,3 +1,5 @@
+import os
+import carsus
 import numpy as np
 import pandas as pd
 from carsus.io.base import BaseParser
@@ -7,6 +9,9 @@ from carsus.model import (
     DataSource
 )
 
+ZETA_PATH = os.path.join(os.path.dirname(carsus.__file__), 
+                        'data', 
+                        'knox_long_recombination_zeta.dat')
 
 class KnoxLongZetaIngester(object):
 
@@ -71,8 +76,13 @@ class KnoxLongZeta(BaseParser):
             Dump the `base` attribute into an HDF5 file
     """
 
-    def __init__(self, fname):
-        self.fname = fname
+    def __init__(self, fname=None):
+
+        if fname is None:
+            self.fname = ZETA_PATH
+        else:
+            self.fname = fname
+
         self._prepare_data()
 
     def _prepare_data(self):


### PR DESCRIPTION
## Current status

> After merging this pull request, Carsus should be capable of creating atomic files using only Pandas, and these files should be **almost identical** to the ones created with the old SQL ingesters. 

There are typos in `gfall.dat`. At least two of these typos affect the resulting levels tables in some way:

1. Missing ground level of `He II` in `gfall.dat` results in missing ground level for the SQL generated file (the Pandas ingester handles this situation just fine).

2. `Ar II` ground level is duplicated because `g = 2` in `gfall.dat` and `g = 4` in `NIST`. Then `.drop_duplicated()` method does nothing because these levels are not strictly duplicated. 

The nicest solution should be to modify `gfall.dat` somehow before Carsus reads the file. 

See also #151.

## Features implemented

- [x] Chianti levels
- [x] Chianti lines
- [x] All-priority system
- [x] ~~Priority w/ dictionaries~~ (not in ths PR)
- [x] Docstrings
- [x] PEP8
---

## Notebooks
- :notebook: [How to use the new Pandas ingester and set priorities](https://nbviewer.jupyter.org/gist/epassaro/85c95fd1721c31848e7c8cc7e242f52d?flush_cache=True)
- :notebook: [Comparing atomic files generated with SQL and Pandas ingesters](https://nbviewer.jupyter.org/gist/epassaro/7ad4f63829f58d333153128f90a7b005)