### PR TITLE
Add Chianti collisional data to the new API

### DIFF
--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -523,13 +523,16 @@ class ChiantiIngester(object):
 
 class ChiantiReader:
     """
-        Class for extracting lines and levels data from Chianti.
+        Class for extracting levels, lines and collisional data 
+        from Chianti.
+        
         Mimics the GFALLReader class.
 
         Attributes
         ----------
         levels : DataFrame
         lines : DataFrame
+        collisions: DataFrame
         version : str
     """
 

--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -1,10 +1,9 @@
-import logging
-import pandas as pd
-import numpy as np
-import pickle
 import os
 import re
-
+import pickle
+import logging
+import numpy as np
+import pandas as pd
 from numpy.testing import assert_almost_equal
 from astropy import units as u
 from sqlalchemy import and_
@@ -16,14 +15,13 @@ from carsus.model import DataSource, Ion, Level, LevelEnergy,\
     Line, LineGFValue, LineAValue, LineWavelength, MEDIUM_VACUUM, \
     ECollision, ECollisionEnergy, ECollisionGFValue, ECollisionTempStrength
 
-logger = logging.getLogger(__name__)
-
 # Compatibility with older versions and pip versions:
 try:
     from ChiantiPy.tools.io import versionRead
-    import ChiantiPy.core as ch
+    import ChiantiPy.core as ch 
+
 except ImportError:
-    # Shamefully copied from their github source:
+    # Shamefully copied from their GitHub source:
     def versionRead():
         """
         Read the version number of the CHIANTI database
@@ -35,6 +33,9 @@ except ImportError:
         vFile.close()
         return versionStr.strip()
     import chianti.core as ch
+
+
+logger = logging.getLogger(__name__)
 
 masterlist_ions_path = os.path.join(
     os.getenv('XUVTOP'), "masterlist", "masterlist_ions.pkl"
@@ -300,7 +301,6 @@ class ChiantiIngester(object):
                 masterlist_version)
 
         self.session = session
-        # ToDo write a parser for Spectral Notation
         self.ion_readers = list()
         self.ions = list()
 
@@ -533,45 +533,66 @@ class ChiantiReader:
         version : str
     """
 
-    def __init__(self, ions, priority=10):
+    def __init__(self, ions, collisions=False, priority=10):
         """
         Parameters
         ----------
         ions : string
+            Selected Chianti ions.
+
+        collisions: bool, optional
+            Grab collisional data (default is False).
         """
         self.ions = parse_selected_species(ions)
         self.priority = priority
-        self._get_levels_lines()
+        self._get_levels_lines(get_collisions=collisions)
 
-    # TODO: write docstring
-    def _get_levels_lines(self):
+    def _get_levels_lines(self, get_collisions=False):
+        """Generates `levels`, `lines`  and `collisions` DataFrames.
 
+        Parameters
+        ----------
+        get_collisions : bool, optional
+            Grab collisional data, by default False.
+        """
         lvl_list = []
         lns_list = []
+        col_list = []
         for ion in self.ions:
 
-            ch_ion = convert_species_tuple2chianti_str(ion)
+            ch_ion = ch_ion = convert_species_tuple2chianti_str(ion)
             reader = ChiantiIonReader(ch_ion)
 
+            # Do not keep levels if lines are not available.
             try:
                 lvl = reader.levels
+                lns = reader.lines
 
             except ChiantiIonReaderError:
-                logger.info('No level data for {}'.format(ch_ion))
+                logger.info(f'Missing levels/lines data for `{ch_ion}`.')
                 continue
 
             lvl['atomic_number'] = ion[0]
             lvl['ion_charge'] = ion[1]
 
-            # Index must start from zero
+            # Indexes must start from zero
             lvl.index = range(0, len(lvl))
             lvl.index.name = 'level_index'
             lvl_list.append(reader.levels)
 
-            lns = reader.lines
             lns['atomic_number'] = ion[0]
             lns['ion_charge'] = ion[1]
             lns_list.append(lns)
+
+            if get_collisions:
+                try:
+                    col = reader.collisions
+                    col['atomic_number'] = ion[0]
+                    col['ion_charge'] = ion[1]
+                    col_list.append(col)
+
+                except ChiantiIonReaderError:
+                    logger.info(f'Missing collisional data for `{ch_ion}`.')
 
         levels = pd.concat(lvl_list, sort=True)
         levels = levels.rename(columns={'J': 'j'})
@@ -588,7 +609,6 @@ class ChiantiReader:
                                       'upper_level_index': 'level_index_upper',
                                       'gf_value': 'gf'})
 
-        # I'm not sure why we need this workaround.
         # Kurucz levels starts from zero, Chianti from 1.
         lines['level_index_lower'] = lines['level_index_lower'] - 1
         lines['level_index_upper'] = lines['level_index_upper'] - 1
@@ -602,6 +622,30 @@ class ChiantiReader:
         lines = lines[['energy_upper', 'j_upper', 'energy_lower', 'j_lower',
                        'wavelength', 'gf']]
 
+        if get_collisions:
+            collisions = pd.concat(col_list, sort=True)
+            collisions = collisions.reset_index()
+            collisions = collisions.rename(columns={'lower_level_index': 'level_index_lower',
+                                                    'upper_level_index': 'level_index_upper',
+                                                    'gf_value': 'gf',})
+            # Do we need to fix level indexes here too ?
+            collisions['level_index_lower'] -= 1
+            collisions['level_index_upper'] -= 1
+            collisions = collisions.set_index(['atomic_number', 'ion_charge',
+                                               'level_index_lower', 'level_index_upper'])
+            collisions = collisions[['temperatures', 'collision_strengths', 'gf', 'energy',
+                                     'ttype', 'cups']]
+
         self.levels = levels
         self.lines = lines
+
+        if get_collisions:
+            self.collisions = collisions
+        else:
+            self.collisions = pd.DataFrame()
+
         self.version = versionRead()
+
+    # TODO:
+    def to_hdf(self, fname):
+        raise NotImplementedError

--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -628,7 +628,6 @@ class ChiantiReader:
             collisions = collisions.rename(columns={'lower_level_index': 'level_index_lower',
                                                     'upper_level_index': 'level_index_upper',
                                                     'gf_value': 'gf',})
-            # Do we need to fix level indexes here too ?
             collisions['level_index_lower'] -= 1
             collisions['level_index_upper'] -= 1
             collisions = collisions.set_index(['atomic_number', 'ion_charge',

--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -646,6 +646,15 @@ class ChiantiReader:
 
         self.version = versionRead()
 
-    # TODO:
     def to_hdf(self, fname):
-        raise NotImplementedError
+        """
+        Parameters
+        ----------
+        fname : path
+           Path to the HDF5 output file
+        """
+
+        with pd.HDFStore(fname, 'w') as f:
+            f.put('/levels', self.levels)
+            f.put('/lines', self.lines)
+            f.put('/collisions', self.collisions)

--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -560,7 +560,7 @@ class ChiantiReader:
         col_list = []
         for ion in self.ions:
 
-            ch_ion = ch_ion = convert_species_tuple2chianti_str(ion)
+            ch_ion = convert_species_tuple2chianti_str(ion)
             reader = ChiantiIonReader(ch_ion)
 
             # Do not keep levels if lines are not available.

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -381,8 +381,7 @@ class GFALLReader(object):
         return lines 
 
     def to_hdf(self, fname, key='lines', raw=True):
-        """Dump the `base` attribute into an HDF5 file
-
+        """
         Parameters
         ----------
         fname : path
@@ -390,7 +389,7 @@ class GFALLReader(object):
         raw : bool
            If `True` stores `gfall_raw` attribute (default is `True`).
         """
-        with pd.HDFStore(fname, 'a') as f:
+        with pd.HDFStore(fname, 'w') as f:
             if raw:
                 f.put(key, self.gfall_raw)
 

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -380,21 +380,18 @@ class GFALLReader(object):
 
         return lines 
 
-    def to_hdf(self, fname, key='lines', raw=True):
+    def to_hdf(self, fname):
         """
         Parameters
         ----------
         fname : path
            Path to the HDF5 output file
         raw : bool
-           If `True` stores `gfall_raw` attribute (default is `True`).
+           If `True` stores `gfall_raw` attribute (default is `True`)
         """
         with pd.HDFStore(fname, 'w') as f:
-            if raw:
-                f.put(key, self.gfall_raw)
-
-            else:
-                f.put(key, self.gfall)
+            f.put('/gfall_raw', self.gfall_raw)
+            f.put('/gfall', self.gfall)
 
 
 class GFALLIngester(object):

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -618,9 +618,6 @@ class TARDISAtomData:
 
         collisions_prepared = self.collisions.loc[:, collisions_columns].copy()
 
-        # collisions_prepared = collisions_prepared.reset_index(drop=True)
-
-        # ToDo: maybe set multiindex
         collisions_prepared.set_index([
                     "atomic_number",
                     "ion_number",

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
 
 
 class TARDISAtomData:
-
     """
     Attributes
     ----------
@@ -143,7 +142,8 @@ class TARDISAtomData:
 
     @staticmethod
     def _create_artificial_fully_ionized(levels):
-        """ Create artificial levels for fully ionized ions """
+        """ Create artificial levels for fully ionized ions. """
+
         fully_ionized_levels = list()
 
         for atomic_number, _ in levels.groupby("atomic_number"):
@@ -196,10 +196,11 @@ class TARDISAtomData:
 
     @staticmethod
     def calculate_collisional_strength(row, temperatures, 
-                                        kb_ev, c_ul_temperature_cols):
+                                       kb_ev, c_ul_temperature_cols):
         """
-            Function to calculation upsilon from Burgess & Tully 1992 (TType 1 - 4; Eq. 23 - 38)
+        Function to calculation upsilon from Burgess & Tully 1992 (TType 1 - 4; Eq. 23 - 38).
         """
+
         c = row["cups"]
         x_knots = np.linspace(0, 1, len(row["btemp"]))
         y_knots = row["bscups"]
@@ -246,6 +247,7 @@ class TARDISAtomData:
         """ Returns the same output than `AtomData._get_all_levels_data()` 
         with `reset_index` method applied.
         """
+
         gf_levels = self.gfall_reader.levels.reset_index()
         gf_levels['source'] = 'gfall'
 
@@ -316,6 +318,7 @@ class TARDISAtomData:
 
     def _get_all_lines_data(self):
         """ Returns the same output than `AtomData._get_all_lines_data()` """
+
         gf = self.gfall_reader
         ch = self.chianti_reader
 
@@ -396,8 +399,8 @@ class TARDISAtomData:
 
     def _create_levels_lines(self, lines_loggf_threshold=-3,
                              levels_metastable_loggf_threshold=-3):
-        """ Returns almost the same output than
-        `AtomData.create_levels_lines` method """
+        """ Returns almost the same output than`AtomData.create_levels_lines` method """
+
         levels_all = self.levels_all
         lines_all = self.lines_all
         ionization_energies = self.ionization_energies.base.reset_index()
@@ -556,21 +559,17 @@ class TARDISAtomData:
     @property
     def levels_prepared(self):
         """
-        Prepare the DataFrame with levels for TARDIS
+        Prepare the DataFrame with levels for TARDIS.
+
         Returns
         -------
-        levels_prepared: pandas.DataFrame
-            DataFrame with:
-                index: none;
-                columns: atomic_number, ion_number, level_number,
-                            energy[eV], g[1], metastable.
+        pandas.DataFrame
         """
 
         levels_prepared = self.levels.loc[:, [
             "atomic_number", "ion_number", "level_number",
             "energy", "g", "metastable"]].copy()
 
-        # Set index
         levels_prepared.set_index(
             ["atomic_number", "ion_number", "level_number"], inplace=True)
 
@@ -579,17 +578,11 @@ class TARDISAtomData:
     @property
     def lines_prepared(self):
         """
-            Prepare the DataFrame with lines for TARDIS
-            Returns
-            -------
-            lines_prepared : pandas.DataFrame
-                DataFrame with:
-                    index: none;
-                    columns: line_id, atomic_number, ion_number,
-                             level_number_lower, level_number_upper,
-                             wavelength[angstrom], nu[Hz], f_lu[1], f_ul[1],
-                             B_ul[cm^3 s^-2 erg^-1], B_lu[cm^3 s^-2 erg^-1],
-                             A_ul[1/s].
+        Prepare the DataFrame with lines for TARDIS.
+
+        Returns
+        -------
+        pandas.DataFrame
         """
 
         lines_prepared = self.lines.loc[:, [
@@ -597,7 +590,11 @@ class TARDISAtomData:
             "f_ul", "f_lu", "level_number_lower", "level_number_upper",
             "nu", "B_lu", "B_ul", "A_ul"]].copy()
 
-        # Set the index
+        # TODO: store units in metadata
+        # wavelength[angstrom], nu[Hz], f_lu[1], f_ul[1],
+        # B_ul[cm^3 s^-2 erg^-1], B_lu[cm^3 s^-2 erg^-1],
+        # A_ul[1/s].
+
         lines_prepared.set_index([
             "atomic_number", "ion_number",
             "level_number_lower", "level_number_upper"], inplace=True)
@@ -607,13 +604,11 @@ class TARDISAtomData:
     @property
     def collisions_prepared(self):
         """
-            Prepare the DataFrame with electron collisions for TARDIS
-            Returns
-            -------
-            collisions_prepared : pandas.DataFrame
-                DataFrame with:
-                    index: atomic_number, ion_number, level_number_lower, level_number_upper;
-                    columns: e_col_id, delta_e, g_ratio, [collision strengths].
+        Prepare the DataFrame with electron collisions for TARDIS.
+
+        Returns
+        -------
+        pandas.DataFrame
         """
 
         collisions_columns = ['atomic_number', 'ion_number', 'level_number_upper',
@@ -633,19 +628,17 @@ class TARDISAtomData:
 
     def _create_macro_atom(self):
         """
-            Create a DataFrame containing *macro atom* data.
-            Returns
-            -------
-            macro_atom: pandas.DataFrame
-                DataFrame with:
-                    index: none;
-                    columns: atomic_number, ion_number, source_level_number,
-                             target_level_number, transition_line_id,
-                             transition_type, transition_probability.
-            Notes:
-                Refer to the docs:
-                https://tardis-sn.github.io/tardis/physics/plasma/macroatom.html
+        Create a DataFrame containing macro atom data.
+
+        Returns
+        -------
+        pandas.DataFrame
+
+        Notes
+        -----
+        Refer to the docs: https://tardis-sn.github.io/tardis/physics/plasma/macroatom.html
         """
+
         # Exclude artificially created levels from levels
         levels = self.levels.loc[self.levels["level_id"]
                                  != -1].set_index("level_id")
@@ -675,7 +668,7 @@ class TARDISAtomData:
             f_ul, f_lu = row["f_ul"], row["f_lu"]
             e_lower, e_upper = row["energy_lower"], row["energy_upper"]
 
-            transition_probabilities_dict = dict()  # type : probability
+            transition_probabilities_dict = dict()
             transition_probabilities_dict[P_EMISSION_DOWN] = 2 * \
                 nu**2 * f_ul / const.c.cgs.value**2 * (e_upper - e_lower)
             transition_probabilities_dict[P_INTERNAL_DOWN] = 2 * \
@@ -704,18 +697,15 @@ class TARDISAtomData:
     @property
     def macro_atom_prepared(self):
         """
-            Prepare the DataFrame with macro atom data for TARDIS
-            Returns
-            -------
-            macro_atom_prepared : pandas.DataFrame
-                DataFrame with the *macro atom data* with:
-                    index: none;
-                    columns: atomic_number, ion_number, source_level_number,
-                             destination_level_number, transition_line_id
-                             transition_type, transition_probability.
-            Notes:
-                Refer to the docs:
-                https://tardis-sn.github.io/tardis/physics/plasma/macroatom.html
+        Prepare the DataFrame with macro atom data for TARDIS
+        
+        Returns
+        -------
+        macro_atom_prepared : pandas.DataFrame
+        
+        Notes
+        -----
+        Refer to the docs: https://tardis-sn.github.io/tardis/physics/plasma/macroatom.html
         """
 
         macro_atom_prepared = self.macro_atom.loc[:, [
@@ -733,14 +723,11 @@ class TARDISAtomData:
 
     def _create_macro_atom_references(self):
         """
-            Create a DataFrame containing *macro atom reference* data.
-            Returns
-            -------
-            macro_atom_reference : pandas.DataFrame
-                DataFrame with:
-                index: no index;
-                and columns: atomic_number, ion_number, source_level_number,
-                count_down, count_up, count_total
+        Create a DataFrame containing macro atom reference data.
+    
+        Returns
+        -------
+        pandas.DataFrame
         """
         macro_atom_references = self.levels.rename(
             columns={"level_number": "source_level_number"}).\
@@ -762,7 +749,6 @@ class TARDISAtomData:
             macro_atom_references["count_down"] + \
             macro_atom_references["count_up"]
 
-        # Convert to int
         macro_atom_references["count_down"] = \
             macro_atom_references["count_down"].astype(np.int)
         macro_atom_references["count_up"] = \
@@ -775,14 +761,11 @@ class TARDISAtomData:
     @property
     def macro_atom_references_prepared(self):
         """
-            Prepare the DataFrame with macro atom references for TARDIS
-            Returns
-            -------
-            macro_atom_references_prepared : pandas.DataFrame
-                DataFrame with:
-                    index: none;
-                    columns: atomic_number, ion_number, source_level_number,
-                             count_down, count_up, count_total.
+        Prepare the DataFrame with macro atom references for TARDIS
+
+        Returns
+        -------
+        pandas.DataFrame
         """
         macro_atom_references_prepared = self.macro_atom_references.loc[:, [
             "atomic_number", "ion_number", "source_level_number", "count_down",
@@ -795,7 +778,9 @@ class TARDISAtomData:
         return macro_atom_references_prepared
 
     def to_hdf(self, fname):
-        """Dump the `base` attribute into an HDF5 file
+        """
+        Dump the `base` attribute into an HDF5 file
+        
         Parameters
         ----------
         fname : path

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -239,9 +239,9 @@ class TARDISAtomData:
             raise ValueError('Not sure what to do with ttype=5')
 
         #### 1992A&A...254..436B Equation 20 & 22 #####
-        c_ul = 8.63e-6 * upsilon / (g_u * temperatures**.5)
+        c_ul_factor = 8.63e-6 * upsilon / (g_u * temperatures**.5)
 
-        return pd.Series(data=c_ul, index=c_ul_temperature_cols)
+        return pd.Series(data=c_ul_factor, index=c_ul_temperature_cols)
 
     def _get_all_levels_data(self):
         """ Returns the same output than `AtomData._get_all_levels_data()` 

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -532,7 +532,7 @@ class TARDISAtomData:
 
         temperatures = self.collisions_param['temperatures']
 
-        # Derive columns for collisional strenghts
+        # Derive columns for collisional strengths
         c_ul_temperature_cols = ['t{:06d}'.format(t) for t in temperatures]
 
         collisions = collisions.rename(columns={'ion_charge': 'ion_number',

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -547,11 +547,11 @@ class TARDISAtomData:
                                  'g_u', 'energy_upper', 'delta_e', 
                                     'g_ratio']]
 
-        collisional_strengths = collisions.apply(self.calculate_collisional_strength, 
-                                                 axis=1, args=(temperatures, kb_ev, 
-                                                               c_ul_temperature_cols))
+        collisional_ul_factors = collisions.apply(self.calculate_collisional_strength, 
+                                                  axis=1, args=(temperatures, kb_ev, 
+                                                                c_ul_temperature_cols))
 
-        collisions = collisions.join(collisional_strengths)
+        collisions = collisions.join(collisional_ul_factors)
         collisions = collisions.set_index('e_col_id')
 
         return collisions

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -507,7 +507,8 @@ class TARDISAtomData:
             g_u = row["g_u"]
 
             ttype = row["ttype"]
-            if ttype > 5: ttype -= 5
+            if ttype > 5: 
+                ttype -= 5
 
             kt = kb_ev * temperatures
 

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -239,9 +239,9 @@ class TARDISAtomData:
             raise ValueError('Not sure what to do with ttype=5')
 
         #### 1992A&A...254..436B Equation 20 & 22 #####
-        c_ul_factor = 8.63e-6 * upsilon / (g_u * temperatures**.5)
+        collisional_ul_factor = 8.63e-6 * upsilon / (g_u * temperatures**.5)
 
-        return pd.Series(data=c_ul_factor, index=c_ul_temperature_cols)
+        return pd.Series(data=collisional_ul_factor, index=c_ul_temperature_cols)
 
     def _get_all_levels_data(self):
         """ Returns the same output than `AtomData._get_all_levels_data()` 

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -1,22 +1,22 @@
 import re
 import logging
-import numpy as np
-import pandas as pd
 import hashlib
-import platform
 import uuid
 import pytz
+import platform
+import numpy as np
+import pandas as pd
+import astropy.units as u
+import astropy.constants as const
+from scipy import interpolate
 from datetime import datetime
 from carsus.util import (convert_wavelength_air2vacuum,
                          serialize_pandas_object,
                          hash_pandas_object)
 from carsus.model import MEDIUM_VACUUM, MEDIUM_AIR
-from astropy import units as u
-from astropy import constants as const
-from scipy import interpolate
 
-# [nm], wavelengths above this value are given in air
 # TODO: pass GFALL_AIR_THRESHOLD as parameter
+# [nm] wavelengths above this value are given in air
 GFALL_AIR_THRESHOLD = 200
 
 P_EMISSION_DOWN = -1

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -479,8 +479,7 @@ class TARDISAtomData:
         # Calculate g_ratio
         collisions["g_ratio"] = collisions["g_l"] / collisions["g_u"]
 
-        # TODO: pass temperatures as a parameter
-        temperatures = np.arange(2000, 50000, 2000)
+        temperatures = self.collisions_param['temperatures']
 
         # Derive columns for collisional strenghts
         c_ul_temperature_cols = ['t{:06d}'.format(t) for t in temperatures]


### PR DESCRIPTION
:information_source: Continuation of #187 
## Motivation
Adding Chianti collisional data is the last step needed to replicate the atomic files made with past versions of Carsus.

## Changes
<!--- List of changes, features and tasks -->

- [x] Create `get_lvl_index2id` staticmethod to avoid duplicated code.
- [x] Modify `ChiantiReader` class to grab collisional data and store it in `collisions` DataFrame.
- [x] Write `to_hdf` method for `ChiantiReader` class.
- [x] Modify `TARDISAtomData` to store collisional data and temperatures.
- [x] Changes to `GFALLReader` regarding `to_hdf` method.


## Examples
```
chianti_reader = ChiantiReader(ions='H-He', collisions=True, priority=20)
```

