### PR TITLE
Updated Gitter link, which was broken 

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,4 +61,4 @@ Carsus is a package to manage atomic datasets. It can read data from a variety o
 
 
 .. seealso::
-    Need help? Contact us `on Gitter <https://gitter.im/tardis-sn/carsus/>`_.
+    Need help? Contact us on `Gitter <https://app.gitter.im/#/room/#tardis-sn_carsus:gitter.im>`_.


### PR DESCRIPTION
The Gitter link in index.rst was broken and not redirecting to the correct chat room. I have updated it to the correct URL.