### PR TITLE
Remove incorrect weighting of photo ion cross-sections for J split levels

### DIFF
--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -579,10 +579,6 @@ class CMFGENReader:
             lambda_angstrom = match['Lam(A)'].tolist()
             level_number = (match['ID'] -1).tolist()
 
-            # Get statistical weights for J-splitted levels
-            match['w'] = match['g']/match.sum()['g']
-            w = match['w'].tolist()
-
             # match is > 1 just for J-splitted levels
             for j in range(len(match)):
                 threshold_energy_ryd = HC_IN_EV_ANGSTROM / lambda_angstrom[j] / RYD_TO_EV
@@ -687,7 +683,6 @@ class CMFGENReader:
 
                 df = pd.DataFrame(phixs_table, columns=['energy', 'sigma'])
                 df['level_index'] = level_number[j]
-                df['sigma'] = w[j]*df['sigma']
 
                 phixs_table_list.append(df)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [X] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [X] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [X] I have assigned and requested two reviewers for this pull request.
