### PR TITLE
Allow running Carsus even if XUVTOP environment variable is not present

### DIFF
--- a/carsus/io/__init__.py
+++ b/carsus/io/__init__.py
@@ -1,17 +1,10 @@
 import os
-import logging
 from carsus.io.nist import NISTIonizationEnergiesParser, NISTIonizationEnergiesIngester,\
     NISTWeightsCompPyparser, NISTWeightsCompIngester
 from carsus.io.kurucz import GFALLReader, GFALLIngester
 from carsus.io.output import AtomData
 from carsus.io.zeta import KnoxLongZetaIngester
 
-logger = logging.getLogger(__name__)    
 
 if "XUVTOP" in os.environ:
     from carsus.io.chianti_ import ChiantiIonReader, ChiantiIngester
-else:
-    logger.warning(
-        "XUVTOP environment variable is not set in your shell configuration file. "
-        "The XUVTOP environment variable is required if you want to use the Chianti submodule."
-    )

--- a/carsus/io/__init__.py
+++ b/carsus/io/__init__.py
@@ -1,6 +1,17 @@
+import os
+import logging
 from carsus.io.nist import NISTIonizationEnergiesParser, NISTIonizationEnergiesIngester,\
     NISTWeightsCompPyparser, NISTWeightsCompIngester
-from carsus.io.chianti_ import ChiantiIonReader, ChiantiIngester
 from carsus.io.kurucz import GFALLReader, GFALLIngester
 from carsus.io.output import AtomData
 from carsus.io.zeta import KnoxLongZetaIngester
+
+logger = logging.getLogger(__name__)    
+
+if "XUVTOP" in os.environ:
+    from carsus.io.chianti_ import ChiantiIonReader, ChiantiIngester
+else:
+    logger.warning(
+        "XUVTOP environment variable is not set in your shell configuration file. "
+        "The XUVTOP environment variable is required if you want to use the Chianti submodule."
+    )

--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -22,6 +22,7 @@ try:
 
 except ImportError:
     # Shamefully copied from their GitHub source:
+    import chianti.core as ch
     def versionRead():
         """
         Read the version number of the CHIANTI database
@@ -32,7 +33,6 @@ except ImportError:
         versionStr = vFile.readline()
         vFile.close()
         return versionStr.strip()
-    import chianti.core as ch
 
 
 logger = logging.getLogger(__name__)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,7 +7,7 @@ Prerequisites
 =============
 
 #. Requires a valid Anaconda `or Miniconda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html>`_ installation.
-#. Download and extract the `Chianti Atomic Database <https://download.chiantidatabase.org/>`_ **v9.0.1** and set the following environment variable in your shell configuration file:
+#. *(optional)*. Download and extract the `Chianti Atomic Database <https://download.chiantidatabase.org/>`_ **v9.0.1** and set the following environment variable in your shell configuration file:
 
     .. code ::
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
XUVTOP environment variable was necessary for using Carsus because it was required by ChiantiPy. This PR makes it optional to use the Chianti Submodule by not asking to set the environment variable. A warning is raised by ChiantiPy when it is imported but the XUVTOP variable is not present.

**Description**
<!--- Describe your changes in detail -->
Resolves https://github.com/tardis-sn/carsus/issues/202 

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
<!--- please describe how you tested your changes, `pytest` flags used, etc. -->

- [X] Testing pipeline
- [ ] Other

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
https://atharva-2001.github.io/carsus/branch/unset_XUVTOP/installation.html


**Type of change**
<!--- Put an `x` in all the boxes that apply -->

- [X] Bug fix <!-- Non-breaking change which fixes an issue -->
- [ ] New feature <!-- Non-breaking change which adds functionality -->
- [ ] Breaking change <!-- Fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above <!-- Please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->

- [X] I have updated the documentation according to my changes
- [X] I have built the documentation by applying the `build_docs` label to this pull request (if you don't have enough privileges a reviewer will do it for you)
- [ ] I have requested two reviewers for this pull request
