### PR TITLE
Resolves 2 pandas warnings

### DIFF
--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -192,8 +192,9 @@ class ChiantiIonReader(object):
         levels = pd.DataFrame(levels_dict)
 
         # Replace empty labels with NaN
-        levels.loc[:, "label"] = levels["label"].replace(
-            r'\s+', np.nan, regex=True)
+        with pd.option_context('future.no_silent_downcasting', True):
+            levels.loc[:, "label"] = levels["label"].replace(
+                r'\s+', np.nan, regex=True).infer_objects(copy=False)
 
         # Extract configuration and term from the "pretty" column
         levels[["term", "configuration"]] = levels["pretty"].str.rsplit(

--- a/carsus/io/nist/weightscomp.py
+++ b/carsus/io/nist/weightscomp.py
@@ -125,8 +125,8 @@ class NISTWeightsCompPyparser(BasePyparser):
 
     def _prepare_atomic_weights(self, atomic):
         grouped = atomic.groupby([AW_TYPE_COL])
-        interval_gr = grouped.get_group(INTERVAL).copy()
-        stable_mass_num_gr = grouped.get_group(STABLE_MASS_NUM).copy()
+        interval_gr = grouped.get_group((INTERVAL,)).copy()
+        stable_mass_num_gr = grouped.get_group((STABLE_MASS_NUM,)).copy()
 
         def atomic_weight_interval_to_nom_val_and_std(row):
             nom_val, std_dev = to_nom_val_and_std_dev(


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

There are a couple of Pandas futures warnings that cause a lot of trash log output. This PR resolves them. See also #417 


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
