### PR TITLE
Fixes collision export for TARDIS

### DIFF
--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -196,8 +196,8 @@ class TARDISAtomData:
             "/molecules/ionization_energies": (self.barklem_2016_data, "ionization_energies"),
             "/molecules/dissociation_energies": (self.barklem_2016_data, "dissociation_energies"),
             "/molecules/partition_functions": (self.barklem_2016_data, "partition_functions"),
-            "/collisions_data": (self.collisions_preparer, "collisions_prepared"),
-            "/collisions_metadata": (self.collisions_preparer, "collisions_metadata"),
+            "/collisions_data": (self, "collisions_prepared"),
+            "/collisions_metadata": (self, "collisions_metadata"),
             "/photoionization_data": (self.cross_sections_preparer, "cross_sections_prepared"),
         }
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Fixes #411 by correctly pointing to the collision preparer.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
