### PR TITLE
Pinned numpy to 1.15 (pytables)

### DIFF
--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -44,7 +44,7 @@ dependencies:
 - recommonmark
 
 # Test/Coverage requirements
-- coverage
+- coverage=4
 - coveralls
 - pytest=4.5.0
 - pytest-cov

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
 - python=3
 - setuptools
-- numpy=1.17
+- numpy=1.15
 - pandas=0.24
 - astropy=3.2
 - Cython=0.29  # TARDIS dep


### PR DESCRIPTION
- Pytables fix.

- Coverage 5.0 is broken at the moment: https://github.com/astropy/astropy/issues/9792