### PR TITLE
Document log(g f) cutoff option in TARDISAtomData (#273)

### DIFF
--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "**Note:**\n",
     "\n",
-    "Get familiar with the [Notation in Carsus](development/notation.rst) and learn how to correctly select ions.\n",
+    "Get familiar with the [Notation in Carsus](reference/notation.rst) and learn how to correctly select ions.\n",
     "    \n",
     "</div>"
    ]

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -249,7 +249,8 @@
     "                           zeta_data,\n",
     "                           chianti_reader,\n",
     "                           cmfgen_reader,\n",
-    "                           nndc_reader)"
+    "                           nndc_reader,\n",
+    "                           levels_lines_param={\"lines_loggf_threshold\": -3})  # Default cutoff is -3 (optional)"
    ]
   },
   {
@@ -265,41 +266,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "A lower value of log(g f) includes weaker transitions, while a higher value filters out more lines.\n",
+    "\n",
     "You are done! Now you can use your file to run TARDIS simulations."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Controlling the log(g f) Cutoff in TARDISAtomData\n",
-    "\n",
-    "By default, Carsus applies a cutoff of **log(g f) = -3** when processing spectral lines.  \n",
-    "This means transitions with log(g f) < -3 are excluded from the atomic data file.\n",
-    "\n",
-    "If you want to change this threshold, modify the `\"lines_loggf_threshold\"` value inside `levels_lines_param`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "atom_data = TARDISAtomData(atomic_weights,\n",
-    "                           ionization_energies,\n",
-    "                           gfall_reader,\n",
-    "                           zeta_data,\n",
-    "                           chianti_reader,\n",
-    "                           cmfgen_reader,\n",
-    "                           levels_lines_param={\"lines_loggf_threshold\": -5})  # Example: Change cutoff to -5"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Setting lines_loggf_threshold to a lower value includes weaker transitions, while increasing it filters out more lines."
    ]
   },
   {

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -272,6 +272,40 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Controlling the log(g f) Cutoff in TARDISAtomData\n",
+    "\n",
+    "By default, Carsus applies a cutoff of **log(g f) = -3** when processing spectral lines.  \n",
+    "This means transitions with log(g f) < -3 are excluded from the atomic data file.\n",
+    "\n",
+    "If you want to change this threshold, modify the `\"lines_loggf_threshold\"` value inside `levels_lines_param`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "atom_data = TARDISAtomData(atomic_weights,\n",
+    "                           ionization_energies,\n",
+    "                           gfall_reader,\n",
+    "                           zeta_data,\n",
+    "                           chianti_reader,\n",
+    "                           cmfgen_reader,\n",
+    "                           levels_lines_param={\"lines_loggf_threshold\": -5})  # Example: Change cutoff to -5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Setting lines_loggf_threshold to a lower value includes weaker transitions, while increasing it filters out more lines."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Metadata\n",
     "\n",
     "Carsus stores metadata inside the HDF5 files to ensure reproducibility. This metadata includes a checksum for each stored table, version number or checksum of selected datasets, and versions of relevant packages. "


### PR DESCRIPTION
### Documentation Update

This PR updates the Quickstart guide to document the `log(g f)` cutoff used in Carsus.

- Default cutoff: `-3`
- Users can modify it via `"lines_loggf_threshold"` inside `levels_lines_param` in `TARDISAtomData`.
- Added an example demonstrating how to change the cutoff.
- Explained how modifying this value affects the included spectral lines.
- Fix: Corrected the broken "Notation in Carsus" link.

### :pushpin: Resources
- [Carsus Quickstart Guide](https://tardis-sn.github.io/carsus/quickstart.html)

### :vertical_traffic_light: Testing
- No testing required as this is a documentation change.

### :ballot_box_with_check: Checklist
- [x] I updated the documentation according to my changes.
- [ ] I built the documentation by applying the `build_docs` label.
- [x] I requested two reviewers for this pull request.


Closes #273.

