### PR TITLE
Sort the Isotope index in nuclear dataframes

### DIFF
--- a/carsus/io/nuclear/nndc.py
+++ b/carsus/io/nuclear/nndc.py
@@ -128,8 +128,8 @@ class NNDCReader:
 
         decay_data = self._add_metastable_column(decay_data_raw)
 
-        decay_data.set_index(['Isotope'], inplace=True)
-        decay_data.drop(['index'], axis=1, inplace=True)
+        decay_data = decay_data.set_index(['Isotope']).drop(['index'], axis=1)
+        decay_data = decay_data.sort_values(by=decay_data.columns.tolist())
 
         return decay_data
 

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -52,7 +52,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-astropy
-  - pytest-arraydiff
+  - epassaro::pytest-arraydiff
 
   # Other
   - git-lfs

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -52,7 +52,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-astropy
-  - epassaro::pytest-arraydiff
+  - pytest-arraydiff
 
   # Other
   - git-lfs


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

This PR is created on top of #355. It sorts the index in the nuclear decay dataframes by the index (Isotope), thus ensuring uniformity every time the dataset is created. Also chained a few index operations together.


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label
