### PR TITLE
fix missing C2 in vald

### DIFF
--- a/carsus/io/tests/test_vald.py
+++ b/carsus/io/tests/test_vald.py
@@ -65,7 +65,9 @@ def test_vald_reader_vald_raw(vald_raw, index, wl_air, log_gf, e_low, e_up):
     ],
 )
 def test_vald_reader_vald(vald, index, wl_air, log_gf, e_low, e_up, ion_charge):
-    row = vald[1].loc[
+    row = vald[
+        1
+    ].loc[
         index
     ]  # vald is a length two array. The first element is the atoms and the second is the molecules
     assert_almost_equal(row["WL_air(A)"], wl_air)
@@ -133,7 +135,7 @@ def test_vald_short_stellar_linelist_molecules(
     v_mic,
     ion_charge,
 ):
-    assert len(vald_linelist_molecules_short_form_stellar) == 94
+    assert len(vald_linelist_molecules_short_form_stellar) == 95
     row = vald_linelist_molecules_short_form_stellar.iloc[index]
     assert_almost_equal(row["wavelength"], wavelength)
     assert_allclose(

--- a/carsus/io/tests/test_vald.py
+++ b/carsus/io/tests/test_vald.py
@@ -65,9 +65,7 @@ def test_vald_reader_vald_raw(vald_raw, index, wl_air, log_gf, e_low, e_up):
     ],
 )
 def test_vald_reader_vald(vald, index, wl_air, log_gf, e_low, e_up, ion_charge):
-    row = vald[
-        1
-    ].loc[
+    row = vald[1].loc[
         index
     ]  # vald is a length two array. The first element is the atoms and the second is the molecules
     assert_almost_equal(row["WL_air(A)"], wl_air)

--- a/carsus/io/vald/vald.py
+++ b/carsus/io/vald/vald.py
@@ -166,7 +166,9 @@ class VALDReader(object):
         # Elm Ion       WL_air(A)  log gf* E_low(eV) J lo  E_up(eV) J up   lower   upper    mean   Rad.  Stark    Waals
         # 'TiO 1',     4100.00020, -11.472,  0.2011, 31.0,  3.2242, 32.0, 99.000, 99.000, 99.000, 6.962, 0.000, 0.000,
 
-        DATA_RE_PATTERN = re.compile(r"'[a-zA-Z]+\d* \d+',[\s*-?\d+[\.\d+]+,]*")
+        DATA_RE_PATTERN = re.compile(
+            r"'[a-zA-Z]+\d* \d+',[\s*-?\d+[\.\d+]+,]*"
+        )  # This matches to the Elm Ion field of the format above (e.g., TiO 1 or C 2)
 
         buffer, checksum = read_from_buffer(self.fname)
         content = buffer.read().decode()

--- a/carsus/io/vald/vald.py
+++ b/carsus/io/vald/vald.py
@@ -166,7 +166,7 @@ class VALDReader(object):
         # Elm Ion       WL_air(A)  log gf* E_low(eV) J lo  E_up(eV) J up   lower   upper    mean   Rad.  Stark    Waals
         # 'TiO 1',     4100.00020, -11.472,  0.2011, 31.0,  3.2242, 32.0, 99.000, 99.000, 99.000, 6.962, 0.000, 0.000,
 
-        DATA_RE_PATTERN = re.compile("'[a-zA-Z]+ \d+',[\s*-?\d+[\.\d+]+,]*")
+        DATA_RE_PATTERN = re.compile("'[a-zA-Z]+\d* \d+',[\s*-?\d+[\.\d+]+,]*")
 
         buffer, checksum = read_from_buffer(self.fname)
         content = buffer.read().decode()

--- a/carsus/io/vald/vald.py
+++ b/carsus/io/vald/vald.py
@@ -166,7 +166,7 @@ class VALDReader(object):
         # Elm Ion       WL_air(A)  log gf* E_low(eV) J lo  E_up(eV) J up   lower   upper    mean   Rad.  Stark    Waals
         # 'TiO 1',     4100.00020, -11.472,  0.2011, 31.0,  3.2242, 32.0, 99.000, 99.000, 99.000, 6.962, 0.000, 0.000,
 
-        DATA_RE_PATTERN = re.compile("'[a-zA-Z]+\d* \d+',[\s*-?\d+[\.\d+]+,]*")
+        DATA_RE_PATTERN = re.compile(r"'[a-zA-Z]+\d* \d+',[\s*-?\d+[\.\d+]+,]*")
 
         buffer, checksum = read_from_buffer(self.fname)
         content = buffer.read().decode()


### PR DESCRIPTION
Fixing a small bug in the vald molecule linelist parsing that caused it to miss diatomic molecules that have the same base atom - mostly just C2. 