### PR TITLE
Fix TypeError on pd.DataFrame.drop() for pandas >= 1.5

### DIFF
--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -278,7 +278,7 @@ class GFALLReader(object):
 
         levels["method"] = levels["theoretical"].\
             apply(lambda x: "theor" if x else "meas")  # Theoretical or measured
-        levels.drop("theoretical", 1, inplace=True)
+        levels.drop("theoretical", axis="columns", inplace=True)
 
         levels["level_index"] = levels.groupby(['atomic_number', 'ion_charge'])['j'].\
             transform(lambda x: np.arange(len(x), dtype=np.int64)).values
@@ -346,7 +346,7 @@ class GFALLReader(object):
 
         lines = gfall[selected_columns].copy()
         lines["gf"] = np.power(10, lines["loggf"])
-        lines = lines.drop(["loggf"], 1)
+        lines = lines.drop(["loggf"], axis="columns")
 
         # Assigning levels to lines
         levels_unique_idxed = self.levels.reset_index().set_index(


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

With pandas 2.0 (maybe also 1.5?) using the GFALL readers gives me the error:

```
  File "GitHub/tardis-sn/carsus/carsus/io/kurucz/gfall.py", line 281, in extract_levels
    levels.drop("theoretical", 1, inplace=True)
TypeError: DataFrame.drop() takes from 1 to 2 positional arguments but 3 positional arguments (and 1 keyword-only argument) were given
```

I'm skipping most of the boilerplate since this is a trivial fix. For Pandas 2.0 (and maybe also 1.5?) the axis argument to DataFrame.drop must be keyword instead of positional. This doesn't break older versions, since the parameter name has not changed.