### PR TITLE
Docs Fix

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches:
     - '*'
+  pull_request:
+    branches:
+    - '*'
 
   workflow_dispatch:
   schedule:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -7,12 +7,20 @@ name: docs
 on:
   push:
     branches:
-    - '*'
-  pull_request:
-    branches:
-    - '*'
+      - master
 
-  workflow_dispatch:
+  pull_request_target:
+    branches:
+      - master
+
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled                         # requires the `build-docs` label
+
+  workflow_dispatch:                    # manual trigger
+
   schedule:
     - cron: '0 0 * * 0' # run at midnight every Sunday
 
@@ -26,32 +34,19 @@ env:
   CHIANTI_DB_VER: CHIANTI_v9.0.1_database.tar.gz
   CMFGEN_DL_URL: http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files
   CMFGEN_DB_VER: atomic_data_15nov16.tar.gz
+  DEPLOY_BRANCH: gh-pages               # deployed docs branch
 
 jobs:
 
   build:
-
-    #  The `docs` workflow is triggered when a commit is pushed to any branch
-    #  of the main repo or fork, but the `build` job starts when one of these 
-    #  conditions is met:
-    #
-    #    a) the branch is `master`
-    #    b) the branch name contains the word `doc(s)`
-    #    c) the commit message includes the a valid tag
-    #    d) the workflow has been triggered manually
-
-    if: github.ref == 'refs/heads/master' ||
+    if: github.event_name == 'push' ||
         github.event_name == 'workflow_dispatch' ||
-        contains(github.ref, 'doc') ||
-        contains(github.event.head_commit.message, '[build docs]') ||
-        contains(github.event.head_commit.message, '[build_docs]') ||
-        contains(github.event.head_commit.message, '[build doc]') ||
-        contains(github.event.head_commit.message, '[build_doc]')
-
+        (github.event_name == 'pull_request_target' &&
+        contains(github.event.pull_request.labels.*.name, 'build-docs'))
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -96,80 +91,100 @@ jobs:
         shell: bash -l {0}
         run: cd docs/; make html
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: html-dir
-          path: docs/_build/html
+      - name: Set destination directory
+        run: |
+          BRANCH=$(echo ${GITHUB_REF#refs/heads/})
+          if [[ $EVENT == push ]] || [[ $EVENT == workflow_dispatch ]]; then
 
-  deploy:
-  
-    needs: build
+            if [[ $BRANCH == $DEFAULT ]]; then
+              echo "DEST_DIR=" >> $GITHUB_ENV
+            else
+              echo "DEST_DIR=branch/$BRANCH" >> $GITHUB_ENV
+            fi
 
-    #  The website is deployed to the root of the `gh-pages` branch of the main 
-    #  repository or fork, only after a commit is pushed to the `master` branch, 
-    #  and the result will be displayed at:
-    #
-    #    tardis-sn.github.io/carsus         (main repository)
-    #    OR <username>.github.io/carsus     (forks)
+          elif [[ $EVENT == pull_request_target ]]; then
+            echo "DEST_DIR=pull/$PR" >> $GITHUB_ENV
 
-    if: github.ref == 'refs/heads/master'
+          else
+            echo "Unexpected event trigger $EVENT"
+            exit 1
 
-    runs-on: ubuntu-latest
-    steps:
+          fi
 
-      - uses: actions/download-artifact@v2
-        with:
-          name: html-dir
-          path: docs/_build/html
+          cat $GITHUB_ENV
+        env:
+          DEFAULT: ${{ github.event.repository.default_branch }}
+          EVENT: ${{ github.event_name }}
+          PR: ${{ github.event.number }}
 
-      - name: Deploy main site
+      - name: Set clean branch option
+        run: |
+          if [[ $EVENT == workflow_dispatch ]]; then
+            echo "CLEAN_BRANCH=true" >> $GITHUB_ENV
+
+          else
+            echo "CLEAN_BRANCH=false" >> $GITHUB_ENV
+
+          fi
+
+          cat $GITHUB_ENV
+        env:
+          EVENT: ${{ github.event_name }}
+
+      - name: Deploy ${{ env.DEST_DIR }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: docs/_build/html
-          force_orphan: true
+          publish_branch: ${{ env.DEPLOY_BRANCH }}
+          publish_dir: ./docs/_build/html
+          destination_dir: ${{ env.DEST_DIR }}
+          keep_files: true
+          force_orphan: ${{ env.CLEAN_BRANCH }}
+          user_name: 'Github Actions'
+          user_email: '41898282+github-actions[bot]@users.noreply.github.com'
 
-  preview:
-    needs: build
-
-    #  Branch preview is only available on forks, and requires at least one of 
-    #  these conditions to be met:
-    #
-    #    a) the branch name contains the word `doc(s)`
-    #    b) commit message includes the a valid tag
-    #    c) the workflow is triggered manually
-    #
-    #  Result will be displayed at: 
-    #
-    #    <username>.github.io/carsus/branch/<branch-name>
-
-    if: github.repository_owner != 'tardis-sn' &&
-        github.ref != 'refs/heads/master' && (
-        github.event_name == 'workflow_dispatch' ||
-        contains(github.ref, 'doc') ||
-        contains(github.event.head_commit.message, '[build docs]') ||
-        contains(github.event.head_commit.message, '[build_docs]') ||
-        contains(github.event.head_commit.message, '[build doc]') ||
-        contains(github.event.head_commit.message, '[build_doc]'))
-
-    runs-on: ubuntu-latest
-    steps:
-
-      - uses: actions/download-artifact@v2
+      - name: Find comment
+        uses: peter-evans/find-comment@v1
+        id: fc
         with:
-          name: html-dir
-          path: docs/_build/html
+          issue-number: ${{ github.event.number }}
+          body-includes: Hi, human.
+        if: always() && github.event_name == 'pull_request_target'
 
-      - name: Get branch name
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: get_branch_name
-
-      - name: Deploy branch site
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Post comment (success)
+        uses: peter-evans/create-or-update-comment@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: docs/_build/html
-          destination_dir: branch/${{ steps.get_branch_name.outputs.branch }}
-          force_orphan: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.number }}
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            *\*beep\* \*bop\**
+
+            Hi, human.
+
+            The **`${{ github.workflow }}`** workflow has **succeeded** :heavy_check_mark:
+            
+            [**Click here**](${{ env.URL }}) to see your results.
+        env:
+          URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pull/${{ github.event.number }}/index.html
+        if: success() && github.event_name == 'pull_request_target'
+
+      - name: Post comment (failure)
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token:  ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.number }}
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            *\*beep\* \*bop\**
+
+            Hi, human.
+
+            The **`${{ github.workflow }}`** workflow has **failed** :x:
+            
+            [**Click here**](${{ env.URL }}) to see the build log.
+        env:
+          URL: https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/actions/runs/${{ github.run_id }}?check_suite_focus=true
+        if: failure() && github.event_name == 'pull_request_target'

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -25,7 +25,7 @@ on:
     - cron: '0 0 * * 0' # run at midnight every Sunday
 
 concurrency:
-  group: docs-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -167,7 +167,7 @@ jobs:
             
             [**Click here**](${{ env.URL }}) to see your results.
         env:
-          URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pull/${{ github.event.number }}/index.html
+          URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pull/${{ github.event.number }}/
         if: success() && github.event_name == 'pull_request_target'
 
       - name: Post comment (failure)

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -43,7 +43,7 @@ dependencies:
   - sphinxcontrib-bibtex
   - nbformat
   - nbsphinx
-  - numpydoc
+  - numpydoc=1.5.0
   - docutils
   - recommonmark
   - pandoc

--- a/conda-linux-64.lock
+++ b/conda-linux-64.lock
@@ -159,7 +159,6 @@ https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed
 https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.3-py_0.tar.bz2#d01180388e6d1838c3e1ad029590aa7a
 https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.5-pyhd8ed1ab_2.tar.bz2#9ff55a0901cf952f05c654394de76bf7
 https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-1.2.18-py37h14c3975_0.tar.bz2#8312512401bdb05d9da4738506d71632
-https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2#4759805cce2d914c38472f70bf4d8bcb
 https://conda.anaconda.org/conda-forge/linux-64/thrift-cpp-0.12.0-hf3afdfd_1004.tar.bz2#2ed22f7ee38e7aad91c5ee1cc58c107c
 https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2#f832c45a477c78bebd107098db465095
 https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2#5844808ffab9ebdb694585b50ba02a96
@@ -234,7 +233,7 @@ https://conda.anaconda.org/conda-forge/noarch/sphinx-5.3.0-pyhd8ed1ab_0.tar.bz2#
 https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-apidoc-0.3.0-py_1.tar.bz2#855b087883443abb10f5faf6eef40860
 https://conda.anaconda.org/conda-forge/linux-64/ipython-7.33.0-py37h89c1867_0.tar.bz2#e4841787deb237aad17b2d44a2d32c23
 https://conda.anaconda.org/conda-forge/noarch/nbclient-0.7.0-pyhd8ed1ab_0.tar.bz2#87eed34d791330d8acdab6a8ab63113f
-https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.7.0-pyhd8ed1ab_0.conda#1ad3afced398492586ca1bef70328be4
+https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.5.0-pyhd8ed1ab_0.tar.bz2#3c275d7168a6a135329f4acb364c229a
 https://conda.anaconda.org/conda-forge/linux-64/pyqt-impl-5.12.3-py37hac37412_8.tar.bz2#148f2e971a67831ed0691f63cd826468
 https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.4-pyhd8ed1ab_0.conda#a9d145de8c5f064b5fa68fb34725d9f4
 https://conda.anaconda.org/conda-forge/noarch/recommonmark-0.7.1-pyhd8ed1ab_0.tar.bz2#b3becf9905b8c7ba839072f65e693253

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -4082,33 +4082,31 @@ package:
   category: main
   optional: false
 - name: numpydoc
-  version: 1.7.0
+  version: 1.5.0
   manager: conda
   platform: linux-64
   dependencies:
     jinja2: '>=2.10'
     python: '>=3.7'
-    sphinx: '>=5'
-    tabulate: '>=0.8.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.7.0-pyhd8ed1ab_0.conda
+    sphinx: '>=1.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.5.0-pyhd8ed1ab_0.tar.bz2
   hash:
-    md5: 1ad3afced398492586ca1bef70328be4
-    sha256: fe33123d34c06c6bc05095f17f92d43f012f990813ad4cf0cc93f7b215c2ad04
+    md5: 3c275d7168a6a135329f4acb364c229a
+    sha256: a45bc74d4ccb5e850f21e3aaf1f0718065569944f99505e49da5409528193348
   category: main
   optional: false
 - name: numpydoc
-  version: 1.7.0
+  version: 1.5.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.7'
     jinja2: '>=2.10'
-    sphinx: '>=5'
-    tabulate: '>=0.8.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.7.0-pyhd8ed1ab_0.conda
+    sphinx: '>=1.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.5.0-pyhd8ed1ab_0.tar.bz2
   hash:
-    md5: 1ad3afced398492586ca1bef70328be4
-    sha256: fe33123d34c06c6bc05095f17f92d43f012f990813ad4cf0cc93f7b215c2ad04
+    md5: 3c275d7168a6a135329f4acb364c229a
+    sha256: a45bc74d4ccb5e850f21e3aaf1f0718065569944f99505e49da5409528193348
   category: main
   optional: false
 - name: olefile
@@ -6625,30 +6623,6 @@ package:
   hash:
     md5: fc4dae09f6b38084f3bfc87c77032584
     sha256: c9c1b7d6025d5efa74f4ddbda1ae72a721f041ad3d4a6ec3dda600befe9dffaa
-  category: main
-  optional: false
-- name: tabulate
-  version: 0.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: 4759805cce2d914c38472f70bf4d8bcb
-    sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
-  category: main
-  optional: false
-- name: tabulate
-  version: 0.9.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: 4759805cce2d914c38472f70bf4d8bcb
-    sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
   category: main
   optional: false
 - name: terminado

--- a/conda-osx-64.lock
+++ b/conda-osx-64.lock
@@ -136,7 +136,6 @@ https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed
 https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.3-py_0.tar.bz2#d01180388e6d1838c3e1ad029590aa7a
 https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.5-pyhd8ed1ab_2.tar.bz2#9ff55a0901cf952f05c654394de76bf7
 https://conda.anaconda.org/conda-forge/osx-64/sqlalchemy-1.2.18-py37h1de35cc_0.tar.bz2#963e47a6588edbea2f76796f2255fcfd
-https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2#4759805cce2d914c38472f70bf4d8bcb
 https://conda.anaconda.org/conda-forge/osx-64/thrift-cpp-0.12.0-h874095a_1004.tar.bz2#e1c65e82c8ea5349169e6ce7e5a24c18
 https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2#f832c45a477c78bebd107098db465095
 https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2#5844808ffab9ebdb694585b50ba02a96
@@ -215,7 +214,7 @@ https://conda.anaconda.org/conda-forge/noarch/uncertainties-3.1.7-pyhd8ed1ab_0.t
 https://conda.anaconda.org/conda-forge/osx-64/ipython-7.33.0-py37hf985489_0.tar.bz2#5290a8018447303c34674bfa57696559
 https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.3.2-py37hf985489_1.tar.bz2#152f8673265782532f880bdfb0e851ce
 https://conda.anaconda.org/conda-forge/noarch/nbclient-0.7.0-pyhd8ed1ab_0.tar.bz2#87eed34d791330d8acdab6a8ab63113f
-https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.7.0-pyhd8ed1ab_0.conda#1ad3afced398492586ca1bef70328be4
+https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.5.0-pyhd8ed1ab_0.tar.bz2#3c275d7168a6a135329f4acb364c229a
 https://conda.anaconda.org/conda-forge/noarch/parquet-cpp-1.5.1-2.tar.bz2#79a5f78c42817594ae016a7896521a97
 https://conda.anaconda.org/conda-forge/osx-64/pytables-3.6.1-py37he7827f7_2.tar.bz2#1ec7244ad2b48010bc8c98c05cf889ae
 https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.4-pyhd8ed1ab_0.conda#a9d145de8c5f064b5fa68fb34725d9f4

--- a/docs/tardis_atomdata_ref.ipynb
+++ b/docs/tardis_atomdata_ref.ipynb
@@ -19,6 +19,7 @@
    },
    "outputs": [],
    "source": [
+    "import pathlib\n",
     "from carsus.io.nist import NISTWeightsComp, NISTIonizationEnergies"
    ]
   },
@@ -59,7 +60,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cmfgen_path = '../../carsus-data-cmfgen/atomic/'"
+    "cmfgen_path = '../../carsus-data-cmfgen/atomic/'\n",
+    "if not pathlib.Path(cmfgen_path).exists():\n",
+    "    cmfgen_path = \"/tmp/atomic/\""
    ]
   },
   {


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation` | :roller_coaster: `infrastructure`

Docs workflow is failing with this traceback-
```
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v5.3.0

Exception occurred:
  File "/home/runner/micromamba/envs/carsus/lib/python3.7/site-packages/numpydoc/__init__.py", line 10, in setup
    from .numpydoc import setup
  File "/home/runner/micromamba/envs/carsus/lib/python3.7/site-packages/numpydoc/numpydoc.py", line 221
    overrides := app.config.numpydoc_validation_overrides.get(
              ^
SyntaxError: invalid syntax
The full traceback has been saved in /tmp/sphinx-err-dmi60mvz.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [Makefile:44: html] Error 2
```

because numpydoc had a recent release (1.6.0) which used the walrus operator in the code which is not compatible with our pinned python dependency. Pinning `numpydoc` to a previous release fixes this. This PR also updates the lock files corresponding to this change.

### :pushpin: Resources
See numpydoc releases here-
https://github.com/numpy/numpydoc/releases
### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
