### PR TITLE
Allow combining NIST and CMFGEN ionization energies

### DIFF
--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -932,7 +932,8 @@ class CMFGENReader:
             )
             ionization_energies = ionization_energies.set_index(
                 ["atomic_number", "ion_charge"]
-            ).squeeze()
+            )
+            ionization_energies = ionization_energies["ionization_energy"]
             self.ionization_energies = ionization_energies
 
         if "cross_sections" in reader.keys():

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -1,15 +1,17 @@
-import re
+import copy
 import logging
+import re
+
+import astropy.constants as const
+import astropy.units as u
 import numpy as np
 import pandas as pd
-import astropy.units as u
-import astropy.constants as const
 from scipy import interpolate
+
+from carsus.model import MEDIUM_AIR, MEDIUM_VACUUM
 from carsus.util import (convert_atomic_number2symbol,
-                         convert_wavelength_air2vacuum,
-                         serialize_pandas_object,
-                         hash_pandas_object)
-from carsus.model import MEDIUM_VACUUM, MEDIUM_AIR
+                         convert_wavelength_air2vacuum, hash_pandas_object,
+                         serialize_pandas_object)
 
 # Wavelengths above this value are given in air
 GFALL_AIR_THRESHOLD = 2000 * u.AA
@@ -53,7 +55,6 @@ class TARDISAtomData:
         self.atomic_weights = atomic_weights
 
         if (cmfgen_reader is not None) and hasattr(cmfgen_reader, 'ionization_energies'):
-            import copy
             combined_ionization_energies = copy.deepcopy(ionization_energies)
             combined_ionization_energies.base = cmfgen_reader.ionization_energies.combine_first(ionization_energies.base)
             self.ionization_energies = combined_ionization_energies
@@ -1008,10 +1009,12 @@ class TARDISAtomData:
 
         """
         import hashlib
-        import uuid
         import platform
-        import pytz
+        import uuid
         from datetime import datetime
+
+        import pytz
+
         from carsus import FORMAT_VERSION
 
         with pd.HDFStore(fname, 'w') as f:

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -51,7 +51,15 @@ class TARDISAtomData:
                 ):
 
         self.atomic_weights = atomic_weights
-        self.ionization_energies = ionization_energies
+
+        if (cmfgen_reader is not None) and hasattr(cmfgen_reader, 'ionization_energies'):
+            import copy
+            combined_ionization_energies = copy.deepcopy(ionization_energies)
+            combined_ionization_energies.base = cmfgen_reader.ionization_energies.combine_first(ionization_energies.base)
+            self.ionization_energies = combined_ionization_energies
+        else:
+            self.ionization_energies = ionization_energies
+
         self.gfall_reader = gfall_reader
         self.zeta_data = zeta_data
         self.chianti_reader = chianti_reader

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -10,9 +10,9 @@
     "\n",
     "<div class=\"alert alert-info\">\n",
     "\n",
-    "**Read first:**\n",
+    "**Note:**\n",
     "\n",
-    "Get familiar with [Notation in Carsus](development/notation.rst) and learn how to select different sets of ions.\n",
+    "Get familiar with the [Notation in Carsus](development/notation.rst) and learn how to correctly select ions.\n",
     "    \n",
     "</div>"
    ]
@@ -21,7 +21,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Atomic Weights and Ionization Energies\n",
+    "## Atomic Weights and Ionization Energies (NIST)\n",
     "\n",
     "Download atomic weights and ionization energies from the National Institute of Standards and Technology (NIST)."
    ]
@@ -49,9 +49,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Levels, Lines, Collisions and Cross-sections\n",
+    "## Levels, Lines, Collisions & Cross-sections\n",
     "\n",
-    "Carsus supports three sources of energy levels and spectral lines: GFALL, CHIANTI and CMFGEN.\n",
+    "Carsus supports three sources of energy levels and spectral lines: **GFALL**, **CHIANTI** and **CMFGEN**.\n",
     "\n",
     "### GFALL\n",
     "\n",
@@ -61,7 +61,7 @@
     "\n",
     "**Warning:**\n",
     "    \n",
-    "Creating a `GFALLReader` instance is **required**. Other sources of levels and lines are **optional**.\n",
+    "Creating a `GFALLReader` instance is **required**.\n",
     "\n",
     "</div>"
    ]
@@ -83,7 +83,8 @@
    "source": [
     "from carsus.io.kurucz import GFALLReader\n",
     "\n",
-    "gfall_reader = GFALLReader('H-Zn', '/tmp/gfall.dat')"
+    "gfall_reader = GFALLReader('H-Zn',\n",
+    "                           '/tmp/gfall.dat')"
    ]
   },
   {
@@ -92,7 +93,15 @@
    "source": [
     "### CHIANTI\n",
     "\n",
-    "The Chianti Atomic Database reader provides levels and lines but also **collision strengths**."
+    "The Chianti Atomic Database reader provides levels and lines but also **collision strengths**.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "**Note:**\n",
+    "\n",
+    "Creating a `ChiantiReader` instance is **optional**. \n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -103,7 +112,9 @@
    "source": [
     "from carsus.io.chianti_ import ChiantiReader\n",
     "\n",
-    "chianti_reader = ChiantiReader('H-He', collisions=True, priority=20)"
+    "chianti_reader = ChiantiReader('H-He', \n",
+    "                               collisions=True, \n",
+    "                               priority=20)"
    ]
   },
   {
@@ -119,7 +130,28 @@
    "source": [
     "### CMFGEN\n",
     "\n",
-    "The atomic database of [CMFGEN](http://kookaburra.phyast.pitt.edu/hillier/web/CMFGEN.htm) is a source of levels, lines and (optionally) **ionization energies**, **photoionization cross-sections** and **collisions** ."
+    "The atomic database of [CMFGEN](http://kookaburra.phyast.pitt.edu/hillier/web/CMFGEN.htm) is a source of levels, lines and (optionally) **ionization energies**, **photoionization cross-sections** and **collisions**.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "    \n",
+    "**Note:**\n",
+    "\n",
+    "Creating a `CMFGENReader` instance is **optional**. \n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "**Warning:**\n",
+    "    \n",
+    "Cross-sections require data from `H 0`, use this the reader with enough `priority` to select levels from this ion.\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -130,7 +162,8 @@
    "source": [
     "from carsus.io.cmfgen import CMFGENReader\n",
     "\n",
-    "cmfgen_reader = CMFGENReader.from_config('Si 0-1', '/tmp/atomic', \n",
+    "cmfgen_reader = CMFGENReader.from_config('Si 0-1', \n",
+    "                                         '/tmp/atomic', \n",
     "                                         priority=30,\n",
     "                                         ionization_energies=True,\n",
     "                                         cross_sections=True,\n",
@@ -143,37 +176,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-warning\">\n",
-    "\n",
-    "**Warning:**\n",
-    "    \n",
-    "Remember that cross-sections requires data from `H 0` so give this the reader enough `priority`. \n",
-    "\n",
-    "</div>\n",
-    "\n",
-    "If you want to use the **ionization energies** from CMFGEN, you will need to apply this dirty hack to merge both sources:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import copy\n",
-    "import pandas as pd\n",
-    "\n",
-    "combined_ionization_energies = copy.deepcopy(ionization_energies)\n",
-    "combined_ionization_energies.base = cmfgen_reader.ionization_energies.combine_first(ionization_energies.base)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Zeta Data\n",
     "\n",
-    "Knox S. Long's ground state recombinations fractions ($\\zeta$)."
+    "Long & Knigge's ground state recombinations fractions ($\\zeta$)."
    ]
   },
   {
@@ -191,7 +196,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Dump to HDF5\n",
+    "## Create an Atomic Data File\n",
     "\n",
     "Finally, create a `TARDISAtomData` object and dump the data with the `to_hdf` method."
    ]
@@ -207,7 +212,7 @@
     "from carsus.io.output import TARDISAtomData\n",
     "\n",
     "atom_data = TARDISAtomData(atomic_weights,\n",
-    "                           combined_ionization_energies,\n",
+    "                           ionization_energies,\n",
     "                           gfall_reader,\n",
     "                           zeta_data,\n",
     "                           chianti_reader,\n",
@@ -234,9 +239,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Metadata\n",
+    "### Metadata\n",
     "\n",
-    "Carsus stores metadata inside the HDF5 files to ensure reproducibility. This metadata includes a checksum per `DataFrame`, the current version of every dataset and relevant software versions. "
+    "Carsus stores metadata inside the HDF5 files to ensure reproducibility. This metadata includes a checksum for each stored table, version number or checksum of selected datasets, and versions of relevant packages. "
    ]
   },
   {
@@ -254,13 +259,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pd.read_hdf('kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5', key='metadata')"
+    "store = pd.HDFStore('kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5', key='metadata')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "store[\"metadata\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "store.root._v_attrs"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -274,7 +297,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.6.15"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->

- Remove hack from Quickstart; make Carsus smart enough to do it for itself.
- Fixes #286
  > The [`squeeze`](https://pandas.pydata.org/pandas-docs/version/1.0/reference/api/pandas.Series.squeeze.html) method that returns a `numpy.float64` when the `pandas.DataFrame` object has a single row. To always get a `pandas.Series` just select the desired column after setting the index.

Preview of the new Quickstart: https://epassaro.github.io/carsus/branch/io/remove-dirty-hack/quickstart.html

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
<!--- please describe how you tested your changes, `pytest` flags used, etc. -->

- [x] Testing pipeline
- [ ] Other

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->

- [x] Bug fix <!-- Non-breaking change which fixes an issue -->
- [x] New feature <!-- Non-breaking change which adds functionality -->
- [ ] Breaking change <!-- Fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above <!-- Please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->

- [x] I have updated the documentation according to my changes
- [x] I have built the documentation by applying the `build_docs` label to this pull request (if you don't have enough privileges a reviewer will do it for you)
- [x] I have requested two reviewers for this pull request
