### PR TITLE
Add carsus-data-kurucz as default data path for GFALLReader

### DIFF
--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -12,7 +12,7 @@ from carsus.util import convert_atomic_number2symbol, parse_selected_species
 from carsus.io.util import read_from_buffer
 
 
-CARSUS_DATA_GFALL_URL = 'https://github.com/s-rathi/carsus-data-kurucz/raw/main/linelists/gfall/gfall.dat'
+CARSUS_DATA_GFALL_URL = 'https://github.com/s-rathi/carsus-data-kurucz/raw/main/linelists/gfall/gfall.dat?raw=true'
 GFALL_AIR_THRESHOLD = 200  # [nm], wavelengths above this value are given in air
 
 logger = logging.getLogger(__name__)

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -13,6 +13,7 @@ from carsus.io.util import read_from_buffer
 
 
 GFALL_URL = 'https://media.githubusercontent.com/media/tardis-sn/carsus-db/master/gfall/gfall_latest.dat'
+CARSUS_DATA_GFALL_URL = 'https://github.com/s-rathi/carsus-data-kurucz/raw/main/linelists/gfall/gfall.dat'
 GFALL_AIR_THRESHOLD = 200  # [nm], wavelengths above this value are given in air
 
 logger = logging.getLogger(__name__)
@@ -73,7 +74,7 @@ class GFALLReader(object):
         """
 
         if fname is None:
-            self.fname = GFALL_URL
+            self.fname = CARSUS_DATA_GFALL_URL
         else:
             self.fname = fname
 
@@ -395,7 +396,7 @@ class GFALLReader(object):
 
 class GFALLIngester(object):
     """
-        Class for ingesting data from kurucz dfall files
+        Class for ingesting data from kurucz gfall files 
 
         Attributes
         ----------
@@ -421,7 +422,7 @@ class GFALLIngester(object):
         self.session = session
         
         if fname is None:
-            self.fname = GFALL_URL
+            self.fname = CARSUS_DATA_GFALL_URL
         else:
             self.fname = fname
         

--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -12,7 +12,6 @@ from carsus.util import convert_atomic_number2symbol, parse_selected_species
 from carsus.io.util import read_from_buffer
 
 
-GFALL_URL = 'https://media.githubusercontent.com/media/tardis-sn/carsus-db/master/gfall/gfall_latest.dat'
 CARSUS_DATA_GFALL_URL = 'https://github.com/s-rathi/carsus-data-kurucz/raw/main/linelists/gfall/gfall.dat'
 GFALL_AIR_THRESHOLD = 200  # [nm], wavelengths above this value are given in air
 


### PR DESCRIPTION
### :pencil: Description

**Type:**  :rocket: `feature`

This pull request enhances the GFALLREADER by designating the gfall.dat file from the `carsus-data-kurucz` repository as the default value for the fname parameter.




### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
