### PR TITLE
Update installation docs to install conda packages for x86 environment only

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -31,7 +31,7 @@ Setup the Environment
 .. code ::
 
     $ cd carsus
-    $ conda env create -f carsus_env3.yml
+    $ CONDA_SUBDIR=osx-64 conda env create -f carsus_env3.yml
 
 
 ===================

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -31,6 +31,19 @@ Setup the Environment
 .. code ::
 
     $ cd carsus
+
+
+If you're using GNU/Linux or Intel-based Mac installation then directly create the environment using the below command:
+
+.. code ::
+
+    $ conda env create -f carsus_env3.yml
+
+
+However, if you're using M1-based Mac (Apple Silicon), then force conda to install Intel-based packages:
+
+.. code ::
+
     $ CONDA_SUBDIR=osx-64 conda env create -f carsus_env3.yml
 
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation`

The current conda packages required for `carsus` are incompatible with Apple Silicon M1 MacBook (`osx-arm64` environment). Hence, the developer should force conda to install packages for `osx-64` (x86) environment.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method: Installation using the modified command was successful on my M1 MacBook
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
