### PR TITLE
Add pandoc to fix doc build

### DIFF
--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -47,6 +47,7 @@ dependencies:
   - numpydoc
   - docutils
   - recommonmark
+  - pandoc
 
   # Test/Coverage
   - pytest=4


### PR DESCRIPTION
The documentation is currently not building since pandoc is missing from the environment.
I have added pandoc to the environment file to fix this.

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
With the change the documentation builds:
https://chvogl.github.io/carsus/branch/fix_env_doc/index.html

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [x] I have assigned and requested two reviewers for this pull request.
