### PR TITLE
Add carsus-data-nndc github URL

### DIFF
--- a/carsus/io/nuclear/nndc.py
+++ b/carsus/io/nuclear/nndc.py
@@ -1,14 +1,10 @@
 import pandas as pd
-import os
-import pathlib
+from pathlib import Path
 import subprocess
 
-DECAY_DATA_SOURCE_DIR = os.path.join(os.path.expanduser("~"), "Downloads", "carsus-data-nndc")
+DECAY_DATA_SOURCE_DIR = Path.home() / "Downloads" / "carsus-data-nndc"
 
-DECAY_DATA_FINAL_DIR = os.path.join(
-    os.path.expanduser("~"), "Downloads", "tardis-data", "decay-data"
-)
-
+DECAY_DATA_FINAL_DIR = Path.home() / "Downloads" / "tardis-data" / "decay-data"
 
 NNDC_SOURCE_URL = "https://github.com/tardis-sn/carsus-data-nndc"
 
@@ -38,12 +34,11 @@ class NNDCReader:
         if dirname is None:
             if remote:
                 subprocess.run(['git', 'clone', NNDC_SOURCE_URL, DECAY_DATA_SOURCE_DIR])
-            self.dirname = os.path.join(DECAY_DATA_SOURCE_DIR, "csv")
+            self.dirname = Path().joinpath(DECAY_DATA_SOURCE_DIR, "csv")
         else:
             self.dirname = dirname
 
         self._decay_data = None
-
 
     @property
     def decay_data(self):
@@ -62,7 +57,7 @@ class NNDCReader:
         """
 
         all_data = []
-        dirpath = pathlib.Path(self.dirname)
+        dirpath = Path(self.dirname)
         for file in dirpath.iterdir():
             # convert every csv file to Dataframe and append it to all_data
             if file.suffix == ".csv" and file.stat().st_size != 0:
@@ -141,10 +136,10 @@ class NNDCReader:
         if fpath is None:
             fpath = DECAY_DATA_FINAL_DIR
 
-        if not os.path.exists(fpath):
-            os.mkdir(fpath)
+        if not Path(fpath).exists():
+            Path(fpath).mkdir()
 
-        target_fname = os.path.join(fpath, "compiled_ensdf_csv.h5")
+        target_fname = Path().joinpath(fpath, "compiled_ensdf_csv.h5")
 
         with pd.HDFStore(target_fname, 'w') as f:
             f.put('/decay_data', self.decay_data)

--- a/carsus/io/nuclear/nndc.py
+++ b/carsus/io/nuclear/nndc.py
@@ -1,14 +1,16 @@
 import pandas as pd
 import os
 import pathlib
+import subprocess
 
-DECAY_DATA_SOURCE_DIR = os.path.join(
-    os.path.expanduser("~"), "Downloads", "carsus-data-nndc-main", "csv"
-)
+DECAY_DATA_SOURCE_DIR = os.path.join(os.path.expanduser("~"), "Downloads", "carsus-data-nndc")
 
 DECAY_DATA_FINAL_DIR = os.path.join(
     os.path.expanduser("~"), "Downloads", "tardis-data", "decay-data"
 )
+
+
+NNDC_SOURCE_URL = "https://github.com/tardis-sn/carsus-data-nndc"
 
 
 class NNDCReader:
@@ -25,7 +27,7 @@ class NNDCReader:
         Return pandas DataFrame representation of the decay data
     """
 
-    def __init__(self, dirname=None):
+    def __init__(self, dirname=None, remote=False):
         """
         Parameters
         ----------
@@ -34,7 +36,9 @@ class NNDCReader:
 
         """
         if dirname is None:
-            self.dirname = DECAY_DATA_SOURCE_DIR
+            if remote:
+                subprocess.run(['git', 'clone', NNDC_SOURCE_URL, DECAY_DATA_SOURCE_DIR])
+            self.dirname = os.path.join(DECAY_DATA_SOURCE_DIR, "csv")
         else:
             self.dirname = dirname
 

--- a/carsus/io/tests/test_nndc.py
+++ b/carsus/io/tests/test_nndc.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import shutil
 
 import pytest
@@ -124,4 +124,4 @@ def test_nndc_reader_decay_data_http(decay_data_http, index, element, z, parent_
     assert row["Rad Energy"] == rad_energy
 
     # Deleting the repository cloned during the test
-    shutil.rmtree(os.path.join(os.path.expanduser("~"), "Downloads", "carsus-data-nndc"))
+    shutil.rmtree(Path.home().joinpath("Downloads", "carsus-data-nndc"))

--- a/carsus/io/tests/test_nndc.py
+++ b/carsus/io/tests/test_nndc.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+
 import pytest
 
 from carsus.io.nuclear import NNDCReader
@@ -9,8 +12,18 @@ def nndc_reader(nndc_dirname):
 
 
 @pytest.fixture()
+def nndc_reader_http():
+    return NNDCReader(remote=True)
+
+
+@pytest.fixture()
 def decay_data(nndc_reader):
     return nndc_reader.decay_data
+
+
+@pytest.fixture()
+def decay_data_http(nndc_reader_http):
+    return nndc_reader_http.decay_data
 
 
 @pytest.mark.parametrize("element, z, parent_e_level, decay_mode, "
@@ -90,3 +103,25 @@ def test_nndc_reader_metastable(decay_data, index, parent_e_level, decay_mode,
     assert row["Decay Mode Value"] == decay_mode_value
     assert row["T1/2 (sec)"] == half_life
     assert row["Metastable"] == metastable
+
+
+@pytest.mark.parametrize("index, element, z, parent_e_level, metastable, "
+                         "decay_mode, decay_mode_value, radiation, rad_subtype, rad_energy", [
+                             ("Ni56", "Ni", 28, 0.0, False, "EC", 100.00, "g", "XR ka2", 6.915),
+                             ("Mn52", "Mn", 25, 377.749, True, "IT", 1.75, "g", "XR ka1", 5.899)
+                         ])
+def test_nndc_reader_decay_data_http(decay_data_http, index, element, z, parent_e_level, metastable,
+                                     decay_mode, decay_mode_value, radiation, rad_subtype, rad_energy):
+    df = decay_data_http[(decay_data_http.index == index) & (decay_data_http["Decay Mode"] == decay_mode) &
+                         (decay_data_http["Decay Mode Value"] == decay_mode_value) &
+                         (decay_data_http["Rad subtype"] == rad_subtype)]
+
+    row = df.loc[index]
+    assert row["Element"] == element
+    assert row["Z"] == z
+    assert row["Parent E(level)"] == parent_e_level
+    assert row["Radiation"] == radiation
+    assert row["Rad Energy"] == rad_energy
+
+    # Deleting the repository cloned during the test
+    shutil.rmtree(os.path.join(os.path.expanduser("~"), "Downloads", "carsus-data-nndc"))


### PR DESCRIPTION
### :pencil: Description

**Type:** :rocket: `feature`

This clones the [carsus-data-nndc](https://github.com/tardis-sn/carsus-data-nndc) when there is no local source of the NNDC CSV data present. The `NNDCReader` class gets another attribute `remote` which needs to be set to `True` when the github mirror is to be used.

The test includes cloning the repository and deleting it at the end of the test.

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label
