### PR TITLE
Add Workflow to check compatibility of TARDIS and Carsus 

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -46,6 +46,18 @@ jobs:
             tar -zxf ${{ env.XUVTOP }}/chianti.tar.gz -C ${{ env.XUVTOP }}
         if: steps.chianti-cache.outputs.cache-hit != 'true'
       
+      - uses: actions/cache@v2
+        with:
+          path: /tmp/atomic
+          key: ${{ env.CMFGEN_DB_VER }}
+        id: cmfgen-cache
+
+      - name: Download CMFGEN database
+        run: |
+            wget -q -U "Mozilla/4.0" ${{ env.CMFGEN_DL_URL }}/${{ env.CMFGEN_DB_VER }} -O /tmp/atomic.tar.gz
+            tar -zxf /tmp/atomic.tar.gz -C /tmp
+        if: steps.cmfgen-cache.outputs.cache-hit != 'true'
+        
       - name: Setup environment
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -140,6 +140,9 @@ jobs:
       - name: Download reference data for simulation data
         run: wget -O unit_test_data_new.h5 https://dev.azure.com/tardis-sn/TARDIS/_apis/git/repositories/tardis-refdata/items?path=unit_test_data.h5&resolveLfs=true
 
+      - name: Download reference data
+        run: bash .ci-helpers/download_reference_data.sh
+
       - name: Print path
         run: python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' unit_test_data_new.h5
       
@@ -147,7 +150,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: reference data
-          path: unit_test_data_new.h5
+          path: tardis-refdata/unit_test_data.h5
 
       - name: Print directory tree
         run: tree

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -40,8 +40,9 @@ jobs:
       - name: Clone tardis-sn/carsus
         uses: actions/checkout@v2
         with:
-          repository: tardis-sn/carsus
+          repository: atharva-2001/carsus
           path: carsus/
+          ref: arraydiff_unpin_version
         
       - uses: actions/cache@v2
         with:
@@ -155,8 +156,12 @@ jobs:
           path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
           # path: kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
       
+      
+      - name: Print path
+        run: python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
+
       - name: Replace atomic data in reference data repository with the generated atomic data
-        run: cp tardis/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5 tardis-refdata/atom_data/kurucz_cd23_chianti_H_He.h5
+        run: cp carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5 tardis-refdata/atom_data/kurucz_cd23_chianti_H_He.h5
       
       - name: Create copy of reference data for comparision
         run: cp tardis-refdata/unit_test_data.h5 tardis-refdata/unit_test_data_org.h5 

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -17,11 +17,14 @@ env:
   CMFGEN_DL_URL: http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files
   CMFGEN_DB_VER: atomic_data_15nov16.tar.gz
 
-jobs:
- carsus-build:
-    defaults:
+
+defaults:
       run:
         shell: bash -l {0}
+
+
+jobs:
+  carsus-build:
     runs-on: ubuntu-latest
 
     steps:
@@ -60,7 +63,7 @@ jobs:
             tar -zxf /tmp/atomic.tar.gz -C /tmp
         if: steps.cmfgen-cache.outputs.cache-hit != 'true'
 
-      - name: Setup environment
+      - name: Setup carsus environment
         uses: conda-incubator/setup-miniconda@v2
         with:
             miniforge-variant: Mambaforge
@@ -81,7 +84,49 @@ jobs:
       - name: upload atom data
         uses: actions/upload-artifact@v2
         with:
-          name: atom_data
+          name: atom-data
           path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
-    
+  
+  tardis-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: tardis-sn/tardis
+          path: tardis/
+
+      - name: Setup TARDIS environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+            miniforge-variant: Mambaforge
+            miniforge-version: latest
+            activate-environment: tardis
+            use-mamba: true
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ matrix.prefix }}
+          key: conda-${{ matrix.label }}-${{ hashFiles('conda-${{ matrix.label }}.lock') }}-${{ env.CACHE_NUMBER }}
+        id: cache-conda
+
+      - name: Update environment
+        run: mamba update -n tardis --file conda-${{ matrix.label }}.lock
+        if: steps.cache-conda.outputs.cache-hit != 'true'
+
+      - name: Install package
+        run: pip install -e .
+
+  generate-spectrum:
+    runs-on: ubuntu-latest
+    needs: [carsus-build, tardis-build]
+
+    steps: 
+      - uses: actions/download-artifact@v2
+        with:
+          name: atom-data
+          path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
+
+
+
+
 

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -136,4 +136,4 @@ jobs:
           path: ref_data_compare_from_paths.html
       
       - name: Check if reference data are equal
-        run: if [ "$(cat /tmp/spectrum_compare)" == 0 ]; then exit 1; fi
+        run: if [ "$(cat refdata_compare_result)" == "REFDATA COMPARISON FAILED" ]; then exit 1; fi

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -1,20 +1,12 @@
 name: tardis-carsus-compatibility-check
 
-# on: 
-#   workflow_dispatch:
-#     inputs:
-#       git-ref:
-#         description: Git Ref (Optional)    
-#         required: false
+on: 
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        description: Git Ref (Optional)    
+        required: false
 
-on:
-  push:
-    branches:
-    - '*'
-
-  pull_request:
-    branches:
-    - '*'
         
 env:
   XUVTOP: /tmp/chianti
@@ -101,24 +93,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: tardis-sn/tardis
-          
-      # - uses: actions/checkout@v2
-      #   with:
-      #     repository: atharva-2001/tardis-refdata
-      #     ref: raise_error_refdata_compare
-      #     path: tardis-refdata
-      #     lfs: true
         
       - name: Download refdata_compare notebook
         run: wget https://raw.githubusercontent.com/atharva-2001/tardis-refdata/raise_error_refdata_compare/notebooks/ref_data_compare_from_paths.ipynb
         
       - name: Download reference data
         run: bash .ci-helpers/download_reference_data.sh
-
-      # - name: Fetch lfs objects
-      #   run: |
-      #        cd tardis-refdata
-      #        git lfs checkout 
 
       - name: Setup TARDIS environment
         uses: conda-incubator/setup-miniconda@v2
@@ -128,15 +108,8 @@ jobs:
             activate-environment: tardis
             use-mamba: true
 
-      # - uses: actions/cache@v2
-      #   with:
-      #     path: /usr/share/miniconda3/envs/tardis
-      #     key: conda-linux-64-${{ hashFiles('conda-linux-64.lock') }}-${{ env.CACHE_NUMBER }}
-      #   id: cache-conda
-
       - name: Update environment
         run: mamba update -n tardis --file conda-linux-64.lock
-      #   if: steps.cache-conda.outputs.cache-hit != 'true'
 
       - name: Install bokeh
         run: mamba install bokeh=2.2 --channel conda-forge --no-update-deps --yes

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -1,7 +1,16 @@
 name: tardis-carsus-compatibility-check
 
-on: 
-  workflow_dispatch
+# on: 
+#   workflow_dispatch
+
+on:
+  push:
+    branches:
+    - '*'
+
+  pull_request:
+    branches:
+    - '*'
 
         
 env:
@@ -136,4 +145,4 @@ jobs:
           path: ref_data_compare_from_paths.html
       
       - name: Check if reference data are equal
-        run: if [ "$(cat refdata_compare_result)" == "REFDATA COMPARISON FAILED" ]; then exit 1; fi
+        run: if [ "$(cat ../refdata_compare_result)" == "REFDATA COMPARISON FAILED" ]; then exit 1; fi

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -149,6 +149,7 @@ jobs:
         run:  pytest tardis ${{ env.PYTEST_FLAGS }}
 
       - name: Run notebook to test spectrum
+        continue-on-error: true
         run: |
             ${{ env.NBCONVERT_CMD }} "tardis-refdata/notebooks/ref_data_compare_from_paths.ipynb"
       

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Run notebooks
         run: |
-          jupyter nbconvert ${{ env.NBCONVERT_FLAGS }} carsus/docs/refdata_gen.ipynb
+          jupyter nbconvert ${{ env.NBCONVERT_FLAGS }} carsus/docs/tardis_atomdata_ref.ipynb
         env:
           CARSUS_REFDATA: ${{ github.workspace }}/carsus-refdata
         
@@ -134,10 +134,10 @@ jobs:
         run: |
             jupyter nbconvert ${{ env.NBCONVERT_FLAGS }} ref_data_compare_from_paths.ipynb
       
-      - name: Upload spectrum notebook
+      - name: Upload comparison notebook
         uses: actions/upload-artifact@v2
         with:
           path: ref_data_compare_from_paths.html
       
-      - name: Check if spectra were equal during comparision
+      - name: Check if reference data are equal
         run: if [ "$(cat /tmp/spectrum_compare)" == 0 ]; then exit 1; fi

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -1,14 +1,12 @@
 name: tardis-carsus-compatibility-check
 
-on:
-  push:
-    branches:
-    - '*'
-
-  pull_request:
-    branches:
-    - '*'
-
+on: 
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        description: Git Ref (Optional)    
+        required: false
+        
 env:
   XUVTOP: /tmp/chianti
   CHIANTI_DL_URL: https://download.chiantidatabase.org

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -88,6 +88,13 @@ jobs:
           path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
   
   tardis-build:
+    strategy: # TODO
+        matrix:
+          include:
+          - os: ubuntu-latest
+            label: linux-64
+            prefix: /usr/share/miniconda3/envs/tardis
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -17,9 +17,9 @@ env:
   CMFGEN_DL_URL: http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files
   CMFGEN_DB_VER: atomic_data_15nov16.tar.gz
   # original reference data
-  REF1_PATH: /home/runner/work/tardis/tardis/tardis-refdata/unit_test_data_org.h5
+  REF1_PATH: /home/runner/work/carsus/carsus/tardis-refdata/unit_test_data_org.h5
   # generated reference data using the new atomic file 
-  REF2_PATH: /home/runner/work/tardis/tardis/tardis-refdata/unit_test_data.h5
+  REF2_PATH: /home/runner/work/carsus/carsus/tardis-refdata/unit_test_data.h5
   PYTEST_FLAGS: --tardis-refdata=${{ github.workspace }}/tardis-refdata 
                 --generate-reference
 

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           repository: atharva-2001/carsus
           path: carsus/
-          ref: arraydiff_unpin_version
+          ref: tardis_carsus_bridge
         
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -12,7 +12,8 @@ on:
 env:
   XUVTOP: /tmp/chianti
   CHIANTI_DL_URL: https://download.chiantidatabase.org
-  CHIANTI_DB_VER: CHIANTI_v9.0.1_database.tar.gz
+  # CHIANTI_DB_VER: CHIANTI_v9.0.1_database.tar.gz
+  CHIANTI_DB_VER: CHIANTI_v8.0.6_database.tar.gz
   NBCONVERT_CMD: jupyter nbconvert --execute --ExecutePreprocessor.timeout=600 --to html
   CMFGEN_DL_URL: http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files
   CMFGEN_DB_VER: atomic_data_15nov16.tar.gz

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -89,7 +89,7 @@ jobs:
           repository: tardis-sn/tardis
         
       - name: Download refdata_compare notebook
-        run: wget https://raw.githubusercontent.com/atharva-2001/tardis-refdata/raise_error_refdata_compare/notebooks/ref_data_compare_from_paths.ipynb
+        run: wget https://raw.githubusercontent.com/tardis-sn/tardis-refdata/master/notebooks/ref_data_compare_from_paths.ipynb
         
       - name: Download reference data
         run: bash .ci-helpers/download_reference_data.sh

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -1,16 +1,7 @@
 name: tardis-carsus-compatibility-check
 
-# on: 
-#   workflow_dispatch
-
-on:
-  push:
-    branches:
-    - '*'
-
-  pull_request:
-    branches:
-    - '*'
+on: 
+  workflow_dispatch
 
         
 env:

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -23,20 +23,14 @@ env:
   PYTEST_FLAGS: --tardis-refdata=${{ github.workspace }}/tardis-refdata 
                 --generate-reference
 
-
 defaults:
       run:
         shell: bash -l {0}
-
 
 jobs:
   carsus-build:
     runs-on: ubuntu-latest
     steps:
-      # - uses: actions/checkout@v2
-      #   with:
-      #     fetch-depth: 0
-
       - name: Clone tardis-sn/carsus
         uses: actions/checkout@v2
         with:
@@ -95,19 +89,6 @@ jobs:
   
   tardis-build:
     needs: carsus-build
-    strategy:
-      matrix:
-        include:
-        - os: ubuntu-latest
-          label: linux-64
-          prefix: /usr/share/miniconda3/envs/tardis
-
-    #     - os: macos-latest
-    #       label: osx-64
-    #       prefix: /Users/runner/miniconda3/envs/tardis
-          
-    # name: ${{ matrix.label }}
-    # runs-on: ${{ matrix.os }}
     runs-on: ubuntu-latest
 
     steps:
@@ -151,14 +132,12 @@ jobs:
       - name: Install package
         run: pip install -e .
         
-      # only run this steop when carsus build is done
+      # only run this step when carsus build is done
       - name: Download atom data
         uses: actions/download-artifact@v2
         with:
           name: atom-data
-          path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
-          # path: kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
-      
+          path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5      
       
       - name: Print path
         run: python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
@@ -183,12 +162,12 @@ jobs:
 
       - name: Run notebook to test spectrum
         run: |
-            ${{ env.NBCONVERT_CMD }} --allow-errors "tardis-refdata/notebooks/ref_data_compare copy.ipynb"
+            ${{ env.NBCONVERT_CMD }} "tardis-refdata/notebooks/ref_data_compare_from_paths.ipynb"
       
       - name: Upload spectrum notebook
         uses: actions/upload-artifact@v2
         with:
-          path: "tardis-refdata/notebooks/ref_data_compare copy.html"
+          path: "tardis-refdata/notebooks/ref_data_compare_from_paths.html"
         
       
 

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -15,9 +15,9 @@ env:
   CMFGEN_DL_URL: http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files
   CMFGEN_DB_VER: atomic_data_15nov16.tar.gz
   # original reference data
-  REF1_PATH: /home/runner/work/carsus/carsus/tardis-refdata/unit_test_data_org.h5
+  REF1_PATH: ${{ github.workspace }}/tardis-refdata/unit_test_data_org.h5
   # generated reference data using the new atomic file 
-  REF2_PATH: /home/runner/work/carsus/carsus/tardis-refdata/unit_test_data.h5
+  REF2_PATH: ${{ github.workspace }}/tardis-refdata/unit_test_data.h5
   PYTEST_FLAGS: --tardis-refdata=${{ github.workspace }}/tardis-refdata 
                 --generate-reference
 
@@ -29,8 +29,7 @@ jobs:
   carsus-build:
     runs-on: ubuntu-latest
     steps:
-      - name: Clone tardis-sn/carsus
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           repository: atharva-2001/carsus
           path: carsus/
@@ -79,7 +78,7 @@ jobs:
         env:
           CARSUS_REFDATA: ${{ github.workspace }}/carsus-refdata
         
-      - name: upload atom data
+      - name: Upload Atom Data
         uses: actions/upload-artifact@v2
         with:
           name: atom-data
@@ -136,16 +135,16 @@ jobs:
           name: atom-data
           path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5      
       
-      - name: Replace atomic data in reference data repository with the generated atomic data
+      - name: Replace Atomic Data
         run: cp carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5 tardis-refdata/atom_data/kurucz_cd23_chianti_H_He.h5
       
-      - name: Create copy of reference data for comparision
+      - name: Generate Reference Data Copy
         run: cp tardis-refdata/unit_test_data.h5 tardis-refdata/unit_test_data_org.h5 
 
-      - name: Run tests and generate new reference data
+      - name: Generate New Reference Data
         run:  pytest tardis ${{ env.PYTEST_FLAGS }}
 
-      - name: Run notebook to test spectrum
+      - name: Compare Reference Data
         run: |
             ${{ env.NBCONVERT_CMD }} "tardis-refdata/notebooks/ref_data_compare_from_paths.ipynb"
       

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -14,6 +14,8 @@ env:
   CHIANTI_DL_URL: https://download.chiantidatabase.org
   CHIANTI_DB_VER: CHIANTI_v9.0.1_database.tar.gz
   NBCONVERT_CMD: jupyter nbconvert --execute --ExecutePreprocessor.timeout=600 --to html
+  CMFGEN_DL_URL: http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files
+  CMFGEN_DB_VER: atomic_data_15nov16.tar.gz
 
 jobs:
  carsus-build:
@@ -57,7 +59,7 @@ jobs:
             wget -q -U "Mozilla/4.0" ${{ env.CMFGEN_DL_URL }}/${{ env.CMFGEN_DB_VER }} -O /tmp/atomic.tar.gz
             tar -zxf /tmp/atomic.tar.gz -C /tmp
         if: steps.cmfgen-cache.outputs.cache-hit != 'true'
-        
+
       - name: Setup environment
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -80,6 +82,6 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: atom_data
-          path: docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
+          path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
     
 

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -138,11 +138,17 @@ jobs:
           # path: kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
 
       - name: Download reference data for simulation data
-        run: wget -q https://dev.azure.com/tardis-sn/TARDIS/_apis/git/repositories/tardis-refdata/items?path=unit_test_data.h5&resolveLfs=true
+        run: wget -O unit_test_data_new.h5 https://dev.azure.com/tardis-sn/TARDIS/_apis/git/repositories/tardis-refdata/items?path=unit_test_data.h5&resolveLfs=true
 
       - name: Print path
-        run: python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' unit_test_data.h5
-        
+        run: python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' unit_test_data_new.h5
+      
+      - name: Upload reference data as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: reference data
+          path: unit_test_data_new.h5
+
       - name: Print directory tree
         run: tree
 

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -26,7 +26,6 @@ defaults:
 jobs:
   carsus-build:
     runs-on: ubuntu-latest
-
     steps:
       # - uses: actions/checkout@v2
       #   with:
@@ -89,14 +88,21 @@ jobs:
   
   tardis-build:
     needs: carsus-build
-    strategy: # TODO
-        matrix:
-          include:
-          - os: ubuntu-latest
-            label: linux-64
-            prefix: /usr/share/miniconda3/envs/tardis
+    strategy:
+      matrix:
+        include:
+        - os: ubuntu-latest
+          label: linux-64
+          prefix: /usr/share/miniconda3/envs/tardis
 
+    #     - os: macos-latest
+    #       label: osx-64
+    #       prefix: /Users/runner/miniconda3/envs/tardis
+          
+    # name: ${{ matrix.label }}
+    # runs-on: ${{ matrix.os }}
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -123,38 +129,28 @@ jobs:
       - name: Install package
         run: pip install -e .
         
-      
+      # only run this steop when carsus build is done
       - name: Download atom data
         uses: actions/download-artifact@v2
         with:
           name: atom-data
-          path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
-      
+          # path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
+          # path: kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
+          
+      - name: Print path
+        run: python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
+        
+
       - name: Run notebook to test spectrum
         run: |
-            ${{ env.NBCONVERT_CMD }} tardis/tests/test_spectrum.ipynb
+            ${{ env.NBCONVERT_CMD }} --allow-errors tardis/tests/test_spectrum.ipynb
       
       - name: Upload spectrum notebook
         uses: actions/upload-artifact@v2
         with:
-          path: tardis/tests/test_spectrum.ipynb
+          path: tardis/tests/test_spectrum.html
         
       
-
-  # generate-spectrum:
-  #   runs-on: ubuntu-latest
-  #   needs: [carsus-build, tardis-build]
-
-  #   steps: 
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: atom-data
-  #         path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
-      
-      
-
-
-
 
 
 

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Upload spectrum notebook
         uses: actions/upload-artifact@v2
         with:
-          path: tardis/tests/test_spectrum.html
+          path: "tardis-refdata/notebooks/ref_data_compare copy.html"
         
       
 

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -19,7 +19,8 @@ env:
   # original reference data
   REF1_PATH: /home/runner/work/carsus/carsus/tardis-refdata/unit_test_data_org.h5
   # generated reference data using the new atomic file 
-  REF2_PATH: /home/runner/work/carsus/carsus/tardis-refdata/unit_test_data.h5
+  # REF2_PATH: /home/runner/work/carsus/carsus/tardis-refdata/unit_test_data.h5
+  REF2_PATH: /home/runner/work/carsus/carsus/tardis-refdata/unit_test_data_org.h5
   PYTEST_FLAGS: --tardis-refdata=${{ github.workspace }}/tardis-refdata 
                 --generate-reference
 
@@ -99,7 +100,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: atharva-2001/tardis-refdata
-          ref: refdata_compare
+          ref: raise_error_refdata_compare
           path: tardis-refdata
           lfs: true
         
@@ -150,6 +151,7 @@ jobs:
       - name: Run notebook to test spectrum
         run: |
             ${{ env.NBCONVERT_CMD }} "tardis-refdata/notebooks/ref_data_compare_from_paths.ipynb"
+            echo $reference_comparision
       
       - name: Upload spectrum notebook
         uses: actions/upload-artifact@v2
@@ -158,4 +160,6 @@ jobs:
       
       - name: Check if spectra were equal during comparision
         if: ${{ env.reference_comparision }} == "failed"
-        run: exit 1      
+        run: |
+             echo $reference_comparision
+             exit 1      

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -35,63 +35,63 @@ defaults:
         shell: bash -l {0}
 
 jobs:
-  # carsus-build:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         repository: atharva-2001/carsus
-  #         path: carsus/
-  #         ref: tardis_carsus_bridge
+  carsus-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: atharva-2001/carsus
+          path: carsus/
+          ref: tardis_carsus_bridge
         
-  #     - uses: actions/cache@v2
-  #       with:
-  #         path: ${{ env.XUVTOP }}
-  #         key: ${{ runner.os }}-${{ env.CHIANTI_DB_VER }}
-  #       id: chianti-cache
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.XUVTOP }}
+          key: ${{ runner.os }}-${{ env.CHIANTI_DB_VER }}
+        id: chianti-cache
 
-  #     - name: Download Chianti database
-  #       run: |
-  #           mkdir -p ${{ env.XUVTOP }}
-  #           wget -q ${{ env.CHIANTI_DL_URL }}/${{ env.CHIANTI_DB_VER }} -O ${{ env.XUVTOP }}/chianti.tar.gz
-  #           tar -zxf ${{ env.XUVTOP }}/chianti.tar.gz -C ${{ env.XUVTOP }}
-  #       if: steps.chianti-cache.outputs.cache-hit != 'true'
+      - name: Download Chianti database
+        run: |
+            mkdir -p ${{ env.XUVTOP }}
+            wget -q ${{ env.CHIANTI_DL_URL }}/${{ env.CHIANTI_DB_VER }} -O ${{ env.XUVTOP }}/chianti.tar.gz
+            tar -zxf ${{ env.XUVTOP }}/chianti.tar.gz -C ${{ env.XUVTOP }}
+        if: steps.chianti-cache.outputs.cache-hit != 'true'
       
-  #     - uses: actions/cache@v2
-  #       with:
-  #         path: /tmp/atomic
-  #         key: ${{ env.CMFGEN_DB_VER }}
-  #       id: cmfgen-cache
+      - uses: actions/cache@v2
+        with:
+          path: /tmp/atomic
+          key: ${{ env.CMFGEN_DB_VER }}
+        id: cmfgen-cache
 
-  #     - name: Download CMFGEN database
-  #       run: |
-  #           wget -q -U "Mozilla/4.0" ${{ env.CMFGEN_DL_URL }}/${{ env.CMFGEN_DB_VER }} -O /tmp/atomic.tar.gz
-  #           tar -zxf /tmp/atomic.tar.gz -C /tmp
-  #       if: steps.cmfgen-cache.outputs.cache-hit != 'true'
+      - name: Download CMFGEN database
+        run: |
+            wget -q -U "Mozilla/4.0" ${{ env.CMFGEN_DL_URL }}/${{ env.CMFGEN_DB_VER }} -O /tmp/atomic.tar.gz
+            tar -zxf /tmp/atomic.tar.gz -C /tmp
+        if: steps.cmfgen-cache.outputs.cache-hit != 'true'
 
-  #     - name: Setup carsus environment
-  #       uses: conda-incubator/setup-miniconda@v2
-  #       with:
-  #           miniforge-variant: Mambaforge
-  #           miniforge-version: latest
-  #           environment-file: carsus/carsus_env3.yml
-  #           activate-environment: carsus
-  #           use-mamba: true
+      - name: Setup carsus environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+            miniforge-variant: Mambaforge
+            miniforge-version: latest
+            environment-file: carsus/carsus_env3.yml
+            activate-environment: carsus
+            use-mamba: true
 
-  #     - name: Install package
-  #       run: pip install -e carsus/
+      - name: Install package
+        run: pip install -e carsus/
 
-  #     - name: Run notebooks
-  #       run: |
-  #         jupyter nbconvert ${{ env.NBCONVERT_FLAGS }} carsus/docs/refdata_gen.ipynb
-  #       env:
-  #         CARSUS_REFDATA: ${{ github.workspace }}/carsus-refdata
+      - name: Run notebooks
+        run: |
+          jupyter nbconvert ${{ env.NBCONVERT_FLAGS }} carsus/docs/refdata_gen.ipynb
+        env:
+          CARSUS_REFDATA: ${{ github.workspace }}/carsus-refdata
         
-  #     - name: Upload Atom Data
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: atom-data
-  #         path: carsus/docs/kurucz_cd23_chianti_H_He.h5
+      - name: Upload Atom Data
+        uses: actions/upload-artifact@v2
+        with:
+          name: atom-data
+          path: carsus/docs/kurucz_cd23_chianti_H_He.h5
   
   tardis-build:
     # needs: carsus-build
@@ -110,7 +110,7 @@ jobs:
       #     lfs: true
         
       - name: Download refdata_compare notebook
-        run: wget https://github.com/atharva-2001/tardis-refdata/blob/raise_error_refdata_compare/notebooks/ref_data_compare_from_paths.ipynb
+        run: wget https://raw.githubusercontent.com/atharva-2001/tardis-refdata/raise_error_refdata_compare/notebooks/ref_data_compare_from_paths.ipynb
         
       - name: Download reference data
         run: bash .ci-helpers/download_reference_data.sh
@@ -161,12 +161,12 @@ jobs:
 
       - name: Compare Reference Data
         run: |
-            jupyter nbconvert ${{ env.NBCONVERT_FLAGS }} tardis-refdata/notebooks/ref_data_compare_from_paths.ipynb
+            jupyter nbconvert ${{ env.NBCONVERT_FLAGS }} ref_data_compare_from_paths.ipynb
       
       - name: Upload spectrum notebook
         uses: actions/upload-artifact@v2
         with:
-          path: tardis-refdata/notebooks/ref_data_compare_from_paths.html
+          path: ref_data_compare_from_paths.html
       
       - name: Check if spectra were equal during comparision
         run: if [ "$(cat /tmp/spectrum_compare)" == 0 ]; then exit 1; fi

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -19,8 +19,7 @@ env:
   # original reference data
   REF1_PATH: /home/runner/work/carsus/carsus/tardis-refdata/unit_test_data_org.h5
   # generated reference data using the new atomic file 
-  # REF2_PATH: /home/runner/work/carsus/carsus/tardis-refdata/unit_test_data.h5
-  REF2_PATH: /home/runner/work/carsus/carsus/tardis-refdata/unit_test_data_org.h5
+  REF2_PATH: /home/runner/work/carsus/carsus/tardis-refdata/unit_test_data.h5
   PYTEST_FLAGS: --tardis-refdata=${{ github.workspace }}/tardis-refdata 
                 --generate-reference
 

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -106,7 +106,7 @@ jobs:
         run: mamba update -n tardis --file conda-linux-64.lock
 
       - name: Install bokeh
-        run: mamba install bokeh=2.2 --channel conda-forge --no-update-deps --yes
+        run: mamba install bokeh --channel conda-forge --no-update-deps --yes
 
       - name: Install package
         run: pip install -e .

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -101,7 +101,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: tardis-sn/tardis
-          path: tardis/
 
       - name: Setup TARDIS environment
         uses: conda-incubator/setup-miniconda@v2
@@ -118,11 +117,12 @@ jobs:
         id: cache-conda
 
       - name: Update environment
-        run: mamba update -n tardis --file tardis/conda-${{ matrix.label }}.lock
+        run: mamba update -n tardis --file conda-${{ matrix.label }}.lock
         if: steps.cache-conda.outputs.cache-hit != 'true'
 
       - name: Install package
-        run: pip install -e tardis
+        run: pip install -e .
+        
       
       - name: Download atom data
         uses: actions/download-artifact@v2
@@ -133,6 +133,11 @@ jobs:
       - name: Run notebook to test spectrum
         run: |
             ${{ env.NBCONVERT_CMD }} tardis/tests/test_spectrum.ipynb
+      
+      - name: Upload spectrum notebook
+        uses: actions/upload-artifact@v2
+        with:
+          path: tardis/tests/test_spectrum.ipynb
         
       
 

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -1,0 +1,73 @@
+name: tardis-carsus-compatibility-check
+
+on:
+  push:
+    branches:
+    - '*'
+
+  pull_request:
+    branches:
+    - '*'
+
+env:
+  XUVTOP: /tmp/chianti
+  CHIANTI_DL_URL: https://download.chiantidatabase.org
+  CHIANTI_DB_VER: CHIANTI_v9.0.1_database.tar.gz
+  NBCONVERT_CMD: jupyter nbconvert --execute --ExecutePreprocessor.timeout=600 --to html
+
+jobs:
+ carsus-build:
+    defaults:
+      run:
+        shell: bash -l {0}
+    runs-on: ubuntu-latest
+
+    steps:
+      # - uses: actions/checkout@v2
+      #   with:
+      #     fetch-depth: 0
+
+      - name: Clone tardis-sn/carsus
+        uses: actions/checkout@v2
+        with:
+          repository: tardis-sn/carsus
+          path: carsus/
+        
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.XUVTOP }}
+          key: ${{ runner.os }}-${{ env.CHIANTI_DB_VER }}
+        id: chianti-cache
+
+      - name: Download Chianti database
+        run: |
+            mkdir -p ${{ env.XUVTOP }}
+            wget -q ${{ env.CHIANTI_DL_URL }}/${{ env.CHIANTI_DB_VER }} -O ${{ env.XUVTOP }}/chianti.tar.gz
+            tar -zxf ${{ env.XUVTOP }}/chianti.tar.gz -C ${{ env.XUVTOP }}
+        if: steps.chianti-cache.outputs.cache-hit != 'true'
+      
+      - name: Setup environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+            miniforge-variant: Mambaforge
+            miniforge-version: latest
+            environment-file: carsus/carsus_env3.yml
+            activate-environment: carsus
+            use-mamba: true
+
+      - name: Install package
+        run: pip install -e carsus/
+
+      - name: Run notebooks
+        run: |
+          ${{ env.NBCONVERT_CMD }} carsus/docs/quickstart.ipynb
+        env:
+          CARSUS_REFDATA: ${{ github.workspace }}/carsus-refdata
+        
+      - name: upload atom data
+        uses: actions/upload-artifact@v2
+        with:
+          name: atom_data
+          path: docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
+    
+

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -132,7 +132,6 @@ jobs:
       - name: Install package
         run: pip install -e .
         
-      # only run this step when carsus build is done
       - name: Download atom data
         uses: actions/download-artifact@v2
         with:
@@ -144,12 +143,6 @@ jobs:
       
       - name: Create copy of reference data for comparision
         run: cp tardis-refdata/unit_test_data.h5 tardis-refdata/unit_test_data_org.h5 
-      
-      - name: Upload reference data as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: reference data
-          path: tardis-refdata/unit_test_data_org.h5
 
       - name: Run tests and generate new reference data
         run:  pytest tardis ${{ env.PYTEST_FLAGS }}

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -11,7 +11,7 @@ env:
   XUVTOP: /tmp/chianti
   CHIANTI_DL_URL: https://download.chiantidatabase.org
   CHIANTI_DB_VER: CHIANTI_v9.0.1_database.tar.gz
-  NBCONVERT_CMD: jupyter nbconvert --execute --ExecutePreprocessor.timeout=600 --to html
+  NBCONVERT_FLAGS: --execute --ExecutePreprocessor.timeout=600 --to html
   CMFGEN_DL_URL: http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files
   CMFGEN_DB_VER: atomic_data_15nov16.tar.gz
   # original reference data
@@ -74,7 +74,7 @@ jobs:
 
       - name: Run notebooks
         run: |
-          ${{ env.NBCONVERT_CMD }} carsus/docs/refdata_gen.ipynb
+          jupyter nbconvert ${{ env.NBCONVERT_FLAGS }} carsus/docs/refdata_gen.ipynb
         env:
           CARSUS_REFDATA: ${{ github.workspace }}/carsus-refdata
         
@@ -82,7 +82,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: atom-data
-          path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
+          path: carsus/docs/kurucz_cd23_chianti_H_He.h5
   
   tardis-build:
     needs: carsus-build
@@ -146,12 +146,12 @@ jobs:
 
       - name: Compare Reference Data
         run: |
-            ${{ env.NBCONVERT_CMD }} "tardis-refdata/notebooks/ref_data_compare_from_paths.ipynb"
+            jupyter nbconvert ${{ env.NBCONVERT_FLAGS }} tardis-refdata/notebooks/ref_data_compare_from_paths.ipynb
       
       - name: Upload spectrum notebook
         uses: actions/upload-artifact@v2
         with:
-          path: "tardis-refdata/notebooks/ref_data_compare_from_paths.html"
+          path: tardis-refdata/notebooks/ref_data_compare_from_paths.html
       
       - name: Check if spectra were equal during comparision
         run: if [ "$(cat /tmp/spectrum_compare)" == 0 ]; then exit 1; fi

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -12,8 +12,7 @@ on:
 env:
   XUVTOP: /tmp/chianti
   CHIANTI_DL_URL: https://download.chiantidatabase.org
-  # CHIANTI_DB_VER: CHIANTI_v9.0.1_database.tar.gz
-  CHIANTI_DB_VER: CHIANTI_v8.0.6_database.tar.gz
+  CHIANTI_DB_VER: CHIANTI_v9.0.1_database.tar.gz
   NBCONVERT_CMD: jupyter nbconvert --execute --ExecutePreprocessor.timeout=600 --to html
   CMFGEN_DL_URL: http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files
   CMFGEN_DB_VER: atomic_data_15nov16.tar.gz

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -158,4 +158,4 @@ jobs:
           path: "tardis-refdata/notebooks/ref_data_compare_from_paths.html"
       
       - name: Check if spectra were equal during comparision
-        run: if [ "$(cat /tmp/spectrum_compare)" == 1 ]; then exit 1; fi
+        run: if [ "$(cat /tmp/spectrum_compare)" == 0 ]; then exit 1; fi

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -138,7 +138,7 @@ jobs:
           # path: kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
           
       - name: Print path
-        run: python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
+        run: python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' unit_test_data.h5
         
 
       - name: Run notebook to test spectrum

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -133,6 +133,7 @@ jobs:
       - name: Upload comparison notebook
         uses: actions/upload-artifact@v2
         with:
+          name: Comparison Notebook
           path: ref_data_compare_from_paths.html
       
       - name: Check if reference data are equal

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -17,9 +17,9 @@ env:
   CMFGEN_DL_URL: http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files
   CMFGEN_DB_VER: atomic_data_15nov16.tar.gz
   # original reference data
-  REF1_PATH: /home/runner/work/tardis/tardis-refdata/unit_test_data_org.h5
+  REF1_PATH: /home/runner/work/tardis/tardis/tardis-refdata/unit_test_data_org.h5
   # generated reference data using the new atomic file 
-  REF2_PATH: /home/runner/work/tardis/tardis-refdata/unit_test_data.h5
+  REF2_PATH: /home/runner/work/tardis/tardis/tardis-refdata/unit_test_data.h5
   PYTEST_FLAGS: --tardis-refdata=${{ github.workspace }}/tardis-refdata 
                 --generate-reference
 

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -151,7 +151,6 @@ jobs:
       - name: Run notebook to test spectrum
         run: |
             ${{ env.NBCONVERT_CMD }} "tardis-refdata/notebooks/ref_data_compare_from_paths.ipynb"
-            echo $reference_comparision
       
       - name: Upload spectrum notebook
         uses: actions/upload-artifact@v2
@@ -159,7 +158,4 @@ jobs:
           path: "tardis-refdata/notebooks/ref_data_compare_from_paths.html"
       
       - name: Check if spectra were equal during comparision
-        if: ${{ env.reference_comparision }} == "failed"
-        run: |
-             echo $reference_comparision
-             exit 1      
+        run: if [ "$(cat /tmp/spectrum_compare)" == 1 ]; then exit 1; fi

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -16,6 +16,12 @@ env:
   NBCONVERT_CMD: jupyter nbconvert --execute --ExecutePreprocessor.timeout=600 --to html
   CMFGEN_DL_URL: http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files
   CMFGEN_DB_VER: atomic_data_15nov16.tar.gz
+  # original reference data
+  REF1_PATH: /home/runner/work/tardis/tardis-refdata/unit_test_data_org.h5
+  # generated reference data using the new atomic file 
+  REF2_PATH: /home/runner/work/tardis/tardis-refdata/unit_test_data.h5
+  PYTEST_FLAGS: --tardis-refdata=${{ github.workspace }}/tardis-refdata 
+                --generate-reference
 
 
 defaults:
@@ -87,7 +93,7 @@ jobs:
           path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
   
   tardis-build:
-    # needs: carsus-build
+    needs: carsus-build
     strategy:
       matrix:
         include:
@@ -142,34 +148,34 @@ jobs:
         run: pip install -e .
         
       # only run this steop when carsus build is done
-      # - name: Download atom data
-      #   uses: actions/download-artifact@v2
-      #   with:
-      #     name: atom-data
-          # path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
+      - name: Download atom data
+        uses: actions/download-artifact@v2
+        with:
+          name: atom-data
+          path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
           # path: kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
-
-      - name: Download reference data for simulation data
-        run: wget -O unit_test_data_new.h5 https://dev.azure.com/tardis-sn/TARDIS/_apis/git/repositories/tardis-refdata/items?path=unit_test_data.h5&resolveLfs=true
-
-      - name: Download reference data
-        run: bash .ci-helpers/download_reference_data.sh
-
-      - name: Print path
-        run: python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' unit_test_data_new.h5
+      
+      - name: Replace atomic data in reference data repository with the generated atomic data
+        run: cp tardis/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5 tardis-refdata/atom_data/kurucz_cd23_chianti_H_He.h5
+      
+      - name: Create copy of reference data for comparision
+        run: cp tardis-refdata/unit_test_data.h5 tardis-refdata/unit_test_data_org.h5 
       
       - name: Upload reference data as artifact
         uses: actions/upload-artifact@v2
         with:
           name: reference data
-          path: tardis-refdata/unit_test_data.h5
+          path: tardis-refdata/unit_test_data_org.h5
   
       - name: Print directory tree
         run: tree
 
+      - name: Run tests and generate new reference data
+        run:  pytest tardis ${{ env.PYTEST_FLAGS }}
+
       - name: Run notebook to test spectrum
         run: |
-            ${{ env.NBCONVERT_CMD }} --allow-errors tardis/tests/test_spectrum.ipynb
+            ${{ env.NBCONVERT_CMD }} --allow-errors "tardis-refdata/notebooks/ref_data_compare copy.ipynb"
       
       - name: Upload spectrum notebook
         uses: actions/upload-artifact@v2

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -87,7 +87,7 @@ jobs:
           path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
   
   tardis-build:
-    needs: carsus-build
+    # needs: carsus-build
     strategy:
       matrix:
         include:
@@ -107,6 +107,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: tardis-sn/tardis
+          
+      - uses: actions/checkout@v2
+        with:
+          repository: atharva-2001/tardis-refdata
+          ref: refdata_compare
+          path: tardis-refdata
 
       - name: Setup TARDIS environment
         uses: conda-incubator/setup-miniconda@v2
@@ -130,10 +136,10 @@ jobs:
         run: pip install -e .
         
       # only run this steop when carsus build is done
-      - name: Download atom data
-        uses: actions/download-artifact@v2
-        with:
-          name: atom-data
+      # - name: Download atom data
+      #   uses: actions/download-artifact@v2
+      #   with:
+      #     name: atom-data
           # path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
           # path: kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
 

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -1,11 +1,7 @@
 name: tardis-carsus-compatibility-check
 
 on: 
-  workflow_dispatch:
-    inputs:
-      git-ref:
-        description: Git Ref (Optional)    
-        required: false
+  workflow_dispatch
 
         
 env:

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -136,10 +136,15 @@ jobs:
           name: atom-data
           # path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
           # path: kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
-          
+
+      - name: Download reference data for simulation data
+        run: wget -q https://dev.azure.com/tardis-sn/TARDIS/_apis/git/repositories/tardis-refdata/items?path=unit_test_data.h5&resolveLfs=true
+
       - name: Print path
         run: python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' unit_test_data.h5
         
+      - name: Print directory tree
+        run: tree
 
       - name: Run notebook to test spectrum
         run: |

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -26,66 +26,66 @@ defaults:
         shell: bash -l {0}
 
 jobs:
-  carsus-build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          repository: atharva-2001/carsus
-          path: carsus/
-          ref: tardis_carsus_bridge
+  # carsus-build:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         repository: atharva-2001/carsus
+  #         path: carsus/
+  #         ref: tardis_carsus_bridge
         
-      - uses: actions/cache@v2
-        with:
-          path: ${{ env.XUVTOP }}
-          key: ${{ runner.os }}-${{ env.CHIANTI_DB_VER }}
-        id: chianti-cache
+  #     - uses: actions/cache@v2
+  #       with:
+  #         path: ${{ env.XUVTOP }}
+  #         key: ${{ runner.os }}-${{ env.CHIANTI_DB_VER }}
+  #       id: chianti-cache
 
-      - name: Download Chianti database
-        run: |
-            mkdir -p ${{ env.XUVTOP }}
-            wget -q ${{ env.CHIANTI_DL_URL }}/${{ env.CHIANTI_DB_VER }} -O ${{ env.XUVTOP }}/chianti.tar.gz
-            tar -zxf ${{ env.XUVTOP }}/chianti.tar.gz -C ${{ env.XUVTOP }}
-        if: steps.chianti-cache.outputs.cache-hit != 'true'
+  #     - name: Download Chianti database
+  #       run: |
+  #           mkdir -p ${{ env.XUVTOP }}
+  #           wget -q ${{ env.CHIANTI_DL_URL }}/${{ env.CHIANTI_DB_VER }} -O ${{ env.XUVTOP }}/chianti.tar.gz
+  #           tar -zxf ${{ env.XUVTOP }}/chianti.tar.gz -C ${{ env.XUVTOP }}
+  #       if: steps.chianti-cache.outputs.cache-hit != 'true'
       
-      - uses: actions/cache@v2
-        with:
-          path: /tmp/atomic
-          key: ${{ env.CMFGEN_DB_VER }}
-        id: cmfgen-cache
+  #     - uses: actions/cache@v2
+  #       with:
+  #         path: /tmp/atomic
+  #         key: ${{ env.CMFGEN_DB_VER }}
+  #       id: cmfgen-cache
 
-      - name: Download CMFGEN database
-        run: |
-            wget -q -U "Mozilla/4.0" ${{ env.CMFGEN_DL_URL }}/${{ env.CMFGEN_DB_VER }} -O /tmp/atomic.tar.gz
-            tar -zxf /tmp/atomic.tar.gz -C /tmp
-        if: steps.cmfgen-cache.outputs.cache-hit != 'true'
+  #     - name: Download CMFGEN database
+  #       run: |
+  #           wget -q -U "Mozilla/4.0" ${{ env.CMFGEN_DL_URL }}/${{ env.CMFGEN_DB_VER }} -O /tmp/atomic.tar.gz
+  #           tar -zxf /tmp/atomic.tar.gz -C /tmp
+  #       if: steps.cmfgen-cache.outputs.cache-hit != 'true'
 
-      - name: Setup carsus environment
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-            miniforge-variant: Mambaforge
-            miniforge-version: latest
-            environment-file: carsus/carsus_env3.yml
-            activate-environment: carsus
-            use-mamba: true
+  #     - name: Setup carsus environment
+  #       uses: conda-incubator/setup-miniconda@v2
+  #       with:
+  #           miniforge-variant: Mambaforge
+  #           miniforge-version: latest
+  #           environment-file: carsus/carsus_env3.yml
+  #           activate-environment: carsus
+  #           use-mamba: true
 
-      - name: Install package
-        run: pip install -e carsus/
+  #     - name: Install package
+  #       run: pip install -e carsus/
 
-      - name: Run notebooks
-        run: |
-          jupyter nbconvert ${{ env.NBCONVERT_FLAGS }} carsus/docs/refdata_gen.ipynb
-        env:
-          CARSUS_REFDATA: ${{ github.workspace }}/carsus-refdata
+  #     - name: Run notebooks
+  #       run: |
+  #         jupyter nbconvert ${{ env.NBCONVERT_FLAGS }} carsus/docs/refdata_gen.ipynb
+  #       env:
+  #         CARSUS_REFDATA: ${{ github.workspace }}/carsus-refdata
         
-      - name: Upload Atom Data
-        uses: actions/upload-artifact@v2
-        with:
-          name: atom-data
-          path: carsus/docs/kurucz_cd23_chianti_H_He.h5
+  #     - name: Upload Atom Data
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: atom-data
+  #         path: carsus/docs/kurucz_cd23_chianti_H_He.h5
   
   tardis-build:
-    needs: carsus-build
+    # needs: carsus-build
     runs-on: ubuntu-latest
 
     steps:
@@ -93,17 +93,23 @@ jobs:
         with:
           repository: tardis-sn/tardis
           
-      - uses: actions/checkout@v2
-        with:
-          repository: atharva-2001/tardis-refdata
-          ref: raise_error_refdata_compare
-          path: tardis-refdata
-          lfs: true
+      # - uses: actions/checkout@v2
+      #   with:
+      #     repository: atharva-2001/tardis-refdata
+      #     ref: raise_error_refdata_compare
+      #     path: tardis-refdata
+      #     lfs: true
         
-      - name: Fetch lfs objects
-        run: |
-             cd tardis-refdata
-             git lfs checkout 
+      - name: Download refdata_compare notebook
+        run: wget https://github.com/atharva-2001/tardis-refdata/blob/raise_error_refdata_compare/notebooks/ref_data_compare_from_paths.ipynb
+        
+      - name: Download reference data
+        run: bash .ci-helpers/download_reference_data.sh
+
+      # - name: Fetch lfs objects
+      #   run: |
+      #        cd tardis-refdata
+      #        git lfs checkout 
 
       - name: Setup TARDIS environment
         uses: conda-incubator/setup-miniconda@v2
@@ -113,15 +119,15 @@ jobs:
             activate-environment: tardis
             use-mamba: true
 
-      - uses: actions/cache@v2
-        with:
-          path: /usr/share/miniconda3/envs/tardis
-          key: conda-linux-64-${{ hashFiles('conda-linux-64.lock') }}-${{ env.CACHE_NUMBER }}
-        id: cache-conda
+      # - uses: actions/cache@v2
+      #   with:
+      #     path: /usr/share/miniconda3/envs/tardis
+      #     key: conda-linux-64-${{ hashFiles('conda-linux-64.lock') }}-${{ env.CACHE_NUMBER }}
+      #   id: cache-conda
 
       - name: Update environment
         run: mamba update -n tardis --file conda-linux-64.lock
-        if: steps.cache-conda.outputs.cache-hit != 'true'
+      #   if: steps.cache-conda.outputs.cache-hit != 'true'
 
       - name: Install bokeh
         run: mamba install bokeh=2.2 --channel conda-forge --no-update-deps --yes
@@ -133,10 +139,10 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: atom-data
-          path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5      
+          path: carsus/docs/kurucz_cd23_chianti_H_He.h5
       
       - name: Replace Atomic Data
-        run: cp carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5 tardis-refdata/atom_data/kurucz_cd23_chianti_H_He.h5
+        run: cp carsus/docs/kurucz_cd23_chianti_H_He.h5/kurucz_cd23_chianti_H_He.h5 tardis-refdata/atom_data/kurucz_cd23_chianti_H_He.h5
       
       - name: Generate Reference Data Copy
         run: cp tardis-refdata/unit_test_data.h5 tardis-refdata/unit_test_data_org.h5 

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -148,7 +148,6 @@ jobs:
         run:  pytest tardis ${{ env.PYTEST_FLAGS }}
 
       - name: Run notebook to test spectrum
-        continue-on-error: true
         run: |
             ${{ env.NBCONVERT_CMD }} "tardis-refdata/notebooks/ref_data_compare_from_paths.ipynb"
       
@@ -156,8 +155,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           path: "tardis-refdata/notebooks/ref_data_compare_from_paths.html"
-        
       
-
-
-
+      - name: Check if spectra were equal during comparision
+        if: ${{ env.reference_comparision }} == "failed"
+        run: exit 1      

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -113,6 +113,11 @@ jobs:
           repository: atharva-2001/tardis-refdata
           ref: refdata_compare
           path: tardis-refdata
+          lfs: true
+        
+      - name: Fetch lfs objects
+        run: cd tardis-refdata
+             git lfs checkout 
 
       - name: Setup TARDIS environment
         uses: conda-incubator/setup-miniconda@v2
@@ -157,7 +162,7 @@ jobs:
         with:
           name: reference data
           path: tardis-refdata/unit_test_data.h5
-
+  
       - name: Print directory tree
         run: tree
 

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -145,6 +145,9 @@ jobs:
         run: mamba update -n tardis --file conda-${{ matrix.label }}.lock
         if: steps.cache-conda.outputs.cache-hit != 'true'
 
+      - name: Install bokeh
+        run: mamba install bokeh=2.2 --channel conda-forge --no-update-deps --yes
+
       - name: Install package
         run: pip install -e .
         

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -1,11 +1,20 @@
 name: tardis-carsus-compatibility-check
 
-on: 
-  workflow_dispatch:
-    inputs:
-      git-ref:
-        description: Git Ref (Optional)    
-        required: false
+# on: 
+#   workflow_dispatch:
+#     inputs:
+#       git-ref:
+#         description: Git Ref (Optional)    
+#         required: false
+
+on:
+  push:
+    branches:
+    - '*'
+
+  pull_request:
+    branches:
+    - '*'
         
 env:
   XUVTOP: /tmp/chianti

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -117,11 +117,11 @@ jobs:
         id: cache-conda
 
       - name: Update environment
-        run: mamba update -n tardis --file conda-${{ matrix.label }}.lock
+        run: mamba update -n tardis --file tardis/conda-${{ matrix.label }}.lock
         if: steps.cache-conda.outputs.cache-hit != 'true'
 
       - name: Install package
-        run: pip install -e .
+        run: pip install -e tardis
 
   generate-spectrum:
     runs-on: ubuntu-latest

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -118,12 +118,12 @@ jobs:
 
       - uses: actions/cache@v2
         with:
-          path: ${{ matrix.prefix }}
-          key: conda-${{ matrix.label }}-${{ hashFiles('conda-${{ matrix.label }}.lock') }}-${{ env.CACHE_NUMBER }}
+          path: /usr/share/miniconda3/envs/tardis
+          key: conda-linux-64-${{ hashFiles('conda-linux-64.lock') }}-${{ env.CACHE_NUMBER }}
         id: cache-conda
 
       - name: Update environment
-        run: mamba update -n tardis --file conda-${{ matrix.label }}.lock
+        run: mamba update -n tardis --file conda-linux-64.lock
         if: steps.cache-conda.outputs.cache-hit != 'true'
 
       - name: Install bokeh
@@ -139,9 +139,6 @@ jobs:
           name: atom-data
           path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5      
       
-      - name: Print path
-        run: python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
-
       - name: Replace atomic data in reference data repository with the generated atomic data
         run: cp carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5 tardis-refdata/atom_data/kurucz_cd23_chianti_H_He.h5
       
@@ -153,9 +150,6 @@ jobs:
         with:
           name: reference data
           path: tardis-refdata/unit_test_data_org.h5
-  
-      - name: Print directory tree
-        run: tree
 
       - name: Run tests and generate new reference data
         run:  pytest tardis ${{ env.PYTEST_FLAGS }}

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -116,7 +116,8 @@ jobs:
           lfs: true
         
       - name: Fetch lfs objects
-        run: cd tardis-refdata
+        run: |
+             cd tardis-refdata
              git lfs checkout 
 
       - name: Setup TARDIS environment

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run notebooks
         run: |
-          ${{ env.NBCONVERT_CMD }} carsus/docs/quickstart.ipynb
+          ${{ env.NBCONVERT_CMD }} carsus/docs/refdata_gen.ipynb
         env:
           CARSUS_REFDATA: ${{ github.workspace }}/carsus-refdata
         

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -94,7 +94,7 @@ jobs:
           path: carsus/docs/kurucz_cd23_chianti_H_He.h5
   
   tardis-build:
-    # needs: carsus-build
+    needs: carsus-build
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -88,6 +88,7 @@ jobs:
           path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
   
   tardis-build:
+    needs: carsus-build
     strategy: # TODO
         matrix:
           include:
@@ -122,16 +123,31 @@ jobs:
 
       - name: Install package
         run: pip install -e tardis
-
-  generate-spectrum:
-    runs-on: ubuntu-latest
-    needs: [carsus-build, tardis-build]
-
-    steps: 
-      - uses: actions/download-artifact@v2
+      
+      - name: Download atom data
+        uses: actions/download-artifact@v2
         with:
           name: atom-data
           path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
+      
+      - name: Run notebook to test spectrum
+        run: |
+            ${{ env.NBCONVERT_CMD }} tardis/tests/test_spectrum.ipynb
+        
+      
+
+  # generate-spectrum:
+  #   runs-on: ubuntu-latest
+  #   needs: [carsus-build, tardis-build]
+
+  #   steps: 
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: atom-data
+  #         path: carsus/docs/kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5
+      
+      
+
 
 
 

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -32,9 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          repository: atharva-2001/carsus
           path: carsus/
-          ref: tardis_carsus_bridge
         
       - uses: actions/cache@v2
         with:

--- a/docs/refdata_gen.ipynb
+++ b/docs/refdata_gen.ipynb
@@ -1,0 +1,331 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generate TARDIS Reference Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Atomic Weights and Ionization Energies (NIST)\n",
+    "\n",
+    "Download atomic weights and ionization energies from the National Institute of Standards and Technology (NIST)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from carsus.io.nist import NISTWeightsComp, NISTIonizationEnergies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "atomic_weights = NISTWeightsComp()\n",
+    "ionization_energies = NISTIonizationEnergies('H-Zn')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Levels, Lines, Collisions & Cross-sections\n",
+    "\n",
+    "Carsus supports three sources of energy levels and spectral lines: **GFALL**, **CHIANTI** and **CMFGEN**.\n",
+    "\n",
+    "### GFALL\n",
+    "\n",
+    "The Robert Kurucz's Atomic Linelist (GFALL) reader is the main source of **levels and lines**.\n",
+    "\n",
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "**Warning:**\n",
+    "    \n",
+    "Creating a `GFALLReader` instance is **required**.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wget -qO /tmp/gfall.dat https://media.githubusercontent.com/media/tardis-sn/carsus-db/master/gfall/gfall_latest.dat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from carsus.io.kurucz import GFALLReader\n",
+    "\n",
+    "gfall_reader = GFALLReader('H-Zn',\n",
+    "                           '/tmp/gfall.dat')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### CHIANTI\n",
+    "\n",
+    "The Chianti Atomic Database reader provides levels and lines but also **collision strengths**.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "**Note:**\n",
+    "\n",
+    "Creating a `ChiantiReader` instance is **optional**. \n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from carsus.io.chianti_ import ChiantiReader\n",
+    "\n",
+    "chianti_reader = ChiantiReader('H-He', \n",
+    "                               collisions=True, \n",
+    "                               priority=20)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default `priority` parameter is set to `10`. Increase this value if you want to keep CHIANTI levels and lines over GFALL."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### CMFGEN\n",
+    "\n",
+    "The atomic database of [CMFGEN](http://kookaburra.phyast.pitt.edu/hillier/web/CMFGEN.htm) is a source of levels, lines and (optionally) **ionization energies**, **photoionization cross-sections** and **collisions**.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "    \n",
+    "**Note:**\n",
+    "\n",
+    "Creating a `CMFGENReader` instance is **optional**. \n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "**Warning:**\n",
+    "    \n",
+    "Cross-sections require data from `H 0`, use this the reader with enough `priority` to select levels from this ion.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from carsus.io.cmfgen import CMFGENReader\n",
+    "\n",
+    "cmfgen_reader = CMFGENReader.from_config('Si 0-1', \n",
+    "                                         '/tmp/atomic', \n",
+    "                                         priority=30,\n",
+    "                                         ionization_energies=True,\n",
+    "                                         cross_sections=True,\n",
+    "                                         collisions=False,\n",
+    "                                         temperature_grid=None,\n",
+    "                                         drop_mismatched_labels=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Zeta Data\n",
+    "\n",
+    "Long & Knigge's ground state recombinations fractions ($\\zeta$)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from carsus.io.zeta import KnoxLongZeta\n",
+    "\n",
+    "zeta_data = KnoxLongZeta()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create an Atomic Data File\n",
+    "\n",
+    "Finally, create a `TARDISAtomData` object and dump the data with the `to_hdf` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from carsus.io.output import TARDISAtomData\n",
+    "\n",
+    "atom_data = TARDISAtomData(atomic_weights,\n",
+    "                           ionization_energies,\n",
+    "                           gfall_reader,\n",
+    "                           zeta_data,\n",
+    "                           chianti_reader,\n",
+    "                           cmfgen_reader)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "atom_data.to_hdf('kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You are done! Now you can use your file to run TARDIS simulations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Metadata\n",
+    "\n",
+    "Carsus stores metadata inside the HDF5 files to ensure reproducibility. This metadata includes a checksum for each stored table, version number or checksum of selected datasets, and versions of relevant packages. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "store = pd.HDFStore('kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5', key='metadata')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "store[\"metadata\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "store.root._v_attrs"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.12"
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/refdata_gen.ipynb
+++ b/docs/refdata_gen.ipynb
@@ -8,18 +8,14 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Atomic Weights and Ionization Energies (NIST)\n",
-    "\n",
-    "Download atomic weights and ionization energies from the National Institute of Standards and Technology (NIST)."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-07-29T09:16:29.906868Z",
+     "start_time": "2022-07-29T09:16:28.516542Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from carsus.io.nist import NISTWeightsComp, NISTIonizationEnergies"
@@ -28,7 +24,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-07-29T09:16:51.744919Z",
+     "start_time": "2022-07-29T09:16:29.908561Z"
+    }
+   },
    "outputs": [],
    "source": [
     "atomic_weights = NISTWeightsComp()\n",
@@ -36,30 +37,14 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Levels, Lines, Collisions & Cross-sections\n",
-    "\n",
-    "Carsus supports three sources of energy levels and spectral lines: **GFALL**, **CHIANTI** and **CMFGEN**.\n",
-    "\n",
-    "### GFALL\n",
-    "\n",
-    "The Robert Kurucz's Atomic Linelist (GFALL) reader is the main source of **levels and lines**.\n",
-    "\n",
-    "<div class=\"alert alert-warning\">\n",
-    "\n",
-    "**Warning:**\n",
-    "    \n",
-    "Creating a `GFALLReader` instance is **required**.\n",
-    "\n",
-    "</div>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-07-29T09:19:24.270027Z",
+     "start_time": "2022-07-29T09:16:51.747861Z"
+    }
+   },
    "outputs": [],
    "source": [
     "!wget -qO /tmp/gfall.dat https://media.githubusercontent.com/media/tardis-sn/carsus-db/master/gfall/gfall_latest.dat"
@@ -68,7 +53,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-07-29T09:19:24.297355Z",
+     "start_time": "2022-07-29T09:19:24.277033Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from carsus.io.kurucz import GFALLReader\n",
@@ -78,26 +68,14 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### CHIANTI\n",
-    "\n",
-    "The Chianti Atomic Database reader provides levels and lines but also **collision strengths**.\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**Note:**\n",
-    "\n",
-    "Creating a `ChiantiReader` instance is **optional**. \n",
-    "\n",
-    "</div>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-07-29T09:19:24.530027Z",
+     "start_time": "2022-07-29T09:19:24.302537Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from carsus.io.chianti_ import ChiantiReader\n",
@@ -108,73 +86,14 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "By default `priority` parameter is set to `10`. Increase this value if you want to keep CHIANTI levels and lines over GFALL."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### CMFGEN\n",
-    "\n",
-    "The atomic database of [CMFGEN](http://kookaburra.phyast.pitt.edu/hillier/web/CMFGEN.htm) is a source of levels, lines and (optionally) **ionization energies**, **photoionization cross-sections** and **collisions**.\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "    \n",
-    "**Note:**\n",
-    "\n",
-    "Creating a `CMFGENReader` instance is **optional**. \n",
-    "\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-warning\">\n",
-    "\n",
-    "**Warning:**\n",
-    "    \n",
-    "Cross-sections require data from `H 0`, use this the reader with enough `priority` to select levels from this ion.\n",
-    "\n",
-    "</div>"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from carsus.io.cmfgen import CMFGENReader\n",
-    "\n",
-    "cmfgen_reader = CMFGENReader.from_config('Si 0-1', \n",
-    "                                         '/tmp/atomic', \n",
-    "                                         priority=30,\n",
-    "                                         ionization_energies=True,\n",
-    "                                         cross_sections=True,\n",
-    "                                         collisions=False,\n",
-    "                                         temperature_grid=None,\n",
-    "                                         drop_mismatched_labels=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Zeta Data\n",
-    "\n",
-    "Long & Knigge's ground state recombinations fractions ($\\zeta$)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-07-29T09:19:25.982059Z",
+     "start_time": "2022-07-29T09:19:24.533157Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from carsus.io.zeta import KnoxLongZeta\n",
@@ -183,18 +102,13 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Create an Atomic Data File\n",
-    "\n",
-    "Finally, create a `TARDISAtomData` object and dump the data with the `to_hdf` method."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-07-29T09:19:26.046819Z",
+     "start_time": "2022-07-29T09:19:25.988275Z"
+    },
     "scrolled": true
    },
    "outputs": [],
@@ -205,69 +119,21 @@
     "                           ionization_energies,\n",
     "                           gfall_reader,\n",
     "                           zeta_data,\n",
-    "                           chianti_reader,\n",
-    "                           cmfgen_reader)"
+    "                           chianti_reader)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-07-29T09:19:26.052578Z",
+     "start_time": "2022-07-29T09:19:26.052554Z"
+    }
+   },
    "outputs": [],
    "source": [
     "atom_data.to_hdf('kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You are done! Now you can use your file to run TARDIS simulations."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Metadata\n",
-    "\n",
-    "Carsus stores metadata inside the HDF5 files to ensure reproducibility. This metadata includes a checksum for each stored table, version number or checksum of selected datasets, and versions of relevant packages. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "store = pd.HDFStore('kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5', key='metadata')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "store[\"metadata\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "store.root._v_attrs"
    ]
   }
  ],

--- a/docs/refdata_gen.ipynb
+++ b/docs/refdata_gen.ipynb
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "atomic_weights = NISTWeightsComp()\n",
-    "ionization_energies = NISTIonizationEnergies('H-He')"
+    "ionization_energies = NISTIonizationEnergies('H-Zn')"
    ]
   },
   {
@@ -63,7 +63,7 @@
    "source": [
     "from carsus.io.kurucz import GFALLReader\n",
     "\n",
-    "gfall_reader = GFALLReader('H-He',\n",
+    "gfall_reader = GFALLReader('H-Zn',\n",
     "                           '/tmp/gfall.dat')"
    ]
   },

--- a/docs/refdata_gen.ipynb
+++ b/docs/refdata_gen.ipynb
@@ -12,8 +12,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2022-08-02T08:09:51.981531Z",
-     "start_time": "2022-08-02T08:09:50.521452Z"
+     "end_time": "2022-08-02T10:44:42.401734Z",
+     "start_time": "2022-08-02T10:44:42.398590Z"
     }
    },
    "outputs": [],
@@ -26,14 +26,14 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2022-08-02T08:10:06.119103Z",
-     "start_time": "2022-08-02T08:09:53.430754Z"
+     "end_time": "2022-08-02T10:44:55.909963Z",
+     "start_time": "2022-08-02T10:44:42.949132Z"
     }
    },
    "outputs": [],
    "source": [
     "atomic_weights = NISTWeightsComp()\n",
-    "ionization_energies = NISTIonizationEnergies('H-Zn')"
+    "ionization_energies = NISTIonizationEnergies('H-Zn', )"
    ]
   },
   {
@@ -78,11 +78,11 @@
    },
    "outputs": [],
    "source": [
-    "# from carsus.io.chianti_ import ChiantiReader\n",
+    "from carsus.io.chianti_ import ChiantiReader\n",
     "\n",
-    "# chianti_reader = ChiantiReader('H-He', \n",
-    "#                                collisions=True, \n",
-    "#                                priority=20)"
+    "chianti_reader = ChiantiReader('H-He', \n",
+    "                               collisions=False, \n",
+    "                               priority=20)"
    ]
   },
   {
@@ -118,7 +118,8 @@
     "atom_data = TARDISAtomData(atomic_weights,\n",
     "                           ionization_energies,\n",
     "                           gfall_reader,\n",
-    "                           zeta_data,)"
+    "                           zeta_data,\n",
+    "                           chianti_reader)"
    ]
   },
   {

--- a/docs/refdata_gen.ipynb
+++ b/docs/refdata_gen.ipynb
@@ -133,7 +133,7 @@
    },
    "outputs": [],
    "source": [
-    "atom_data.to_hdf('kurucz_cd23_chianti_He_cmfgen_H_Si_I-II.h5')"
+    "atom_data.to_hdf('kurucz_cd23_chianti_H_He.h5')"
    ]
   }
  ],

--- a/docs/refdata_gen.ipynb
+++ b/docs/refdata_gen.ipynb
@@ -12,8 +12,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2022-07-29T09:16:29.906868Z",
-     "start_time": "2022-07-29T09:16:28.516542Z"
+     "end_time": "2022-08-02T08:09:51.981531Z",
+     "start_time": "2022-08-02T08:09:50.521452Z"
     }
    },
    "outputs": [],
@@ -26,14 +26,14 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2022-07-29T09:16:51.744919Z",
-     "start_time": "2022-07-29T09:16:29.908561Z"
+     "end_time": "2022-08-02T08:10:06.119103Z",
+     "start_time": "2022-08-02T08:09:53.430754Z"
     }
    },
    "outputs": [],
    "source": [
     "atomic_weights = NISTWeightsComp()\n",
-    "ionization_energies = NISTIonizationEnergies('H-Zn')"
+    "ionization_energies = NISTIonizationEnergies('H-He')"
    ]
   },
   {
@@ -41,8 +41,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2022-07-29T09:19:24.270027Z",
-     "start_time": "2022-07-29T09:16:51.747861Z"
+     "end_time": "2022-08-02T08:10:38.821252Z",
+     "start_time": "2022-08-02T08:10:13.465692Z"
     }
    },
    "outputs": [],
@@ -55,15 +55,15 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2022-07-29T09:19:24.297355Z",
-     "start_time": "2022-07-29T09:19:24.277033Z"
+     "end_time": "2022-08-02T08:10:59.427252Z",
+     "start_time": "2022-08-02T08:10:59.409344Z"
     }
    },
    "outputs": [],
    "source": [
     "from carsus.io.kurucz import GFALLReader\n",
     "\n",
-    "gfall_reader = GFALLReader('H-Zn',\n",
+    "gfall_reader = GFALLReader('H-He',\n",
     "                           '/tmp/gfall.dat')"
    ]
   },
@@ -72,17 +72,17 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2022-07-29T09:19:24.530027Z",
-     "start_time": "2022-07-29T09:19:24.302537Z"
+     "end_time": "2022-08-02T08:11:11.360903Z",
+     "start_time": "2022-08-02T08:11:11.353226Z"
     }
    },
    "outputs": [],
    "source": [
-    "from carsus.io.chianti_ import ChiantiReader\n",
+    "# from carsus.io.chianti_ import ChiantiReader\n",
     "\n",
-    "chianti_reader = ChiantiReader('H-He', \n",
-    "                               collisions=True, \n",
-    "                               priority=20)"
+    "# chianti_reader = ChiantiReader('H-He', \n",
+    "#                                collisions=True, \n",
+    "#                                priority=20)"
    ]
   },
   {
@@ -90,8 +90,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2022-07-29T09:19:25.982059Z",
-     "start_time": "2022-07-29T09:19:24.533157Z"
+     "end_time": "2022-08-02T08:11:12.931369Z",
+     "start_time": "2022-08-02T08:11:11.700068Z"
     }
    },
    "outputs": [],
@@ -106,8 +106,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2022-07-29T09:19:26.046819Z",
-     "start_time": "2022-07-29T09:19:25.988275Z"
+     "end_time": "2022-08-02T08:11:30.555303Z",
+     "start_time": "2022-08-02T08:11:13.631612Z"
     },
     "scrolled": true
    },
@@ -118,8 +118,7 @@
     "atom_data = TARDISAtomData(atomic_weights,\n",
     "                           ionization_energies,\n",
     "                           gfall_reader,\n",
-    "                           zeta_data,\n",
-    "                           chianti_reader)"
+    "                           zeta_data,)"
    ]
   },
   {
@@ -127,8 +126,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2022-07-29T09:19:26.052578Z",
-     "start_time": "2022-07-29T09:19:26.052554Z"
+     "end_time": "2022-07-29T10:28:50.219288Z",
+     "start_time": "2022-07-29T10:28:49.208901Z"
     }
    },
    "outputs": [],

--- a/docs/tardis_atomdata_ref.ipynb
+++ b/docs/tardis_atomdata_ref.ipynb
@@ -4,7 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Generate TARDIS Reference Data"
+    "# Generate Atomic Data Reference for TARDIS\n",
+    "This noteboook generates atomic data to be compared with the [atomic data stored in tardis refdata repository](https://github.com/tardis-sn/tardis-refdata/blob/master/atom_data/kurucz_cd23_chianti_H_He.h5) for testing purposes. "
    ]
   },
   {
@@ -82,7 +83,7 @@
     "\n",
     "chianti_reader = ChiantiReader('H-He', \n",
     "                               collisions=False, \n",
-    "                               priority=20)"
+    "                               priority=30)"
    ]
   },
   {


### PR DESCRIPTION
### :pencil: Description

**Type:** :rocket: `feature` :vertical_traffic_light: `testing` 

<!-- Write a complete description of your changes, including the necessary context or any piece of information required to understand your work.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 
-->
This PR adds a workflow to check if the current Carsus atomic file makes any difference to the TARDIS spectrum and other data.

The workflow takes the following steps to do this:
- Clone TARDIS, Carsus and TARDIS refdata repositories.
- Generate the Carsus atomic data and save it as an artifact.
- Download the artifact in another job.
- Replace the [atom data used for testing](https://github.com/tardis-sn/tardis-refdata/blob/master/atom_data/kurucz_cd23_chianti_H_He.h5) with this artifact.
- Create a copy of the [reference data](https://github.com/tardis-sn/tardis-refdata/blob/master/unit_test_data.h5) generated from tests.
- Use the artifact(atom data) to generate new reference data.
- Compare this reference data with the saved one using [this](https://github.com/atharva-2001/tardis-refdata/blob/refdata_compare/notebooks/ref_data_compare_from_paths.ipynb) notebook.



### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
