### PR TITLE
Define default `columns` variable in `CMFGENEnergyLevelsParser`

### DIFF
--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -43,6 +43,19 @@ class CMFGENEnergyLevelsParser(BaseParser):
             "engine": "python",
         }
 
+        columns = [
+            'label',
+            'g',
+            'E(cm^-1)',
+            '10^15 Hz',
+            'eV',
+            'Lam(A)',
+            'ID',
+            'ARAD',
+            'C4',
+            'C6'
+        ]
+
         try:
             df = pd.read_csv(fname, **config)
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Define the default value of `columns` for `CMFGENEnergyLevelsParser` based on the columns in the CMFGEN Energy Levels data.

`closes` #274  


### :pushpin: Resources

[Carsus-refdata](https://github.com/tardis-sn/carsus-refdata/blob/master/cmfgen/energy_levels/si2_osc_kurucz)


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

@atharva-2001 @epassaro 