### PR TITLE
Raise KeyError when ions are not found in the CMFGEN Reader

### DIFF
--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -504,7 +504,7 @@ class CMFGENReader:
                     logger.info(f'Configuration schema found for {symbol} {ion[1]}.')
 
                 except KeyError:
-                    continue
+                    raise KeyError(f'Configuration schema missing for {symbol} {ion[1]}.')
 
                 osc_fname = BASE_PATH.joinpath(ion_keys['osc']
                                                 ).as_posix()

--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -504,7 +504,9 @@ class CMFGENReader:
                     logger.info(f'Configuration schema found for {symbol} {ion[1]}.')
 
                 except KeyError:
-                    raise KeyError(f'Configuration schema missing for {symbol} {ion[1]}.')
+                    raise KeyError(f'Configuration schema missing for {symbol} {ion[1]}.'
+                                    'Please check the CMFGEN configuration file: carsus/data/cmfgen_config.yml'
+                    )
 
                 osc_fname = BASE_PATH.joinpath(ion_keys['osc']
                                                 ).as_posix()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR raises an exception inside the CMFGEN Reader if the ion provided isn't present in the configuration schema.

**Description**
<!--- Describe your changes in detail -->
Earlier the CMFGENReader wouldn't tell that an ion was not found. This PR raises an exception that for the same:
```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
~/workspace/code/tardis-main/carsus/carsus/io/cmfgen/base.py in from_config(cls, ions, atomic_path, priority, ionization_energies, cross_sections, config_yaml)
    498                 try:
--> 499                     ion_keys = conf['atom'][symbol]['ion_charge'][ion[1]]
    500                     BASE_PATH = ATOMIC_PATH.joinpath(CMFGEN_ATOM_DICT[symbol],

KeyError: 'Ca'

During handling of the above exception, another exception occurred:

KeyError                                  Traceback (most recent call last)
<ipython-input-3-0c046062b844> in <module>
----> 1 cmfgen_reader = CMFGENReader.from_config('Ca 10', cmfgen_path+'/atomic',  ionization_energies=False, cross_sections=True,  )

~/workspace/code/tardis-main/carsus/carsus/io/cmfgen/base.py in from_config(cls, ions, atomic_path, priority, ionization_energies, cross_sections, config_yaml)
    505 
    506                 except KeyError:
--> 507                     raise KeyError(f'Configuration schema missing for {symbol} {ion[1]}.'
    508                                     ' Please check the CMFGEN configuration file: carsus/data/cmfgen_config.yml'
    509                     )

KeyError: 'Configuration schema missing for Ca 10. Please check the CMFGEN configuration file: carsus/data/cmfgen_config.yml'
```

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [X] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [X] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [X] I have assigned and requested two reviewers for this pull request.
