### PR TITLE
Integrate carsus atomic data repositories with carsus

### DIFF
--- a/.github/workflows/carsus-data-repos-config.yml
+++ b/.github/workflows/carsus-data-repos-config.yml
@@ -28,24 +28,19 @@ jobs:
         uses: actions/cache@v3
         with:
           path: carsus-data-kurucz
-          key: ${{ runner.os }}-cache-${{ hashFiles('ccarsus-data-kurucz/**/*.lock') }}
+          key: ${{ runner.os }}-cache-${{ hashFiles('carsus-data-kurucz/**/*.lock') }}
 
       - name: Restore cache
         uses: actions/cache@v3
         with:
           path: carsus-data-nist
           key: ${{ runner.os }}-cache-${{ hashFiles('carsus-data-nist/**/*.lock') }}
-
-
-      - run: |
-          ls
         
       - run: |
           for repo in carsus-data-cmfgen carsus-data-kurucz carsus-data-nist; do
             repo_path="$repo"
-            echo "Checking for repository $repo_path..."        
+       
             if [ ! -d $repo_path ] ; then
-              echo "Cloning repository $repo..."
               git clone https://github.com/s-rathi/$repo $repo_path     
             else                               
               cd $repo_path
@@ -54,8 +49,7 @@ jobs:
               cd ..
             fi
           done
-      - run: |
-            ls
+
       - name: Setup carsus environment
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -67,17 +61,6 @@ jobs:
 
       - name: Install package
         run: pip install -e carsus/
-
-      - run: |
-          current_dir="${PWD}"
-          echo "curent: $current_dir"
-          #cd carsus-data-cmfgen/atomic/HYD/I
-          ls
-          cd carsus/
-          ls
-          #cd ../../carsus-data-nist
-          #echo "carsus-data-nist"
-          #ls
           
       - name: Run notebooks
         run: |

--- a/.github/workflows/carsus-data-repos-config.yml
+++ b/.github/workflows/carsus-data-repos-config.yml
@@ -28,16 +28,19 @@ jobs:
         uses: actions/cache@v3
         with:
           path: carsus-data-kurucz
-          key: ${{ runner.os }}-cache-${{ hashFiles('carsus-data-kurucz/**/*.lock') }}
+          key: ${{ runner.os }}-cache-${{ hashFiles('ccarsus-data-kurucz/**/*.lock') }}
 
       - name: Restore cache
         uses: actions/cache@v3
         with:
           path: carsus-data-nist
           key: ${{ runner.os }}-cache-${{ hashFiles('carsus-data-nist/**/*.lock') }}
+
+
+      - run: |
+          ls
         
       - run: |
-          - run: |
           for repo in carsus-data-cmfgen carsus-data-kurucz carsus-data-nist; do
             repo_path="$repo"
             echo "Checking for repository $repo_path..."        
@@ -51,7 +54,8 @@ jobs:
               cd ..
             fi
           done
-
+      - run: |
+            ls
       - name: Setup carsus environment
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -63,6 +67,17 @@ jobs:
 
       - name: Install package
         run: pip install -e carsus/
+
+      - run: |
+          current_dir="${PWD}"
+          echo "curent: $current_dir"
+          #cd carsus-data-cmfgen/atomic/HYD/I
+          ls
+          cd carsus/
+          ls
+          #cd ../../carsus-data-nist
+          #echo "carsus-data-nist"
+          #ls
           
       - name: Run notebooks
         run: |

--- a/.github/workflows/carsus-data-repos-config.yml
+++ b/.github/workflows/carsus-data-repos-config.yml
@@ -1,0 +1,79 @@
+name: carsus-data-repos-config
+
+on: 
+  workflow_dispatch: 
+        
+env:
+  NBCONVERT_FLAGS: --execute --ExecutePreprocessor.timeout=600 --to html
+
+defaults:
+      run:
+        shell: bash -l {0}
+
+jobs:
+  carsus-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: carsus/
+                      
+      - name: Cache carsus-data-cmfgen
+        uses: actions/cache@v3
+        with:
+          path: cloned-repo-carsus-data-cmfgen
+          key: ${{ runner.os }}-cache-${{ hashFiles('cloned-repo-carsus-data-cmfgen/**/*') }}
+        id: cmfgen-cache
+            
+      - name: Clone carsus-data-cmfgen
+        run: | 
+          git clone https://github.com/tardis-sn/carsus-data-cmfgen cloned-repo-carsus-data-cmfgen
+        if: steps.cmfgen-cache.outputs.cache-hit != 'true'
+
+      - name: Cache Cloned carsus-data-kurucz
+        uses: actions/cache@v3
+        with:
+          path: cloned-repo-carsus-data-kurucz
+          key: ${{ runner.os }}-cache-${{ hashFiles('cloned-repo-carsus-data-kurucz/**/*') }}
+        id: kurucz-cache
+
+      - name: Clone Repo carsus-data-kurucz
+        run: |
+          git clone https://github.com/tardis-sn/carsus-data-kurucz cloned-repo-carsus-data-kurucz
+        if: steps.kurucz-cache.outputs.cache-hit != 'true'
+
+      - name: Cache Cloned carsus-data-nist
+        uses: actions/cache@v3
+        with:
+          path: cloned-repo-carsus-data-nist
+          key: ${{ runner.os }}-cache-${{ hashFiles('cloned-repo-carsus-data-nist/**/*') }}
+        id: nist-cache
+
+      - name: Clone Repo carsus-data-nist
+        run: |
+          git clone https://github.com/tardis-sn/carsus-data-nist cloned-repo-carsus-data-nist
+        if: steps.nist-cache.outputs.cache-hit != 'true'
+        
+      - name: Setup carsus environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+            miniforge-variant: Mambaforge
+            miniforge-version: latest
+            environment-file: carsus/carsus_env3.yml
+            activate-environment: carsus
+            use-mamba: true
+
+      - name: Install package
+        run: pip install -e carsus/
+
+      - name: Run notebooks
+        run: |
+          jupyter nbconvert ${{ env.NBCONVERT_FLAGS }} carsus/docs/tardis_atomdata_ref.ipynb
+        env:
+          CARSUS_REFDATA: ${{ github.workspace }}/carsus-refdata
+        
+      - name: Upload Atom Data
+        uses: actions/upload-artifact@v3
+        with:
+          name: atom-data
+          path: carsus/docs/kurucz_cd23_cmfgen_H_Si_I-II.h5

--- a/.github/workflows/carsus-data-repos-config.yml
+++ b/.github/workflows/carsus-data-repos-config.yml
@@ -78,4 +78,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: atom-data
-          path: carsus/docs/kurucz_cd23_cmfgen_Si.h5
+          path: carsus/docs/kurucz_cd23_cmfgen_H_Si.h5

--- a/.github/workflows/carsus-data-repos-config.yml
+++ b/.github/workflows/carsus-data-repos-config.yml
@@ -21,40 +21,36 @@ jobs:
       - name: Restore cache
         uses: actions/cache@v3
         with:
-          path: cloned-repo-carsus-data-cmfgen
-          key: ${{ runner.os }}-cache-${{ hashFiles('cloned-repo-carsus-data-cmfgen/**/*.lock') }}
+          path: carsus-data-cmfgen
+          key: ${{ runner.os }}-cache-${{ hashFiles('carsus-data-cmfgen/**/*.lock') }}
 
       - name: Restore cache
         uses: actions/cache@v3
         with:
-          path: cloned-repo-carsus-data-kurucz
-          key: ${{ runner.os }}-cache-${{ hashFiles('cloned-repo-carsus-data-kurucz/**/*.lock') }}
+          path: carsus-data-kurucz
+          key: ${{ runner.os }}-cache-${{ hashFiles('carsus-data-kurucz/**/*.lock') }}
 
       - name: Restore cache
         uses: actions/cache@v3
         with:
-          path: cloned-repo-carsus-data-nist
-          key: ${{ runner.os }}-cache-${{ hashFiles('cloned-repo-carsus-data-nist/**/*.lock') }}
+          path: carsus-data-nist
+          key: ${{ runner.os }}-cache-${{ hashFiles('carsus-data-nist/**/*.lock') }}
         
       - run: |
+          - run: |
           for repo in carsus-data-cmfgen carsus-data-kurucz carsus-data-nist; do
-            repo_path="cloned-repo-$repo"
-
-            if [ ! -d $repo_path ]] ; then
+            repo_path="$repo"
+            echo "Checking for repository $repo_path..."        
+            if [ ! -d $repo_path ] ; then
               echo "Cloning repository $repo..."
-              git clone https://github.com/tardis-sn/$repo $repo_path
-            fi
-
-            # check for changes and update
-            cd $repo_path
-            git fetch
-            if git diff origin/main --exit-code; then
-              echo "No changes found for $repo. Using existing clone."
-            else
+              git clone https://github.com/s-rathi/$repo $repo_path     
+            else                               
+              cd $repo_path
+              git fetch
               git checkout origin/main
-              echo "Repository $repo updated. Checked out latest changes."
+              cd ..
             fi
-          done
+          done- run: |
 
       - name: Setup carsus environment
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/carsus-data-repos-config.yml
+++ b/.github/workflows/carsus-data-repos-config.yml
@@ -11,49 +11,51 @@ defaults:
         shell: bash -l {0}
 
 jobs:
-  carsus-build:
+  checkout:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           path: carsus/
-                      
-      - name: Cache carsus-data-cmfgen
+
+      - name: Restore cache
         uses: actions/cache@v3
         with:
           path: cloned-repo-carsus-data-cmfgen
-          key: ${{ runner.os }}-cache-${{ hashFiles('cloned-repo-carsus-data-cmfgen/**/*') }}
-        id: cmfgen-cache
-            
-      - name: Clone carsus-data-cmfgen
-        run: | 
-          git clone https://github.com/tardis-sn/carsus-data-cmfgen cloned-repo-carsus-data-cmfgen
-        if: steps.cmfgen-cache.outputs.cache-hit != 'true'
+          key: ${{ runner.os }}-cache-${{ hashFiles('cloned-repo-carsus-data-cmfgen/**/*.lock') }}
 
-      - name: Cache Cloned carsus-data-kurucz
+      - name: Restore cache
         uses: actions/cache@v3
         with:
           path: cloned-repo-carsus-data-kurucz
-          key: ${{ runner.os }}-cache-${{ hashFiles('cloned-repo-carsus-data-kurucz/**/*') }}
-        id: kurucz-cache
+          key: ${{ runner.os }}-cache-${{ hashFiles('cloned-repo-carsus-data-kurucz/**/*.lock') }}
 
-      - name: Clone Repo carsus-data-kurucz
-        run: |
-          git clone https://github.com/tardis-sn/carsus-data-kurucz cloned-repo-carsus-data-kurucz
-        if: steps.kurucz-cache.outputs.cache-hit != 'true'
-
-      - name: Cache Cloned carsus-data-nist
+      - name: Restore cache
         uses: actions/cache@v3
         with:
           path: cloned-repo-carsus-data-nist
-          key: ${{ runner.os }}-cache-${{ hashFiles('cloned-repo-carsus-data-nist/**/*') }}
-        id: nist-cache
-
-      - name: Clone Repo carsus-data-nist
-        run: |
-          git clone https://github.com/tardis-sn/carsus-data-nist cloned-repo-carsus-data-nist
-        if: steps.nist-cache.outputs.cache-hit != 'true'
+          key: ${{ runner.os }}-cache-${{ hashFiles('cloned-repo-carsus-data-nist/**/*.lock') }}
         
+      - run: |
+          for repo in carsus-data-cmfgen carsus-data-kurucz carsus-data-nist; do
+            repo_path="cloned-repo-$repo"
+
+            if [ ! -d $repo_path ]] ; then
+              echo "Cloning repository $repo..."
+              git clone https://github.com/tardis-sn/$repo $repo_path
+            fi
+
+            # check for changes and update
+            cd $repo_path
+            git fetch
+            if git diff origin/main --exit-code; then
+              echo "No changes found for $repo. Using existing clone."
+            else
+              git checkout origin/main
+              echo "Repository $repo updated. Checked out latest changes."
+            fi
+          done
+
       - name: Setup carsus environment
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -65,7 +67,7 @@ jobs:
 
       - name: Install package
         run: pip install -e carsus/
-
+          
       - name: Run notebooks
         run: |
           jupyter nbconvert ${{ env.NBCONVERT_FLAGS }} carsus/docs/tardis_atomdata_ref.ipynb
@@ -76,4 +78,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: atom-data
-          path: carsus/docs/kurucz_cd23_cmfgen_H_Si_I-II.h5
+          path: carsus/docs/kurucz_cd23_cmfgen_Si.h5

--- a/.github/workflows/carsus-data-repos-config.yml
+++ b/.github/workflows/carsus-data-repos-config.yml
@@ -50,7 +50,7 @@ jobs:
               git checkout origin/main
               cd ..
             fi
-          done- run: |
+          done
 
       - name: Setup carsus environment
         uses: conda-incubator/setup-miniconda@v2

--- a/docs/tardis_atomdata_ref.ipynb
+++ b/docs/tardis_atomdata_ref.ipynb
@@ -48,7 +48,7 @@
    },
    "outputs": [],
    "source": [
-    "!wget -qO /tmp/gfall.dat https://media.githubusercontent.com/media/tardis-sn/carsus-db/master/gfall/gfall_latest.dat"
+    "gfall_path = '../../cloned-repo-carsus-data-kurucz/linelists/gfall/gfall.dat'"
    ]
   },
   {
@@ -65,25 +65,34 @@
     "from carsus.io.kurucz import GFALLReader\n",
     "\n",
     "gfall_reader = GFALLReader('H-Zn',\n",
-    "                           '/tmp/gfall.dat')"
+    "                           gfall_path)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-08-02T08:11:11.360903Z",
-     "start_time": "2022-08-02T08:11:11.353226Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from carsus.io.chianti_ import ChiantiReader\n",
+    "cmfgen_path = '../../cloned-repo-carsus-data-cmfgen/atomic/'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from carsus.io.cmfgen import CMFGENReader\n",
     "\n",
-    "chianti_reader = ChiantiReader('H-He', \n",
-    "                               collisions=False, \n",
-    "                               priority=30)"
+    "cmfgen_reader = CMFGENReader.from_config('Si 0-1',\n",
+    "                                         cmfgen_path,\n",
+    "                                         priority=30,\n",
+    "                                         ionization_energies=True,\n",
+    "                                         cross_sections=True,\n",
+    "                                         collisions=False,\n",
+    "                                         temperature_grid=None,\n",
+    "                                         drop_mismatched_labels=True)\n"
    ]
   },
   {
@@ -120,7 +129,7 @@
     "                           ionization_energies,\n",
     "                           gfall_reader,\n",
     "                           zeta_data,\n",
-    "                           chianti_reader)"
+    "                           cmfgen_reader)"
    ]
   },
   {
@@ -134,7 +143,7 @@
    },
    "outputs": [],
    "source": [
-    "atom_data.to_hdf('kurucz_cd23_chianti_H_He.h5')"
+    "atom_data.to_hdf('kurucz_cd23_cmfgen_H_Si.h5')"
    ]
   }
  ],

--- a/docs/tardis_atomdata_ref.ipynb
+++ b/docs/tardis_atomdata_ref.ipynb
@@ -48,7 +48,7 @@
    },
    "outputs": [],
    "source": [
-    "gfall_path = '../../cloned-repo-carsus-data-kurucz/linelists/gfall/gfall.dat'"
+    "gfall_path = '../../carsus-data-kurucz/linelists/gfall/gfall.dat'"
    ]
   },
   {
@@ -74,7 +74,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cmfgen_path = '../../cloned-repo-carsus-data-cmfgen/atomic/'"
+    "cmfgen_path = '../../carsus-data-cmfgen/atomic/'"
    ]
   },
   {

--- a/docs/tardis_atomdata_ref.ipynb
+++ b/docs/tardis_atomdata_ref.ipynb
@@ -42,20 +42,6 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2022-08-02T08:10:38.821252Z",
-     "start_time": "2022-08-02T08:10:13.465692Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "gfall_path = '../../carsus-data-kurucz/linelists/gfall/gfall.dat'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
      "end_time": "2022-08-02T08:10:59.427252Z",
      "start_time": "2022-08-02T08:10:59.409344Z"
     }
@@ -64,8 +50,7 @@
    "source": [
     "from carsus.io.kurucz import GFALLReader\n",
     "\n",
-    "gfall_reader = GFALLReader('H-Zn',\n",
-    "                           gfall_path)"
+    "gfall_reader = GFALLReader('H-Zn')"
    ]
   },
   {


### PR DESCRIPTION
### Description :pencil: 

This PR integrates the `carsus-data-cmfgen`,  `carsus-data-kurucz` and  `carsus-data-nist` to the `carsus` repository.

**Type:**  :roller_coaster: `infrastructure`





### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
