### PR TITLE
Improve energy resolution of hydrogen photoionization cross section t…

### DIFF
--- a/carsus/io/cmfgen/util.py
+++ b/carsus/io/cmfgen/util.py
@@ -4,6 +4,7 @@ import itertools
 import astropy.constants as const
 import astropy.units as u
 import numpy as np
+from scipy.interpolate import interp1d
 
 from enum import IntEnum, unique
 
@@ -182,19 +183,42 @@ def get_seaton_phixs_table(threshold_energy_ryd, sigma_t, beta, s, nu_0=None, n_
     return phixs_table
 
 
-def get_hydrogenic_n_phixs_table(hyd_gaunt_energy_grid_ryd, hyd_gaunt_factor, threshold_energy_ryd, n):
+def get_hydrogenic_n_phixs_table(
+    hyd_gaunt_energy_grid_ryd,
+    hyd_gaunt_factor,
+    threshold_energy_ryd,
+    n,
+    hyd_n_phixs_stop2start_energy_ratio,
+    hyd_n_phixs_num_points,
+):
     """
     Citation required.
     """
-    energy_grid = hyd_gaunt_energy_grid_ryd[n]
+    hyd_gaunt_energy_grid_ryd_n = np.array(hyd_gaunt_energy_grid_ryd[n])
+    energy_grid = np.geomspace(
+        hyd_gaunt_energy_grid_ryd_n.min(),
+        hyd_gaunt_energy_grid_ryd_n.min() * hyd_n_phixs_stop2start_energy_ratio,
+        hyd_n_phixs_num_points,
+    )
     phixs_table = np.empty((len(energy_grid), 2))
     scale_factor = 7.91 / threshold_energy_ryd / n
+    log_hyd_gaunt_factor_interpolator = interp1d(
+        np.log(hyd_gaunt_energy_grid_ryd_n),
+        np.log(np.array(hyd_gaunt_factor[n])),
+        fill_value=(hyd_gaunt_factor[n][0], hyd_gaunt_factor[n][-1]),
+        bounds_error=False,
+    )
 
     for i, energy_ryd in enumerate(energy_grid):
         energy_div_threshold = energy_ryd / energy_grid[0]
 
         if energy_div_threshold > 0:
-            cross_section = scale_factor * hyd_gaunt_factor[n][i] / (energy_div_threshold) ** 3
+            hyd_gaunt_factor_n = np.exp(
+                log_hyd_gaunt_factor_interpolator(np.log(energy_ryd))
+            )
+            cross_section = (
+                scale_factor * hyd_gaunt_factor_n / (energy_div_threshold) ** 3
+            )
         else:
             cross_section = 0.0
 

--- a/carsus/io/cmfgen/util.py
+++ b/carsus/io/cmfgen/util.py
@@ -195,6 +195,7 @@ def get_hydrogenic_n_phixs_table(
     Citation required.
     """
     hyd_gaunt_energy_grid_ryd_n = np.array(hyd_gaunt_energy_grid_ryd[n])
+    log_gaunt_factor_n = np.log(hyd_gaunt_factor[n])
     energy_grid = np.geomspace(
         hyd_gaunt_energy_grid_ryd_n.min(),
         hyd_gaunt_energy_grid_ryd_n.min() * hyd_n_phixs_stop2start_energy_ratio,
@@ -204,8 +205,8 @@ def get_hydrogenic_n_phixs_table(
     scale_factor = 7.91 / threshold_energy_ryd / n
     log_hyd_gaunt_factor_interpolator = interp1d(
         np.log(hyd_gaunt_energy_grid_ryd_n),
-        np.log(np.array(hyd_gaunt_factor[n])),
-        fill_value=(hyd_gaunt_factor[n][0], hyd_gaunt_factor[n][-1]),
+        log_gaunt_factor_n,
+        fill_value=(log_gaunt_factor_n[0], log_gaunt_factor_n[-1]),
         bounds_error=False,
     )
 

--- a/carsus/io/tests/test_cmfgen.py
+++ b/carsus/io/tests/test_cmfgen.py
@@ -166,15 +166,27 @@ def test_get_seaton_phixs_table(threshold_energy_ryd, fit_coeff_list):
 
 
 @pytest.mark.array_compare
-@pytest.mark.parametrize("hyd_gaunt_energy_grid_ryd", [{1: list(range(1, 3))}])
+@pytest.mark.parametrize("hyd_gaunt_energy_grid_ryd", [{1: list(range(1, 4))}])
 @pytest.mark.parametrize("hyd_gaunt_factor", [{1: list(range(3, 6))}])
 @pytest.mark.parametrize("threshold_energy_ryd", [0.5])
 @pytest.mark.parametrize("n", [1])
+@pytest.mark.parametrize("hyd_n_phixs_stop2start_energy_ratio", [20])
+@pytest.mark.parametrize("hyd_n_phixs_num_points", [20])
 def test_get_hydrogenic_n_phixs_table(
-    hyd_gaunt_energy_grid_ryd, hyd_gaunt_factor, threshold_energy_ryd, n
+    hyd_gaunt_energy_grid_ryd,
+    hyd_gaunt_factor,
+    threshold_energy_ryd,
+    n,
+    hyd_n_phixs_stop2start_energy_ratio,
+    hyd_n_phixs_num_points,
 ):
     hydrogenic_n_phixs_table = get_hydrogenic_n_phixs_table(
-        hyd_gaunt_energy_grid_ryd, hyd_gaunt_factor, threshold_energy_ryd, n
+        hyd_gaunt_energy_grid_ryd,
+        hyd_gaunt_factor,
+        threshold_energy_ryd,
+        n,
+        hyd_n_phixs_stop2start_energy_ratio,
+        hyd_n_phixs_num_points,
     )
     return hydrogenic_n_phixs_table
 


### PR DESCRIPTION
The way Carsus currently exports the photoionization cross sections for hydrogen is not ideal: the frequency grid is very coarse but extends up to ridiculous energies (e.g. 3 MeV for n=2). This causes problems in TARDIS and needs to be fixed.
### :pencil: Description

**Type:** ::rocket: `feature`


### :pushpin: Resources



### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (locally)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
