### PR TITLE
Fixed paths to CMFGEN atomic files

### DIFF
--- a/carsus/data/cmfgen_config.yml
+++ b/carsus/data/cmfgen_config.yml
@@ -89,7 +89,7 @@ atom:
   Co:
     ion_charge:
       1:
-        date: 30oct12
+        date: 15nov11
         osc: fin_osc_bound
         col: Co2_COL_DATA
         pho:
@@ -113,7 +113,7 @@ atom:
           - niphot_c.dat
           - niphot_d.dat
       1:
-        date: 12sep12
+        date: 23jan06
         osc: fin_osc
         col: n2col.dat
         pho:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This pull request changes the paths to the Co II and N II atomic files from CMFGEN.
The file names are correct but the name of the directories were wrong.

**Description**
<!--- Describe your changes in detail -->
The correct path to the directories are given.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Cannot create an atomic file if Co II or N II data are required because the paths to these files are incorrect.

**How has this been tested?**
<!--- please describe how you tested your changes, `pytest` flags used, etc. -->

- [x] Testing pipeline
- [ ] Other

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->

- [x] Bug fix <!-- Non-breaking change which fixes an issue -->
- [ ] New feature <!-- Non-breaking change which adds functionality -->
- [ ] Breaking change <!-- Fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above <!-- Please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation according to my changes
- [ ] I have built the documentation by applying the `build_docs` label to this pull request (if you don't have enough privileges a reviewer will do it for you)
- [x] I have requested two reviewers for this pull request
