### PR TITLE
Improve Handling of J Values in CMFGEN Data #409

### DIFF
--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -847,6 +847,7 @@ class CMFGENReader:
         lns_list = []
         ioz_list = []
         pxs_list = []
+        j_values_list = []  # List to store J values
 
         for ion, reader in data.items():
             atomic_number = ion[0]
@@ -866,6 +867,12 @@ class CMFGENReader:
             lvl["ion_charge"] = ion_charge
             lvl_list.append(lvl)
 
+            # Store J values in a separate DataFrame
+            j_values = lvl[["ID", "g"]].copy()
+            j_values["j"] = (j_values["g"] - 1) / 2
+            j_values["atomic_number"] = atomic_number
+            j_values["ion_charge"] = ion_charge
+            j_values_list.append(j_values)
             lns = reader["lines"].copy()
             lns = lns.set_index(["i", "j"])
             lns["energy_lower"] = lvl_id["E(cm^-1)"].reindex(lns.index, level=0).values
@@ -960,6 +967,9 @@ class CMFGENReader:
         lines = lines[
             ["energy_lower", "energy_upper", "gf", "j_lower", "j_upper", "wavelength"]
         ]
+        j_values_df = pd.concat(j_values_list)
+        j_values_df = j_values_df.set_index(["atomic_number", "ion_charge", "ID"])
+        j_values_df = j_values_df["j"]
 
         if "ionization_energy" in reader.keys():
             ionization_energies = pd.DataFrame.from_records(ioz_list)
@@ -983,6 +993,7 @@ class CMFGENReader:
 
         self.levels = levels
         self.lines = lines
+        self.j_values = j_values_df  # Store J values in the class
 
         return
 


### PR DESCRIPTION
:pencil: Description

Type: :rocket: feature

This PR addresses issue [#409](https://github.com/tardis-sn/carsus/issues/409) by implementing a cleaner handling of J values in CMFGEN data. Previously, J values were dropped in cross_sections_squeeze, causing loss of information. Since storing J values in ion_levels is not feasible due to shape mismatch, this PR introduces a separate DataFrame for J values.

Changes made:

-Extracted J values from energy levels.

-Computed J values using the formula: .

-Stored J values in a new DataFrame indexed by atomic_number, ion_charge, and ID.

-Added self.j_values attribute to CMFGENReader to store J values.

-Ensured J values are properly structured and retrievable.

This update ensures that J values are preserved and can be used in future calculations, improving the overall data handling in Carsus.

Closes #409.

:pushpin: Resources

[CMFGEN Atomic Data](https://kookaburra.phyast.pitt.edu/hillier/web/CMFGEN.htm)

[Carsus Documentation](https://tardis-sn.github.io/carsus/)
### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [X] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
```
from carsus.io.cmfgen import CMFGENReader, CMFGENEnergyLevelsParser, CMFGENOscillatorStrengthsParser

levels_path = "al2_osc_split.dat"  
lines_path = "al2_osc_split.dat"    

al2_lvl_parser = CMFGENEnergyLevelsParser(levels_path)
al2_osc_parser = CMFGENOscillatorStrengthsParser(lines_path)

al2_lvl_data = {
    (13, 2): {
        "levels": al2_lvl_parser.base,  # Energy levels
        "lines": al2_osc_parser.base    # Spectral lines (oscillator strengths)
    }
}

reader = CMFGENReader(al2_lvl_data)

# Generate levels, lines, and J values
reader._get_levels_lines(al2_lvl_data, hyd_n_phixs_stop2start_energy_ratio=1.0, hyd_n_phixs_num_points=100)

# Access stored data
print(reader.j_values) 

```
### Output
![Screenshot 2025-03-01 at 10 14 18 PM](https://github.com/user-attachments/assets/b79dbd2a-82d0-4e6e-86f3-73e42af04eec)
