### PR TITLE
Fix documentation pipeline

### DIFF
--- a/azure-pipelines/doc-build.yml
+++ b/azure-pipelines/doc-build.yml
@@ -9,6 +9,8 @@ pr:
 # Variables we can reference later
 variables:
   system.debug: 'true'
+  CHIANTI_DATA_URL: "http://www.chiantidatabase.org/download/CHIANTI_9.0_data.tar.gz"
+  XUVTOP: "/usr/share/chianti"
 
 jobs:
 # Title of job
@@ -60,6 +62,14 @@ jobs:
   - bash: |
         conda env create -f carsus_env3.yml
     displayName: 'Install Carsus env'
+
+# Download chianti data for tests
+  - bash: |
+          mkdir /usr/share/chianti
+          wget $CHIANTI_DATA_URL -O /usr/share/chianti/CHIANTI_9.0_data.tar.gz
+          tar -zxvf /usr/share/chianti/CHIANTI_9.0_data.tar.gz -C /usr/share/chianti
+    displayName: "Fetch Chianti Data"
+
 # Activate the environment, use sphinx to make the html documentation of the build, and deploy to gh-pages
   - bash: |
         source activate carsus


### PR DESCRIPTION
Need to download Chianti data an set `XUVTOP` env variable in documentation pipeline after #170 got merged.

I can't test these changes until merged, since the documentation pipeline doesn't build PRs.