### PR TITLE
Include NNDC decay data in the final Carsus HDF output

### DIFF
--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -47,6 +47,7 @@ class TARDISAtomData:
                  zeta_data,
                  chianti_reader=None,
                  cmfgen_reader=None,
+                 nndc_reader=None,
                  levels_lines_param={"levels_metastable_loggf_threshold": -3,
                                      "lines_loggf_threshold": -3},
                  collisions_param={"temperatures": np.arange(2000, 50000, 2000)}
@@ -65,6 +66,7 @@ class TARDISAtomData:
         self.zeta_data = zeta_data
         self.chianti_reader = chianti_reader
         self.cmfgen_reader = cmfgen_reader
+        self.nndc_reader = nndc_reader
         self.levels_lines_param = levels_lines_param
         self.collisions_param = collisions_param
 
@@ -1031,6 +1033,7 @@ class TARDISAtomData:
             f.put('/macro_atom_data', self.macro_atom_prepared)
             f.put('/macro_atom_references',
                   self.macro_atom_references_prepared)
+            f.put('/nndc_decay_data', self.nndc_reader.decay_data)
 
             if hasattr(self, 'collisions'):
                 f.put('/collisions_data', self.collisions_prepared)

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -1033,7 +1033,7 @@ class TARDISAtomData:
             f.put('/macro_atom_data', self.macro_atom_prepared)
             f.put('/macro_atom_references',
                   self.macro_atom_references_prepared)
-            f.put('/nndc_decay_data', self.nndc_reader.decay_data)
+            f.put('/nuclear_decay_rad', self.nndc_reader.decay_data)
 
             if hasattr(self, 'collisions'):
                 f.put('/collisions_data', self.collisions_prepared)

--- a/carsus/io/tests/test_output_base.ipynb
+++ b/carsus/io/tests/test_output_base.ipynb
@@ -94,7 +94,7 @@
     "gfall_reader = GFALLReader(ions=GFALL_IONS)\n",
     "chianti_reader = ChiantiReader(ions=CHIANTI_IONS, collisions=True, priority=20)\n",
     "zeta_data = KnoxLongZeta()\n",
-    "nndc_reader = NNDCReader()\n",
+    "nndc_reader = NNDCReader(remote=True)\n",
     "\n",
     "si_0_lvl = CMFGENEnergyLevelsParser(os.path.join(CARSUS_REFDATA, 'cmfgen/energy_levels/SiI_OSC')).base\n",
     "si_0_osc = CMFGENOscillatorStrengthsParser(os.path.join(CARSUS_REFDATA, 'cmfgen/energy_levels/SiI_OSC')).base\n",
@@ -432,7 +432,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert_frame_equal(decay_data, refdata['nndc_decay_data'])"
+    "assert_frame_equal(decay_data, refdata['nuclear_decay_rad'])"
    ]
   },
   {

--- a/carsus/io/tests/test_output_base.ipynb
+++ b/carsus/io/tests/test_output_base.ipynb
@@ -86,6 +86,7 @@
     "from carsus.io.zeta import KnoxLongZeta\n",
     "from carsus.io.chianti_ import ChiantiReader\n",
     "from carsus.io.cmfgen import CMFGENEnergyLevelsParser, CMFGENOscillatorStrengthsParser, CMFGENReader\n",
+    "from carsus.io.nuclear import NNDCReader\n",
     "from carsus.io.output import TARDISAtomData\n",
     "\n",
     "atomic_weights = NISTWeightsComp()\n",
@@ -93,6 +94,7 @@
     "gfall_reader = GFALLReader(ions=GFALL_IONS)\n",
     "chianti_reader = ChiantiReader(ions=CHIANTI_IONS, collisions=True, priority=20)\n",
     "zeta_data = KnoxLongZeta()\n",
+    "nndc_reader = NNDCReader()\n",
     "\n",
     "si_0_lvl = CMFGENEnergyLevelsParser(os.path.join(CARSUS_REFDATA, 'cmfgen/energy_levels/SiI_OSC')).base\n",
     "si_0_osc = CMFGENOscillatorStrengthsParser(os.path.join(CARSUS_REFDATA, 'cmfgen/energy_levels/SiI_OSC')).base\n",
@@ -116,7 +118,8 @@
     "                            gfall_reader,\n",
     "                            zeta_data,\n",
     "                            chianti_reader,\n",
-    "                            cmfgen_reader)"
+    "                            cmfgen_reader, \n",
+    "                            nndc_reader)"
    ]
   },
   {
@@ -261,6 +264,15 @@
    "outputs": [],
    "source": [
     "zeta_data = atom_data.zeta_data.base"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "decay_data = atom_data.nndc_reader.decay_data"
    ]
   },
   {
@@ -412,6 +424,15 @@
    "outputs": [],
    "source": [
     "assert_frame_equal(zeta_data, refdata['zeta_data'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert_frame_equal(decay_data, refdata['nndc_decay_data'])"
    ]
   },
   {


### PR DESCRIPTION
### :pencil: Description

**Type:** :rocket: `feature`

This PR uses the NNDC decay-data created in #345 and merges it into the final HDF output produced by Carsus.

The test-notebook should run successfully once the changes in carsus-refdata have been made as per the [PR 13](https://github.com/tardis-sn/carsus-refdata/pull/13).
