### PR TITLE
Changing ion number to ion charge where appropriate

### DIFF
--- a/carsus/io/util.py
+++ b/carsus/io/util.py
@@ -62,7 +62,7 @@ def convert_species_tuple2chianti_str(species):
 
     Parameters
     -----------
-    species: tuple (atomic_number, ion_number)
+    species: tuple (atomic_number, ion_charge)
 
     Returns
     --------
@@ -78,8 +78,8 @@ def convert_species_tuple2chianti_str(species):
     'si_2'
 
     """
-    atomic_number, ion_number = species
-    chianti_ion_name = convert_atomic_number2symbol(atomic_number).lower() + '_' + str(ion_number + 1)
+    atomic_number, ion_charge = species
+    chianti_ion_name = convert_atomic_number2symbol(atomic_number).lower() + '_' + str(ion_charge + 1)
     return chianti_ion_name
 
 

--- a/carsus/util/selected.py
+++ b/carsus/util/selected.py
@@ -112,7 +112,7 @@ def parse_selected_atoms(atoms):
 def parse_selected_species(species):
     """
     Parse the sting specifying selected species to the list of tuples in the
-    form (atomic_number, ion_number).
+    form (atomic_number, ion_charge).
 
     Parameters
     ----------
@@ -125,7 +125,7 @@ def parse_selected_species(species):
 
     Returns
     -------
-    list of tuples (atomic_number, ion_number)
+    list of tuples (atomic_number, ion_charge)
         List of selected ions
 
     Examples


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

See issue #214. Likely requires changes on the TARDIS end if we want to completely remove the 1-indexed option.

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
