### PR TITLE
add vald quickstart to docs page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Carsus is a package to manage atomic datasets. It can read data from a variety o
     io/cmfgen
     io/zeta
     io/nndc
-
+    io/vald
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
When I made the VALD reader I forgot to add the quickstart notebook I made to the docs to display on the github pages website. Not sure if this is all I need to do, but maybe somebody can tell me if something else needs to be changed to make it display. 