### PR TITLE
Rename CMFGEN Index labels 2

### DIFF
--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -83,7 +83,12 @@ class TARDISAtomData:
             )
         else:
             if hasattr(cmfgen_reader, "collisions"):
-                self.collisions = cmfgen_reader.collisions
+                collisions = cmfgen_reader.collisions
+                collisions.index = collisions.index.rename(
+                    ['atomic_number', 'ion_number', 'level_number_lower', 'level_number_upper']
+                )
+
+                self.collisions = collisions
                 self.collisions_metadata = cmfgen_reader.collisional_metadata
 
             elif hasattr(chianti_reader, "collisions"):

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -83,7 +83,7 @@ class TARDISAtomData:
             )
         else:
             if hasattr(cmfgen_reader, "collisions"):
-                collisions = cmfgen_reader.collisions
+                collisions = cmfgen_reader.collisions.copy()
                 collisions.index = collisions.index.rename(
                     ['atomic_number', 'ion_number', 'level_number_lower', 'level_number_upper']
                 )


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

Write a complete description of your changes, including the necessary context or any piece of information required to understand your work.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 

Addresses issue mentioned in https://github.com/tardis-sn/carsus/pull/304#issuecomment-1138885838.

The collisions dataframe is now consistent among the readers, but these label names are renamed for both Chianti and CMFGEN in the output module. The new final collisions dataframe does not have the same index labels as those in the readers. 

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [X] Other method (describe)
- [ ] My changes can't be tested (explain why)
I am able to generate a carsus output file with these changes now. Changes introduced in PR https://github.com/tardis-sn/carsus/pull/304 did now allow creating a carsus output file with CMFGEN collisions.

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
