### PR TITLE
Adds an exception if the user requests atoms with number greater than 94

### DIFF
--- a/carsus/io/nist/weightscomp.py
+++ b/carsus/io/nist/weightscomp.py
@@ -261,6 +261,12 @@ class NISTWeightsComp(BaseParser):
 
     def _prepare_data(self, atoms):
         atomic_numbers = parse_selected_atoms(atoms)
+
+        if atomic_numbers[-1] > 94:
+            raise ValueError(
+                "Atoms with atomic number greater than 94 are not stable, and cannot be handled by the NIST parser."
+                )
+
         atom_data_list = []
 
         for atomic_number in atomic_numbers:

--- a/docs/io/nist.ipynb
+++ b/docs/io/nist.ipynb
@@ -20,7 +20,15 @@
    "source": [
     "## Atomic Weights\n",
     "\n",
-    "Provided by the NIST Atomic Weights and Isotopic Compositions Database."
+    "Provided by the NIST Atomic Weights and Isotopic Compositions Database.\n",
+    "\n",
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "**Warning:** \n",
+    "    \n",
+    "Carsus does not support unstable atoms with atomic numbers greater than 94\n",
+    "\n",
+    "</div>"
    ]
   },
   {


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

Fixes #171. True fix is to have Carsus handle isotopes correctly.

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
