### PR TITLE
Add nuclear decay data to the quickstart notebook

### DIFF
--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -196,6 +196,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Nuclear decay data\n",
+    "\n",
+    "Carsus also supports the decay radiation data of all the nuclides at the [NNDC Archives](https://www.nndc.bnl.gov/ensdfarchivals/). The ENSDF data is stored in CSV format in the repository [carsus-data-nndc](https://github.com/tardis-sn/carsus-data-nndc).\n",
+    "\n",
+    "### NNDC\n",
+    "\n",
+    "The NNDCReader instance looks for the `carsus-data-nndc` repository in the local system at the path specified by the argument `dirname`. If the data is to be downloaded from the Github repository directly , the `remote` argument should be set to `True`.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "    \n",
+    "**Note:**\n",
+    "\n",
+    "Creating a `NNDCReader` instance is **optional**. \n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from carsus.io.nuclear import NNDCReader\n",
+    "\n",
+    "nndc_reader = NNDCReader(remote=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Create an Atomic Data File\n",
     "\n",
     "Finally, create a `TARDISAtomData` object and dump the data with the `to_hdf` method."
@@ -216,7 +248,8 @@
     "                           gfall_reader,\n",
     "                           zeta_data,\n",
     "                           chianti_reader,\n",
-    "                           cmfgen_reader)"
+    "                           cmfgen_reader,\n",
+    "                           nndc_reader)"
    ]
   },
   {


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation`

Adding the nuclear radiation data obtained from NNDC to the [Quickstart notebook](https://tardis-sn.github.io/carsus/quickstart.html). 


### :pushpin: Resources

PR #350, PR #354 

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

