### PR TITLE
Make NNDC Reader optional

### DIFF
--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -1033,7 +1033,9 @@ class TARDISAtomData:
             f.put('/macro_atom_data', self.macro_atom_prepared)
             f.put('/macro_atom_references',
                   self.macro_atom_references_prepared)
-            f.put('/nuclear_decay_rad', self.nndc_reader.decay_data)
+
+            if hasattr(self.nndc_reader, 'decay_data'):
+                f.put('/nuclear_decay_rad', self.nndc_reader.decay_data)
 
             if hasattr(self, 'collisions'):
                 f.put('/collisions_data', self.collisions_prepared)


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

This PR makes having the NNDCReader object optional while creating the atomic data HDF output.

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

