### PR TITLE
Fixes for conda environment

### DIFF
--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -54,6 +54,10 @@ dependencies:
   - pytest-cov
   - pytest-astropy
   - pytest-xdist
+  - pytest-notebook
+  - nbconvert=5  # chrisjsewell/pytest-notebook/issues/10
+  - coverage=4  # chrisjsewell/pytest-notebook/issues/6
+  - attrs=20  # chrisjsewell/pytest-notebook/issues/16
 
   # ChiantiPy
   - scipy
@@ -61,7 +65,3 @@ dependencies:
 
   # Other
   - git-lfs
-
-  # Pip
-  - pip:
-    - pytest_notebook>=0.7

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -15,23 +15,24 @@ dependencies:
 
   # I/O
   - pyyaml
-  - requests
   - uncertainties
-  - beautifulsoup4
-  - html5lib
   - pyparsing=2.2
   - sqlalchemy=1.0
+  - beautifulsoup4
+  - html5lib
   - h5py
   - pytables
-  - pyarrow=0.14
+  - pyarrow=0.14.1
+  - glog=0.5  # ???
+  - requests
   - roman
 
 # --- Not required for conda-forge package ---
 
   # Analysis
-  - jupyter
-  - jupyter_client=6  # jupyter/jupyter_client/issues/637
-  - matplotlib
+  - notebook
+  - tornado=6.0  # ???
+  - matplotlib-base
 
   # Documentation
   - sphinx
@@ -41,7 +42,6 @@ dependencies:
   - sphinx_rtd_theme
   - sphinxcontrib-apidoc
   - sphinxcontrib-bibtex
-  - nbconvert=5  # chrisjsewell/pytest-notebook/issues/10
   - nbformat
   - nbsphinx
   - numpydoc
@@ -55,14 +55,10 @@ dependencies:
   - pytest-astropy
   - pytest-notebook
   - pytest-xdist
-  - coverage=4  # chrisjsewell/pytest-notebook/issues/6
-  - attrs=20  # chrisjsewell/pytest-notebook/issues/16
 
   # ChiantiPy
   - scipy
   - ipyparallel
-  - blas=1.1  # numpy/numpy/issues/14165
 
   # Other
   - git-lfs
-  

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -55,6 +55,7 @@ dependencies:
   - pytest-astropy
   - pytest-xdist
   - pytest-notebook
+  - jupyter_client=6  # jupyter/jupyter_client/issues/637
   - nbconvert=5  # chrisjsewell/pytest-notebook/issues/10
   - coverage=4  # chrisjsewell/pytest-notebook/issues/6
   - attrs=20  # chrisjsewell/pytest-notebook/issues/16

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -32,7 +32,6 @@ dependencies:
 
   # Analysis
   - notebook
-  - tornado=6.0  # ???
   - matplotlib-base
 
   # Documentation
@@ -54,7 +53,6 @@ dependencies:
   - pytest=4
   - pytest-cov
   - pytest-astropy
-  - pytest-notebook
   - pytest-xdist
 
   # ChiantiPy
@@ -63,3 +61,7 @@ dependencies:
 
   # Other
   - git-lfs
+
+  # Pip
+  - pip:
+    - pytest_notebook>=0.7

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -12,6 +12,7 @@ dependencies:
   - pandas=1.0
   - astropy=3
   - chiantipy=0.8.4
+  - typing-extensions=4.1  # https://github.com/python/typing/issues/1158
 
   # I/O
   - pyyaml
@@ -23,7 +24,7 @@ dependencies:
   - h5py
   - pytables
   - pyarrow=0.14.1
-  - glog=0.5  # ???
+  - glog=0.5  # https://github.com/google/glog/issues/814
   - requests
   - roman
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->


**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

Two conda-forge packages have been updated in the last month and broke the environment. Also, seems pinning `blas` is not required anymore, probably fixed upstream in the `macos-latest` image.

Other minor rearrangements have been made.

See:

- https://github.com/google/glog/issues/814
- https://github.com/python/typing/issues/1158


**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [ ] I have assigned and requested two reviewers for this pull request.
