### PR TITLE
split docs workflow in multiple jobs

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -25,6 +25,7 @@ env:
 jobs:
 
   build:
+
     runs-on: ubuntu-latest
     steps:
 
@@ -74,6 +75,24 @@ jobs:
         shell: bash -l {0}
         run: cd docs/; make html
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: html-dir
+          path: docs/_build/html
+
+  deploy:
+  
+    needs: build
+    if: github.ref == 'refs/heads/master'
+
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: html-dir
+          path: docs/_build/html
+
       - name: Deploy main site
         uses: peaceiris/actions-gh-pages@v3
         with:
@@ -81,18 +100,37 @@ jobs:
           publish_branch: gh-pages
           publish_dir: docs/_build/html
           force_orphan: true
-        if: github.ref == 'refs/heads/master'
+
+  preview:
+    needs: build
+
+    # Branch deploy is only available on forks, and requires at least one of 
+    # these conditions to be met:
+    #
+    #   a) the branch name contains the word `doc(s)`
+    #   b) commit message includes the a valid tag
+    #   c) the workflow is triggered manually
+
+    if: github.repository_owner != 'tardis-sn' &&
+        github.ref != 'refs/heads/master' && (
+        github.event_name == 'workflow_dispatch' ||
+        contains(github.ref, 'doc') ||
+        contains(github.event.head_commit.message, '[build docs]') ||
+        contains(github.event.head_commit.message, '[build_docs]') ||
+        contains(github.event.head_commit.message, '[build doc]') ||
+        contains(github.event.head_commit.message, '[build_doc]'))
+
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: my-artifact
+          path: docs/_build/html
 
       - name: Get branch name
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: get_branch_name
-
-        # Branch deploy is only available on forks, and requires at least one of 
-        # these conditions to be met:
-        #
-        # - branch name contains the word `doc(s)`.
-        # - commit message includes the a valid tag.
-        # - the workflow is triggered manually.
 
       - name: Deploy branch site
         uses: peaceiris/actions-gh-pages@v3
@@ -102,11 +140,3 @@ jobs:
           publish_dir: docs/_build/html
           destination_dir: branch/${{ steps.get_branch_name.outputs.branch }}
           force_orphan: false
-        if: github.repository_owner != 'tardis-sn' &&
-            github.ref != 'refs/heads/master' && (
-            github.event_name == 'workflow_dispatch' ||
-            contains(github.ref, 'doc') ||
-            contains(github.event.head_commit.message, '[build docs]') ||
-            contains(github.event.head_commit.message, '[build_docs]') ||
-            contains(github.event.head_commit.message, '[build doc]') ||
-            contains(github.event.head_commit.message, '[build_doc]'))

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -21,7 +21,6 @@ env:
   CHIANTI_DB_VER: CHIANTI_v9.0.1_database.tar.gz
   CMFGEN_DL_URL: http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files
   CMFGEN_DB_VER: atomic_data_15nov16.tar.gz
-  SPHINX_CORES: auto
 
 jobs:
 
@@ -74,7 +73,7 @@ jobs:
 
       - name: Build documentation
         shell: bash -l {0}
-        run: cd docs/; CORES=${{ env.SPHINX_CORES }} make html
+        run: cd docs/; make html
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,6 +1,6 @@
-#  For more information about this pipeline, please refer to:
-#  https://tardis-sn.github.io/tardis/development/continuous_integration.html
-#  https://tardis-sn.github.io/tardis/development/documentation_preview.html
+#  For more information about TARDIS pipelines, please refer to:
+#
+#    https://tardis-sn.github.io/tardis/development/continuous_integration.html
 
 name: docs
 

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -21,6 +21,7 @@ env:
   CHIANTI_DB_VER: CHIANTI_v9.0.1_database.tar.gz
   CMFGEN_DL_URL: http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files
   CMFGEN_DB_VER: atomic_data_15nov16.tar.gz
+  SPHINX_CORES: auto
 
 jobs:
 
@@ -73,7 +74,7 @@ jobs:
 
       - name: Build documentation
         shell: bash -l {0}
-        run: cd docs/; make html
+        run: cd docs/; CORES=${{ env.SPHINX_CORES }} make html
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,6 +1,6 @@
-# For more information about this pipeline, please refer to:
-# https://tardis-sn.github.io/tardis/development/continuous_integration.html
-# https://tardis-sn.github.io/tardis/development/documentation_preview.html
+#  For more information about this pipeline, please refer to:
+#  https://tardis-sn.github.io/tardis/development/continuous_integration.html
+#  https://tardis-sn.github.io/tardis/development/documentation_preview.html
 
 name: docs
 
@@ -25,6 +25,23 @@ env:
 jobs:
 
   build:
+
+    #  The `docs` workflow is triggered when a commit is pushed to any branch
+    #  of the main repo or fork, but the `build` job starts when one of these 
+    #  conditions is met:
+    #
+    #    a) the branch is `master`
+    #    b) the branch name contains the word `doc(s)`
+    #    c) the commit message includes the a valid tag
+    #    d) the workflow has been triggered manually
+
+    if: github.ref == 'refs/heads/master' ||
+        github.event_name == 'workflow_dispatch' ||
+        contains(github.ref, 'doc') ||
+        contains(github.event.head_commit.message, '[build docs]') ||
+        contains(github.event.head_commit.message, '[build_docs]') ||
+        contains(github.event.head_commit.message, '[build doc]') ||
+        contains(github.event.head_commit.message, '[build_doc]')
 
     runs-on: ubuntu-latest
     steps:
@@ -83,6 +100,14 @@ jobs:
   deploy:
   
     needs: build
+
+    #  The website is deployed to the root of the `gh-pages` branch of the main 
+    #  repository or fork, only after a commit is pushed to the `master` branch, 
+    #  and the result will be displayed at:
+    #
+    #    tardis-sn.github.io/carsus         (main repository)
+    #    OR <username>.github.io/carsus     (forks)
+
     if: github.ref == 'refs/heads/master'
 
     runs-on: ubuntu-latest
@@ -104,12 +129,16 @@ jobs:
   preview:
     needs: build
 
-    # Branch preview is only available on forks, and requires at least one of 
-    # these conditions to be met:
+    #  Branch preview is only available on forks, and requires at least one of 
+    #  these conditions to be met:
     #
-    #   a) the branch name contains the word `doc(s)`
-    #   b) commit message includes the a valid tag
-    #   c) the workflow is triggered manually
+    #    a) the branch name contains the word `doc(s)`
+    #    b) commit message includes the a valid tag
+    #    c) the workflow is triggered manually
+    #
+    #  Result will be displayed at: 
+    #
+    #    <username>.github.io/carsus/branch/<branch-name>
 
     if: github.repository_owner != 'tardis-sn' &&
         github.ref != 'refs/heads/master' && (

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -104,7 +104,7 @@ jobs:
   preview:
     needs: build
 
-    # Branch deploy is only available on forks, and requires at least one of 
+    # Branch preview is only available on forks, and requires at least one of 
     # these conditions to be met:
     #
     #   a) the branch name contains the word `doc(s)`
@@ -125,7 +125,7 @@ jobs:
 
       - uses: actions/download-artifact@v2
         with:
-          name: my-artifact
+          name: html-dir
           path: docs/_build/html
 
       - name: Get branch name

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,6 @@
-#  For more information about this pipeline, please refer to:
-#  https://tardis-sn.github.io/tardis/development/continuous_integration.html
+#  For more information about TARDIS pipelines, please refer to:
+#
+#    https://tardis-sn.github.io/tardis/development/continuous_integration.html
 
 name: tests
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,5 @@
-# For more information about this pipeline, please refer to:
-# https://tardis-sn.github.io/tardis/development/continuous_integration.html
+#  For more information about this pipeline, please refer to:
+#  https://tardis-sn.github.io/tardis/development/continuous_integration.html
 
 name: tests
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,6 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
-CORES		  = 1
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -42,7 +41,7 @@ clean:
 	-rm -rf generated
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -j $(CORES)
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,6 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
+CORES		  = 1
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -41,7 +42,7 @@ clean:
 	-rm -rf generated
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -j $(CORES)
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
- Split pipeline in `build`, `deploy`  and `preview` jobs
- Fix some logic stuff
- Add very descriptive comments

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Fix bugs, more maintainable.

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
