### PR TITLE
Mapping labels into levels for each ion

### DIFF
--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -964,13 +964,14 @@ class CMFGENReader:
             will have all the temperatures from the CMFGEN dataset by default.
         """
         col_list, t_grid = [], []
-        levels_combine = self.levels.copy().reset_index()
-        label_ind_mapping = {
-            label: index
-            for label, index in zip(levels_combine.label, levels_combine.level_index)
-        }
 
         for ion, data_dict in data.items():
+            levels_combine = self.levels.loc[ion].copy().reset_index()
+            label_ind_mapping = {
+                label: index
+                for label, index in zip(levels_combine.label, levels_combine.level_index)
+                }
+
             levels = data_dict["levels"].copy()
             collisions = data_dict["collisions"].copy()
 

--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -1023,12 +1023,12 @@ class CMFGENReader:
                     f"Entries having label(s): {', '.join(missing_labels)} will be dropped for ion: {ion}."
                 )
 
-            collisions["level_number_lower"] = lower_level_index
-            collisions["level_number_upper"] = upper_level_index
+            collisions["level_index_lower"] = lower_level_index
+            collisions["level_index_upper"] = upper_level_index
             collisions["gi"] = gi
 
             collisions = collisions.dropna(
-                subset=["level_number_lower", "level_number_upper"]
+                subset=["level_index_lower", "level_index_upper"]
             )
 
             collisions["atomic_number"] = ion[0]
@@ -1037,8 +1037,8 @@ class CMFGENReader:
 
             collisions = collisions.astype(
                 {
-                    "level_number_upper": int,
-                    "level_number_lower": int,
+                    "level_index_upper": int,
+                    "level_index_lower": int,
                 }
             )
 
@@ -1046,8 +1046,8 @@ class CMFGENReader:
                 [
                     "atomic_number",
                     "ion_number",
-                    "level_number_lower",
-                    "level_number_upper",
+                    "level_index_lower",
+                    "level_index_upper",
                 ]
             )
             # divide the dataframe by gi and remove the column

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -696,6 +696,11 @@ class TARDISAtomData:
                         for ion in ions]
         collisions = pd.concat(col_list, sort=True)
         collisions = collisions.sort_values(by=['lower_level_id', 'upper_level_id'])
+        
+        # Everything else has been solved by the CMFGEN reader, we just need to rename the columns 
+        collisions = collisions.rename(columns={'lower_level_id': 'level_number_lower', 'upper_level_id': 'level_number_upper'})
+        collisions = collisions.set_index(['atomic_number', 'ion_number', 'level_number_lower', 'level_number_upper'])
+        collisions = collisions.drop(columns=['level_index_lower', 'level_index_upper'])
 
         return collisions
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Write a complete description of your changes, including the necessary context or any piece of information required to understand your work.

There is a problem when mapping `labels` into `level indexes`. Mapping is done for all ions simultaneously, but `labels` are not unique, and one could get some levels that are not included in the CMFGEN files. With this PR, `labels` are mapped within each ion.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
@epassaro 