### PR TITLE
Bugfix for issue #323

### DIFF
--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -680,7 +680,9 @@ class TARDISAtomData:
 
         collisions = pd.concat([collisions, collisional_ul_factors], axis=1)
         collisions = collisions.set_index('e_col_id')
-
+        collisions = collisions.dropna(subset=['level_number_upper', 'level_number_lower'])
+        collisions = collisions.astype({'atomic_number':int, 'ion_number':int, 
+                            'level_number_lower':int, 'level_number_upper':int})
         return collisions
 
     def create_cross_sections(self):


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

Fixes issue #323 

In `TARDISAtomData.create_collisions()`, dropped all rows of the output DataFrame that had `nan` values for `level_number_upper` and `level_number_lower`, then turned all values of the `atomic_number`, `ion_number`, `level_number_upper` and `level_number_lower` columns from `float64 `into `int`.

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
