### PR TITLE
Fix broken tests

### DIFF
--- a/carsus/io/__init__.py
+++ b/carsus/io/__init__.py
@@ -1,6 +1,6 @@
-#from carsus.io.nist import NISTIonizationEnergiesParser, NISTIonizationEnergiesIngester,\
-#    NISTWeightsCompPyparser, NISTWeightsCompIngester
-#from carsus.io.chianti_ import ChiantiIonReader, ChiantiIngester
-#from carsus.io.kurucz import GFALLReader, GFALLIngester
-#from carsus.io.output import AtomData
-#from carsus.io.zeta import KnoxLongZetaIngester
+from carsus.io.nist import NISTIonizationEnergiesParser, NISTIonizationEnergiesIngester,\
+    NISTWeightsCompPyparser, NISTWeightsCompIngester
+from carsus.io.chianti_ import ChiantiIonReader, ChiantiIngester
+from carsus.io.kurucz import GFALLReader, GFALLIngester
+from carsus.io.output import AtomData
+from carsus.io.zeta import KnoxLongZetaIngester


### PR DESCRIPTION
## Summary
- Tests are not working anymore with fresh `carsus` environments after a recent update.

- I couldn't trace the package that causes the failure. 

- I had to uncomment import lines in `carsus/io/__init__.py` to make tests work again. That's strange because this file remained untouched almost for 2 years and do very basic stuff.