### PR TITLE
retaining label in tardis atom data

### DIFF
--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -343,11 +343,11 @@ class TARDISAtomData:
         levels = pd.concat([gf_levels, ch_levels, cf_levels], sort=True)
         levels['g'] = 2*levels['j'] + 1
         levels['g'] = levels['g'].astype(np.int)
-        levels = levels.drop(columns=['j', 'label', 'method'])
+        levels = levels.drop(columns=['j', 'method'])
         levels = levels.reset_index()
         levels = levels.rename(columns={'ion_charge': 'ion_number'})
         levels = levels[['atomic_number', 'ion_number', 'g', 'energy', 
-                         'ds_id', 'priority']]
+                         'ds_id', 'priority', 'label']]
         levels['energy'] = u.Quantity(levels['energy'], 'cm-1').to(
             'eV', equivalencies=u.spectral()).value
  
@@ -399,7 +399,7 @@ class TARDISAtomData:
             levels = levels.drop(levels[mask].index)
 
         levels = levels[['atomic_number', 'ion_number', 'g', 'energy', 
-                         'ds_id']]
+                         'ds_id', 'label']]
         levels = levels.reset_index()
 
         return levels


### PR DESCRIPTION
### :pencil: Description

**Type:** :vertical_traffic_light: `testing`

Making a dummy PR to run workflows after retaining label in level information in `TARDISAtomicData`

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
