### PR TITLE
Major changes to the environment file

### DIFF
--- a/azure-pipelines/multi_test_framework.yml
+++ b/azure-pipelines/multi_test_framework.yml
@@ -95,7 +95,7 @@ jobs:
   - bash: |
           source activate carsus
           coverage xml
-    condition: and(succeeded(), eq(variables['COVERAGE'], '--cov=carsus --cov-report=xml --cov-report=html'))
+    condition: and(succeeded(), eq(variables['SETUP_CMD'], '--cov=carsus --cov-report=xml --cov-report=html'))
     displayName: "Make xml file to publish"
     
 # Publish Code Coverage Results
@@ -105,7 +105,7 @@ jobs:
       codeCoverageTool: 'cobertura'
       summaryFileLocation: '$(Build.Repository.LocalPath)/coverage.xml'
       reportDirectory: '$(Build.Repository.LocalPath)/htmlcov'
-    condition: and(succeeded(), eq(variables['COVERAGE'], true))
+    condition: and(succeeded(), eq(variables['SETUP_CMD'], '--cov=carsus --cov-report=xml --cov-report=html'))
     displayName: "Publish Results of coverage"
 
 # Clean up in case of failure

--- a/azure-pipelines/multi_test_framework.yml
+++ b/azure-pipelines/multi_test_framework.yml
@@ -31,7 +31,6 @@ jobs:
 
 - job: "Test"
 
-# Five different tests with different inputs
   pool:
     vmImage: "Ubuntu-16.04"
   strategy:
@@ -46,7 +45,7 @@ jobs:
         SETUP_CMD: "--test-db=$HOME/carsus-db/test_databases/test.db"
         TEST_MODE: "with_test_db"
       coverage:
-        COVERAGE: true
+        SETUP_CMD: "--cov=carsus --cov-report=xml --cov-report=html"
     
     maxParallel: 5
 
@@ -89,14 +88,14 @@ jobs:
   - bash: |
           source activate carsus
           echo pytest carsus $SETUP_CMD
+          pip install pytest-azurepipelines
           pytest carsus $SETUP_CMD
-    displayName: "TARDIS test"
+    displayName: "Carsus test"
 
-# Make a coverage file in xml for Azure
   - bash: |
           source activate carsus
           coverage xml
-    condition: and(succeeded(), eq(variables['COVERAGE'], true))
+    condition: and(succeeded(), eq(variables['COVERAGE'], '--cov=carsus --cov-report=xml --cov-report=html'))
     displayName: "Make xml file to publish"
     
 # Publish Code Coverage Results

--- a/azure-pipelines/multi_test_framework.yml
+++ b/azure-pipelines/multi_test_framework.yml
@@ -26,6 +26,7 @@ variables:
   CONDA: "/usr/share/miniconda"
   XUVTOP: "/usr/share/chianti"
   PYTHON_VERSION: '3.7'
+  codecov.token: 'bd02b09d-d24f-45a3-8c0b-25eec64a29e7'
 
 jobs:
 
@@ -93,21 +94,10 @@ jobs:
     displayName: "Carsus test"
 
   - bash: |
-          source activate carsus
-          coverage xml
+          bash <(curl -s https://codecov.io/bash)
     condition: and(succeeded(), eq(variables['SETUP_CMD'], '--cov=carsus --cov-report=xml --cov-report=html'))
-    displayName: "Make xml file to publish"
+    displayName: "Upload to codecov.io"
     
-# Publish Code Coverage Results
-# Publish Cobertura or JaCoCo code coverage results from a build
-  - task: PublishCodeCoverageResults@1
-    inputs:
-      codeCoverageTool: 'cobertura'
-      summaryFileLocation: '$(Build.Repository.LocalPath)/coverage.xml'
-      reportDirectory: '$(Build.Repository.LocalPath)/htmlcov'
-    condition: and(succeeded(), eq(variables['SETUP_CMD'], '--cov=carsus --cov-report=xml --cov-report=html'))
-    displayName: "Publish Results of coverage"
-
 # Clean up in case of failure
   - bash: |
           source activate carsus

--- a/azure-pipelines/multi_test_framework.yml
+++ b/azure-pipelines/multi_test_framework.yml
@@ -42,12 +42,11 @@ jobs:
         SETUP_CMD: "--remote-data"
       slow:
         SETUP_CMD: "--runslow"
-        INSTALL_CHIANTI: true
       database:
         SETUP_CMD: "--test-db=$HOME/carsus-db/test_databases/test.db"
         TEST_MODE: "with_test_db"
       coverage:
-        SETUP_CMD: "--coverage"
+        COVERAGE: true
     
     maxParallel: 5
 
@@ -97,7 +96,7 @@ jobs:
   - bash: |
           source activate carsus
           coverage xml
-    condition: and(succeeded(), eq(variables['SETUP_CMD'], '--coverage'))
+    condition: and(succeeded(), eq(variables['COVERAGE'], true))
     displayName: "Make xml file to publish"
     
 # Publish Code Coverage Results
@@ -107,7 +106,7 @@ jobs:
       codeCoverageTool: 'cobertura'
       summaryFileLocation: '$(Build.Repository.LocalPath)/coverage.xml'
       reportDirectory: '$(Build.Repository.LocalPath)/htmlcov'
-    condition: and(succeeded(), eq(variables['SETUP_CMD'], '--coverage'))
+    condition: and(succeeded(), eq(variables['COVERAGE'], true))
     displayName: "Publish Results of coverage"
 
 # Clean up in case of failure

--- a/azure-pipelines/multi_test_framework.yml
+++ b/azure-pipelines/multi_test_framework.yml
@@ -18,7 +18,7 @@ variables:
   system.debug: "true"
   PANDAS_VERSION: 0.24
   ASTROPY_USE_SYSTEM_PYTEST: 1
-  SETUP_CMD: "test"
+  SETUP_CMD: ""
   TEST_MODE: "normal"
   CHIANTI_DATA_URL: "http://www.chiantidatabase.org/download/CHIANTI_9.0_data.tar.gz"
   CARSUS_DB_URL: "https://github.com/tardis-sn/carsus-db.git"
@@ -37,17 +37,17 @@ jobs:
   strategy:
     matrix:
       simple:
-        SETUP_CMD: "test"
+        SETUP_CMD: ""
       remote_data:
-        SETUP_CMD: "test --remote-data"
+        SETUP_CMD: "--remote-data"
       slow:
-        SETUP_CMD: 'test --args="--runslow"'
+        SETUP_CMD: "--runslow"
         INSTALL_CHIANTI: true
       database:
-        SETUP_CMD: 'test --args="--test-db=$HOME/carsus-db/test_databases/test.db"'
+        SETUP_CMD: "--test-db=$HOME/carsus-db/test_databases/test.db"
         TEST_MODE: "with_test_db"
       coverage:
-        SETUP_CMD: 'test --coverage'
+        SETUP_CMD: "--coverage"
     
     maxParallel: 5
 
@@ -89,15 +89,15 @@ jobs:
 # Activate environment and start test
   - bash: |
           source activate carsus
-          echo python setup.py $SETUP_CMD
-          python setup.py $SETUP_CMD
+          echo pytest carsus $SETUP_CMD
+          pytest carsus $SETUP_CMD
     displayName: "TARDIS test"
 
 # Make a coverage file in xml for Azure
   - bash: |
           source activate carsus
           coverage xml
-    condition: and(succeeded(), eq(variables['SETUP_CMD'], 'test --coverage'))
+    condition: and(succeeded(), eq(variables['SETUP_CMD'], '--coverage'))
     displayName: "Make xml file to publish"
     
 # Publish Code Coverage Results
@@ -107,7 +107,7 @@ jobs:
       codeCoverageTool: 'cobertura'
       summaryFileLocation: '$(Build.Repository.LocalPath)/coverage.xml'
       reportDirectory: '$(Build.Repository.LocalPath)/htmlcov'
-    condition: and(succeeded(), eq(variables['SETUP_CMD'], 'test --coverage'))
+    condition: and(succeeded(), eq(variables['SETUP_CMD'], '--coverage'))
     displayName: "Publish Results of coverage"
 
 # Clean up in case of failure

--- a/carsus/__init__.py
+++ b/carsus/__init__.py
@@ -16,7 +16,7 @@ from ._astropy_init import *
 
 import logging, sys
 from .base import init_db
-from tardis.util.colored_logger import ColoredFormatter, formatter_message
+from .util.colored_logger import ColoredFormatter, formatter_message
 
 FORMAT = "[$BOLD%(name)-20s$RESET][%(levelname)-18s]  %(message)s ($BOLD%(filename)s$RESET:%(lineno)d)"
 COLOR_FORMAT = formatter_message(FORMAT, True)

--- a/carsus/io/tests/test_output_tardis.py
+++ b/carsus/io/tests/test_output_tardis.py
@@ -300,8 +300,7 @@ def test_create_lines_convert_air2vacuum(lines, atomic_number, ion_number, level
 def test_create_lines_loggf_treshold(lines, atomic_number, ion_number, level_number_lower, level_number_upper):
     lines = lines.set_index(["atomic_number", "ion_number",
                              "level_number_lower", "level_number_upper"])
-    # Normally this would raise a `KeyError`. Keep this in mind for future releases of Pandas.
-    with pytest.raises(TypeError):
+    with pytest.raises(KeyError):
         assert lines.loc[(atomic_number, ion_number, level_number_lower, level_number_upper)]
 
 

--- a/carsus/util/colored_logger.py
+++ b/carsus/util/colored_logger.py
@@ -1,0 +1,66 @@
+import logging
+'''
+Code for Custom Logger Classes (ColoredFormatter and ColorLogger) and its helper function
+(formatter_message) is used from this thread
+http://stackoverflow.com/questions/384076/how-can-i-color-python-logging-output
+'''
+
+def formatter_message(message, use_color=True):
+    '''
+    Helper Function used for Coloring Log Output
+    '''
+    #These are the sequences need to get colored ouput
+    RESET_SEQ = "\033[0m"
+    BOLD_SEQ = "\033[1m"
+    if use_color:
+        message = message.replace(
+            "$RESET", RESET_SEQ).replace("$BOLD", BOLD_SEQ)
+    else:
+        message = message.replace("$RESET", "").replace("$BOLD", "")
+    return message
+
+
+class ColoredFormatter(logging.Formatter):
+    '''
+    Custom logger class for changing levels color
+    '''
+    def __init__(self, msg, use_color=True):
+        logging.Formatter.__init__(self, msg)
+        self.use_color = use_color
+
+    def format(self, record):
+        COLOR_SEQ = "\033[1;%dm"
+        RESET_SEQ = "\033[0m"
+        BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
+        COLORS = {
+            'WARNING': YELLOW,
+            'INFO': WHITE,
+            'DEBUG': BLUE,
+            'CRITICAL': YELLOW,
+            'ERROR': RED
+        }
+        levelname = record.levelname
+        if self.use_color and levelname in COLORS:
+            levelname_color = COLOR_SEQ % (
+                30 + COLORS[levelname]) + levelname + RESET_SEQ
+            record.levelname = levelname_color
+        return logging.Formatter.format(self, record)
+
+
+class ColoredLogger(logging.Logger):
+    '''
+    Custom logger class with multiple destinations
+    '''
+    FORMAT = "[$BOLD%(name)-20s$RESET][%(levelname)-18s]  %(message)s ($BOLD%(filename)s$RESET:%(lineno)d)"
+    COLOR_FORMAT = formatter_message(FORMAT, True)
+
+    def __init__(self, name):
+        logging.Logger.__init__(self, name, logging.DEBUG)
+
+        color_formatter = ColoredFormatter(self.COLOR_FORMAT)
+
+        console = logging.StreamHandler()
+        console.setFormatter(color_formatter)
+
+        self.addHandler(console)
+        return

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -9,7 +9,6 @@ dependencies:
 - numpy=1.15
 - pandas=1.0
 - astropy=3
-- Cython=0.29  # TARDIS dep
 - numexpr
 - ipyparallel
 - uncertainties
@@ -23,8 +22,6 @@ dependencies:
 - PyYAMl
 - h5py
 - pytables
-- pyne=0.5     # TARDIS dep
-- tqdm         # TARDIS dep
 
 # Analysis
 - jupyter
@@ -52,5 +49,4 @@ dependencies:
 
 # Pip
 - pip:
-  - git+https://github.com/tardis-sn/tardis
   - git+https://github.com/chianti-atomic/ChiantiPy.git@0.8.4

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -53,5 +53,5 @@ dependencies:
 
 # Pip
 - pip:
-  - ChiantiPy=0.8.7
+  - ChiantiPy==0.8.7
   - git+https://github.com/tardis-sn/tardis

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -53,5 +53,5 @@ dependencies:
 
 # Pip
 - pip:
-  - ChiantiPy==0.8.5
+  - git+https://github.com/chianti-atomic/ChiantiPy.git@0.8.4	
   - git+https://github.com/tardis-sn/tardis

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -20,7 +20,7 @@ dependencies:
 - beautifulsoup4
 - pyparsing=2.2.0
 - html5lib
-- SQLAlchemy=1.0.19
+- SQLAlchemy=1.0
 - PyYAMl
 - h5py
 - pytables

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -53,5 +53,5 @@ dependencies:
 
 # Pip
 - pip:
-  - ChiantiPy
+  - ChiantiPy=0.8.7
   - git+https://github.com/tardis-sn/tardis

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -42,7 +42,6 @@ dependencies:
 - pytest-cov
 - pytest-astropy
 - coverage
-- coveralls
 - requests
 
 # ChiantiPy dependencies

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -2,7 +2,6 @@ name: carsus
 
 channels:
     - conda-forge
-    - default
 
 dependencies:
 - python=3
@@ -46,7 +45,7 @@ dependencies:
 # Test/Coverage requirements
 - coverage=4
 - coveralls
-- pytest=4.5.0
+- pytest=4
 - pytest-cov
 - pytest-astropy
 - requests

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -54,4 +54,4 @@ dependencies:
 # Pip
 - pip:
   - git+https://github.com/tardis-sn/tardis
-  - git+https://github.com/chianti-atomic/ChiantiPy.git@0.8.4
+  - git+https://github.com/chianti-atomic/ChiantiPy.git@0.9.5

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -9,7 +9,7 @@ dependencies:
 - setuptools
 - numpy=1.15
 - pandas=1.0
-- astropy=3.2
+- astropy=3
 - Cython=0.29  # TARDIS dep
 - numexpr
 - ipyparallel

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -53,5 +53,5 @@ dependencies:
 
 # Pip
 - pip:
+  - ChiantiPy
   - git+https://github.com/tardis-sn/tardis
-  - git+https://github.com/chianti-atomic/ChiantiPy.git@0.9.5

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -8,7 +8,7 @@ dependencies:
 - python=3
 - setuptools
 - numpy=1.15
-- pandas=0.24
+- pandas=1.0
 - astropy=3.2
 - Cython=0.29  # TARDIS dep
 - numexpr

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -9,7 +9,6 @@ dependencies:
 - numpy=1.15
 - pandas=1.0
 - astropy=3
-- numexpr
 - uncertainties
 - pip
 
@@ -39,11 +38,11 @@ dependencies:
 - recommonmark
 
 # Test/Coverage requirements
-- coverage=4
-- coveralls
 - pytest=4
 - pytest-cov
 - pytest-astropy
+- coverage=4
+- coveralls
 - requests
 
 # ChiantiPy dependencies

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -18,7 +18,7 @@ dependencies:
 
 # I/O
 - beautifulsoup4
-- pyparsing=2.2.0
+- pyparsing=2.2
 - html5lib
 - SQLAlchemy=1.0
 - PyYAMl

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -10,7 +10,6 @@ dependencies:
 - pandas=1.0
 - astropy=3
 - numexpr
-- ipyparallel
 - uncertainties
 - pip
 
@@ -46,6 +45,10 @@ dependencies:
 - pytest-cov
 - pytest-astropy
 - requests
+
+# ChiantiPy dependencies
+- scipy
+- ipyparallel
 
 # Pip
 - pip:

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -41,7 +41,7 @@ dependencies:
 - pytest=4
 - pytest-cov
 - pytest-astropy
-- coverage=4
+- coverage
 - coveralls
 - requests
 

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -53,5 +53,5 @@ dependencies:
 
 # Pip
 - pip:
-  - git+https://github.com/chianti-atomic/ChiantiPy.git@0.8.4	
   - git+https://github.com/tardis-sn/tardis
+  - git+https://github.com/chianti-atomic/ChiantiPy.git@0.8.4

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -53,5 +53,5 @@ dependencies:
 
 # Pip
 - pip:
-  - ChiantiPy==0.8.7
+  - ChiantiPy==0.8.5
   - git+https://github.com/tardis-sn/tardis


### PR DESCRIPTION
# Summary
To have a healthier `carsus` environment I make some pinned dependencies less restrictive and removed some packages.

- [x] Pin `pytest=4`
- [x] Pin `pandas=1.0`
- [x] Pin `astropy=3`
- [x] Pin `pyparsing=2.2`
- [x] Pin `SQLAlchemy=1.0`
- [x] Unpin `coverage`
- [x] Remove `coveralls`
- [x] Remove `tardis`
- [x] Remove `numexpr`
- [x] Remove channel `default`


Some minor changes and additions to the code were necessary.

Also, unpinning `coverage` led to make agressive changes in the testing pipeline: unpinning `coverage` -> use `pytest` instead `python setup.py test` -> use `codecov.io` instead of `coveralls`.