### PR TITLE
Remove nbsphinx hidden cells in favor of `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ pip-wheel-metadata/
 # Carsus
 carsus/tests/data/*.db
 carsus/model/tests/data/*.db
+docs/**/*.h5

--- a/docs/development/compare_atomic_files.ipynb
+++ b/docs/development/compare_atomic_files.ipynb
@@ -280,18 +280,6 @@
     "tt.style.applymap(highlight_values, subset=['val_lvl', 'val_lns']).applymap(\n",
     "                    highlight_diff, subset=['diff_lvl', 'diff_lns'])"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "nbsphinx": "hidden"
-   },
-   "outputs": [],
-   "source": [
-    "# nbsphinx hidden cell\n",
-    "!rm A.h5 B.h5"
-   ]
   }
  ],
  "metadata": {

--- a/docs/legacy/quickstart_legacy.ipynb
+++ b/docs/legacy/quickstart_legacy.ipynb
@@ -295,18 +295,6 @@
    "source": [
     "You are done! Now you can use your file to run TARDIS simulations."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "nbsphinx": "hidden"
-   },
-   "outputs": [],
-   "source": [
-    "# nbsphinx hidden cell\n",
-    "!rm kurucz_H-Mg_chianti_O_I-III.h5"
-   ]
   }
  ],
  "metadata": {

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -256,23 +256,11 @@
    "source": [
     "pd.read_hdf('kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5', key='meta')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "nbsphinx": "hidden"
-   },
-   "outputs": [],
-   "source": [
-    "# nbsphinx hidden cell\n",
-    "!rm kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5"
-   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -286,7 +274,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.15"
+   "version": "3.8.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->

Add `docs/**/*.h5`files to `.gitignore`, remove hidden nbsphinx cells that remove `.h5` files.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

Way simpler solution.

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

See: 
- https://epassaro.github.io/carsus/branch/docs/hdf-to-gitignore/quickstart.html
- and https://github.com/epassaro/carsus/tree/gh-pages/branch/docs/hdf-to-gitignore/io

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [x] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [x] I have assigned and requested two reviewers for this pull request.
