### PR TITLE
Quickstart warning

### DIFF
--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -26,6 +26,13 @@
    "source": [
     "# Quickstart for Carsus\n",
     "\n",
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "**NOTE:** currently Carsus can only handle atomic data from **H** to **Pr** (Z=59).\n",
+    "\n",
+    "</div>\n",
+    "\n",
+    "\n",
     "## Initialization and imports"
    ]
   },


### PR DESCRIPTION
Missing configurations for ground levels makes Carsus capable of handle only atoms from Z=1 to 59 (see #168).

For now, we just add a warning box to the Quickstart guide.