### PR TITLE
Fix photoionization fit type 0

### DIFF
--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -586,7 +586,7 @@ class CMFGENReader:
                 threshold_energy_ryd = HC_IN_EV_ANGSTROM / lambda_angstrom[j] / RYD_TO_EV
 
                 if cross_section_type == CrossSectionType.CONSTANT_ZERO:
-                    phixs_table = get_null_phixs_table()
+                    phixs_table = get_null_phixs_table(threshold_energy_ryd)
 
                 elif cross_section_type in [CrossSectionType.POINTS_TABLE,
                                             CrossSectionType.OPACITY_PROJECT_SC,
@@ -609,7 +609,7 @@ class CMFGENReader:
                         continue
 
                     if len(fit_coeff_list) == 1 and fit_coeff_list[0] == 0.0:
-                        phixs_table = get_null_phixs_table()
+                        phixs_table = get_null_phixs_table(threshold_energy_ryd)
 
                     else:
                         phixs_table = get_seaton_phixs_table(threshold_energy_ryd, *fit_coeff_list)
@@ -677,7 +677,7 @@ class CMFGENReader:
 
                     except NotImplementedError:
                         logger.warning(f'Leibowitz\'s cross-section type 4 not implemented yet.')
-                        phixs_table = get_null_phixs_table()
+                        phixs_table = get_null_phixs_table(threshold_energy_ryd)
 
                 else:
                     logger.warning(f'Unknown cross-section type {cross_section_type} for configuration \'{lower_level_label}\'.')

--- a/carsus/io/cmfgen/util.py
+++ b/carsus/io/cmfgen/util.py
@@ -350,11 +350,22 @@ def get_leibowitz_phixs_table(threshold_energy_ryd, a, b, c, d, e, f, n_points=1
     raise NotImplementedError
 
 
-def get_null_phixs_table(n_points=1000):
+def get_null_phixs_table(threshold_energy_ryd):
     """
-    Returns a 1-D array of zeros with `n_points` size.
+    Returns a photoionization table with zero cross sections.
+
+    Parameters
+    ----------
+    threshold_energy_ryd : float
+        Photoionization threshold energy in Rydberg.
+
+    Returns
+    -------
+    numpy.ndarray
+        Photoionization cross sections table with zero cross sections.
     """
-    phixs_table = np.column_stack((np.linspace(0, 1.0, 1000, endpoint=False), 
-                                    np.zeros(1000)))
+    energy = np.array([1., 100.]) * threshold_energy_ryd
+    phixs = np.zeros_like(energy)
+    phixs_table = np.column_stack([energy, phixs])
 
     return phixs_table


### PR DESCRIPTION
This PR addresses #263.

**Description**
The frequency grid for fit type 0 now starts at the threshold for photoionization (and not zero). Also, the size of the cross-section table is reduced to two entries.

**Motivation and context**
See #263 

**How has this been tested?**
- [ ] Testing pipeline.
- [x] On my local machine

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [x] I have assigned and requested two reviewers for this pull request.
