### PR TITLE
Add warning for when carsus-data-nndc already exists 

### DIFF
--- a/carsus/io/nuclear/nndc.py
+++ b/carsus/io/nuclear/nndc.py
@@ -37,8 +37,12 @@ class NNDCReader:
         """
         if dirname is None:
             if remote:
-                subprocess.run(['git', 'clone', NNDC_SOURCE_URL, DECAY_DATA_SOURCE_DIR])
-                logger.info(f"Downloading NNDC decay data from {NNDC_SOURCE_URL}")
+                try:
+                    subprocess.run(['git', 'clone', NNDC_SOURCE_URL, DECAY_DATA_SOURCE_DIR], check=True)
+                    logger.info(f"Downloading NNDC decay data from {NNDC_SOURCE_URL}")
+                except subprocess.CalledProcessError:
+                    logger.warning(f"Failed to clone the repository.\n"
+                                   "Check if the repository already exists at {DECAY_DATA_SOURCE_DIR}")
             self.dirname = DECAY_DATA_SOURCE_DIR / "csv"
         else:
             self.dirname = dirname

--- a/carsus/io/nuclear/nndc.py
+++ b/carsus/io/nuclear/nndc.py
@@ -39,7 +39,7 @@ class NNDCReader:
             if remote:
                 subprocess.run(['git', 'clone', NNDC_SOURCE_URL, DECAY_DATA_SOURCE_DIR])
                 logger.info(f"Downloading NNDC decay data from {NNDC_SOURCE_URL}")
-            self.dirname = Path().joinpath(DECAY_DATA_SOURCE_DIR, "csv")
+            self.dirname = DECAY_DATA_SOURCE_DIR / "csv"
         else:
             self.dirname = dirname
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

When downloading the remote NNDC data from [carsus-data-nndc](https://github.com/tardis-sn/carsus-data-nndc/), it throws an error when the repository already exists in the `DECAY_DATA_SOURCE_DIR`. This PR handles the error by logging a warning.

Also, replaced `joinpath()` with `/`.

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

