### PR TITLE
Logging the local NNDC data source and remote data source

### DIFF
--- a/carsus/io/nuclear/nndc.py
+++ b/carsus/io/nuclear/nndc.py
@@ -1,3 +1,5 @@
+import logging
+
 import pandas as pd
 from pathlib import Path
 import subprocess
@@ -7,6 +9,8 @@ DECAY_DATA_SOURCE_DIR = Path.home() / "Downloads" / "carsus-data-nndc"
 DECAY_DATA_FINAL_DIR = Path.home() / "Downloads" / "tardis-data" / "decay-data"
 
 NNDC_SOURCE_URL = "https://github.com/tardis-sn/carsus-data-nndc"
+
+logger = logging.getLogger(__name__)
 
 
 class NNDCReader:
@@ -34,9 +38,12 @@ class NNDCReader:
         if dirname is None:
             if remote:
                 subprocess.run(['git', 'clone', NNDC_SOURCE_URL, DECAY_DATA_SOURCE_DIR])
+                logger.info(f"Downloading NNDC decay data from {NNDC_SOURCE_URL}")
             self.dirname = Path().joinpath(DECAY_DATA_SOURCE_DIR, "csv")
         else:
             self.dirname = dirname
+
+        logger.info(f"Parsing decay data from: {DECAY_DATA_SOURCE_DIR}/csv")
 
         self._decay_data = None
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :rocket: `feature`

Logging the source path for the NNDC data and the remote repo URL when downloading from [carsus-data-nndc](https://github.com/tardis-sn/carsus-data-nndc).

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
Ran the NNDCReader in command line with the following snippet:
```
from carsus.io.nuclear import NNDCReader
nndc_reader = NNDCReader(remote=True) # and one when remote = False
nndc_reader.to_hdf()
``` 
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

