### PR TITLE
Render notebooks on documentation pipeline

### DIFF
--- a/azure-pipelines/doc-build.yml
+++ b/azure-pipelines/doc-build.yml
@@ -80,6 +80,7 @@ jobs:
 # Activate the environment, use sphinx to make the html documentation of the build, and deploy to gh-pages
   - bash: |
         source activate carsus
+        python setup.py install
         bash deploy_docs.sh
     displayName: 'Carsus build and deployment to gh-pages'
 # See github.com/tardis-sn/carsus for the contents of these files


### PR DESCRIPTION
## Motivation
Carsus package wasn't installed in the documentation pipeline, so Sphinx couldn't run the notebooks. This fix should be enough.