### PR TITLE
Refactored os.path to pathlib in CARSUS (#388)

### DIFF
--- a/carsus/_astropy_init.py
+++ b/carsus/_astropy_init.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
-
+from pathlib import Path
 __all__ = ['__version__', 'test']
 
 try:
@@ -10,4 +10,4 @@ except ImportError:
 
 # Create the test function for self test
 from astropy.tests.runner import TestRunner
-test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
+test = TestRunner.make_test_runner_in(str(Path(__file__).parent))

--- a/carsus/_astropy_init.py
+++ b/carsus/_astropy_init.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import os
+
 from pathlib import Path
 __all__ = ['__version__', 'test']
 

--- a/carsus/data/basic_atomic_data.csv
+++ b/carsus/data/basic_atomic_data.csv
@@ -1,119 +1,119 @@
-atomic_number ,symbol ,name          ,group ,period
-            1 ,H      ,Hydrogen      ,1.0   ,     1
-            2 ,He     ,Helium        ,18.0  ,     1
-            3 ,Li     ,Lithium       ,1.0   ,     2
-            4 ,Be     ,Beryllium     ,2.0   ,     2
-            5 ,B      ,Boron         ,13.0  ,     2
-            6 ,C      ,Carbon        ,14.0  ,     2
-            7 ,N      ,Nitrogen      ,15.0  ,     2
-            8 ,O      ,Oxygen        ,16.0  ,     2
-            9 ,F      ,Fluorine      ,17.0  ,     2
-           10 ,Ne     ,Neon          ,18.0  ,     2
-           11 ,Na     ,Sodium        ,1.0   ,     3
-           12 ,Mg     ,Magnesium     ,2.0   ,     3
-           13 ,Al     ,Aluminium     ,13.0  ,     3
-           14 ,Si     ,Silicon       ,14.0  ,     3
-           15 ,P      ,Phosphorus    ,15.0  ,     3
-           16 ,S      ,Sulfur        ,16.0  ,     3
-           17 ,Cl     ,Chlorine      ,17.0  ,     3
-           18 ,Ar     ,Argon         ,18.0  ,     3
-           19 ,K      ,Potassium     ,1.0   ,     4
-           20 ,Ca     ,Calcium       ,2.0   ,     4
-           21 ,Sc     ,Scandium      ,3.0   ,     4
-           22 ,Ti     ,Titanium      ,4.0   ,     4
-           23 ,V      ,Vanadium      ,5.0   ,     4
-           24 ,Cr     ,Chromium      ,6.0   ,     4
-           25 ,Mn     ,Manganese     ,7.0   ,     4
-           26 ,Fe     ,Iron          ,8.0   ,     4
-           27 ,Co     ,Cobalt        ,9.0   ,     4
-           28 ,Ni     ,Nickel        ,10.0  ,     4
-           29 ,Cu     ,Copper        ,11.0  ,     4
-           30 ,Zn     ,Zinc          ,12.0  ,     4
-           31 ,Ga     ,Gallium       ,13.0  ,     4
-           32 ,Ge     ,Germanium     ,14.0  ,     4
-           33 ,As     ,Arsenic       ,15.0  ,     4
-           34 ,Se     ,Selenium      ,16.0  ,     4
-           35 ,Br     ,Bromine       ,17.0  ,     4
-           36 ,Kr     ,Krypton       ,18.0  ,     4
-           37 ,Rb     ,Rubidium      ,1.0   ,     5
-           38 ,Sr     ,Strontium     ,2.0   ,     5
-           39 ,Y      ,Yttrium       ,3.0   ,     5
-           40 ,Zr     ,Zirconium     ,4.0   ,     5
-           41 ,Nb     ,Niobium       ,5.0   ,     5
-           42 ,Mo     ,Molybdenum    ,6.0   ,     5
-           43 ,Tc     ,Technetium    ,7.0   ,     5
-           44 ,Ru     ,Ruthenium     ,8.0   ,     5
-           45 ,Rh     ,Rhodium       ,9.0   ,     5
-           46 ,Pd     ,Palladium     ,10.0  ,     5
-           47 ,Ag     ,Silver        ,11.0  ,     5
-           48 ,Cd     ,Cadmium       ,12.0  ,     5
-           49 ,In     ,Indium        ,13.0  ,     5
-           50 ,Sn     ,Tin           ,14.0  ,     5
-           51 ,Sb     ,Antimony      ,15.0  ,     5
-           52 ,Te     ,Tellurium     ,16.0  ,     5
-           53 ,I      ,Iodine        ,17.0  ,     5
-           54 ,Xe     ,Xenon         ,18.0  ,     5
-           55 ,Cs     ,Caesium       ,1.0   ,     6
-           56 ,Ba     ,Barium        ,2.0   ,     6
-           57 ,La     ,Lanthanum     ,-1.0  ,     6
-           58 ,Ce     ,Cerium        ,-1.0  ,     6
-           59 ,Pr     ,Praseodymium  ,-1.0  ,     6
-           60 ,Nd     ,Neodymium     ,-1.0  ,     6
-           61 ,Pm     ,Promethium    ,-1.0  ,     6
-           62 ,Sm     ,Samarium      ,-1.0  ,     6
-           63 ,Eu     ,Europium      ,-1.0  ,     6
-           64 ,Gd     ,Gadolinium    ,-1.0  ,     6
-           65 ,Tb     ,Terbium       ,-1.0  ,     6
-           66 ,Dy     ,Dysprosium    ,-1.0  ,     6
-           67 ,Ho     ,Holmium       ,-1.0  ,     6
-           68 ,Er     ,Erbium        ,-1.0  ,     6
-           69 ,Tm     ,Thulium       ,-1.0  ,     6
-           70 ,Yb     ,Ytterbium     ,-1.0  ,     6
-           71 ,Lu     ,Lutetium      ,3.0   ,     6
-           72 ,Hf     ,Hafnium       ,4.0   ,     6
-           73 ,Ta     ,Tantalum      ,5.0   ,     6
-           74 ,W      ,Tungsten      ,6.0   ,     6
-           75 ,Re     ,Rhenium       ,7.0   ,     6
-           76 ,Os     ,Osmium        ,8.0   ,     6
-           77 ,Ir     ,Iridium       ,9.0   ,     6
-           78 ,Pt     ,Platinum      ,10.0  ,     6
-           79 ,Au     ,Gold          ,11.0  ,     6
-           80 ,Hg     ,Mercury       ,12.0  ,     6
-           81 ,Tl     ,Thallium      ,13.0  ,     6
-           82 ,Pb     ,Lead          ,14.0  ,     6
-           83 ,Bi     ,Bismuth       ,15.0  ,     6
-           84 ,Po     ,Polonium      ,16.0  ,     6
-           85 ,At     ,Astatine      ,17.0  ,     6
-           86 ,Rn     ,Radon         ,18.0  ,     6
-           87 ,Fr     ,Francium      ,1.0   ,     7
-           88 ,Ra     ,Radium        ,2.0   ,     7
-           89 ,Ac     ,Actinium      ,-1.0  ,     7
-           90 ,Th     ,Thorium       ,-1.0  ,     7
-           91 ,Pa     ,Protactinium  ,-1.0  ,     7
-           92 ,U      ,Uranium       ,-1.0  ,     7
-           93 ,Np     ,Neptunium     ,-1.0  ,     7
-           94 ,Pu     ,Plutonium     ,-1.0  ,     7
-           95 ,Am     ,Americium     ,-1.0  ,     7
-           96 ,Cm     ,Curium        ,-1.0  ,     7
-           97 ,Bk     ,Berkelium     ,-1.0  ,     7
-           98 ,Cf     ,Californium   ,-1.0  ,     7
-           99 ,Es     ,Einsteinium   ,-1.0  ,     7
-          100 ,Fm     ,Fermium       ,-1.0  ,     7
-          101 ,Md     ,Mendelevium   ,-1.0  ,     7
-          102 ,No     ,Nobelium      ,-1.0  ,     7
-          103 ,Lr     ,Lawrencium    ,3.0   ,     7
-          104 ,Rf     ,Rutherfordium ,4.0   ,     7
-          105 ,Db     ,Dubnium       ,5.0   ,     7
-          106 ,Sg     ,Seaborgium    ,6.0   ,     7
-          107 ,Bh     ,Bohrium       ,7.0   ,     7
-          108 ,Hs     ,Hassium       ,8.0   ,     7
-          109 ,Mt     ,Meitnerium    ,9.0   ,     7
-          110 ,Ds     ,Darmstadtium  ,10.0  ,     7
-          111 ,Rg     ,Roentgenium   ,11.0  ,     7
-          112 ,Cn     ,Copernicium   ,12.0  ,     7
-          113 ,Uut    ,Ununtrium     ,13.0  ,     7
-          114 ,Fl     ,Flerovium     ,14.0  ,     7
-          115 ,Uup    ,Ununpentium   ,15.0  ,     7
-          116 ,Lv     ,Livermorium   ,16.0  ,     7
-          117 ,Uus    ,Ununseptium   ,17.0  ,     7
-          118 ,Uuo    ,Ununoctium    ,18.0  ,     7
+atomic_number,symbol,name,group,period
+1,H,Hydrogen,1.0,1
+2,He,Helium,18.0,1
+3,Li,Lithium,1.0,2
+4,Be,Beryllium,2.0,2
+5,B,Boron,13.0,2
+6,C,Carbon,14.0,2
+7,N,Nitrogen,15.0,2
+8,O,Oxygen,16.0,2
+9,F,Fluorine,17.0,2
+10,Ne,Neon,18.0,2
+11,Na,Sodium,1.0,3
+12,Mg,Magnesium,2.0,3
+13,Al,Aluminium,13.0,3
+14,Si,Silicon,14.0,3
+15,P,Phosphorus,15.0,3
+16,S,Sulfur,16.0,3
+17,Cl,Chlorine,17.0,3
+18,Ar,Argon,18.0,3
+19,K,Potassium,1.0,4
+20,Ca,Calcium,2.0,4
+21,Sc,Scandium,3.0,4
+22,Ti,Titanium,4.0,4
+23,V,Vanadium,5.0,4
+24,Cr,Chromium,6.0,4
+25,Mn,Manganese,7.0,4
+26,Fe,Iron,8.0,4
+27,Co,Cobalt,9.0,4
+28,Ni,Nickel,10.0,4
+29,Cu,Copper,11.0,4
+30,Zn,Zinc,12.0,4
+31,Ga,Gallium,13.0,4
+32,Ge,Germanium,14.0,4
+33,As,Arsenic,15.0,4
+34,Se,Selenium,16.0,4
+35,Br,Bromine,17.0,4
+36,Kr,Krypton,18.0,4
+37,Rb,Rubidium,1.0,5
+38,Sr,Strontium,2.0,5
+39,Y,Yttrium,3.0,5
+40,Zr,Zirconium,4.0,5
+41,Nb,Niobium,5.0,5
+42,Mo,Molybdenum,6.0,5
+43,Tc,Technetium,7.0,5
+44,Ru,Ruthenium,8.0,5
+45,Rh,Rhodium,9.0,5
+46,Pd,Palladium,10.0,5
+47,Ag,Silver,11.0,5
+48,Cd,Cadmium,12.0,5
+49,In,Indium,13.0,5
+50,Sn,Tin,14.0,5
+51,Sb,Antimony,15.0,5
+52,Te,Tellurium,16.0,5
+53,I,Iodine,17.0,5
+54,Xe,Xenon,18.0,5
+55,Cs,Caesium,1.0,6
+56,Ba,Barium,2.0,6
+57,La,Lanthanum,-1.0,6
+58,Ce,Cerium,-1.0,6
+59,Pr,Praseodymium,-1.0,6
+60,Nd,Neodymium,-1.0,6
+61,Pm,Promethium,-1.0,6
+62,Sm,Samarium,-1.0,6
+63,Eu,Europium,-1.0,6
+64,Gd,Gadolinium,-1.0,6
+65,Tb,Terbium,-1.0,6
+66,Dy,Dysprosium,-1.0,6
+67,Ho,Holmium,-1.0,6
+68,Er,Erbium,-1.0,6
+69,Tm,Thulium,-1.0,6
+70,Yb,Ytterbium,-1.0,6
+71,Lu,Lutetium,3.0,6
+72,Hf,Hafnium,4.0,6
+73,Ta,Tantalum,5.0,6
+74,W,Tungsten,6.0,6
+75,Re,Rhenium,7.0,6
+76,Os,Osmium,8.0,6
+77,Ir,Iridium,9.0,6
+78,Pt,Platinum,10.0,6
+79,Au,Gold,11.0,6
+80,Hg,Mercury,12.0,6
+81,Tl,Thallium,13.0,6
+82,Pb,Lead,14.0,6
+83,Bi,Bismuth,15.0,6
+84,Po,Polonium,16.0,6
+85,At,Astatine,17.0,6
+86,Rn,Radon,18.0,6
+87,Fr,Francium,1.0,7
+88,Ra,Radium,2.0,7
+89,Ac,Actinium,-1.0,7
+90,Th,Thorium,-1.0,7
+91,Pa,Protactinium,-1.0,7
+92,U,Uranium,-1.0,7
+93,Np,Neptunium,-1.0,7
+94,Pu,Plutonium,-1.0,7
+95,Am,Americium,-1.0,7
+96,Cm,Curium,-1.0,7
+97,Bk,Berkelium,-1.0,7
+98,Cf,Californium,-1.0,7
+99,Es,Einsteinium,-1.0,7
+100,Fm,Fermium,-1.0,7
+101,Md,Mendelevium,-1.0,7
+102,No,Nobelium,-1.0,7
+103,Lr,Lawrencium,3.0,7
+104,Rf,Rutherfordium,4.0,7
+105,Db,Dubnium,5.0,7
+106,Sg,Seaborgium,6.0,7
+107,Bh,Bohrium,7.0,7
+108,Hs,Hassium,8.0,7
+109,Mt,Meitnerium,9.0,7
+110,Ds,Darmstadtium,10.0,7
+111,Rg,Roentgenium,11.0,7
+112,Cn,Copernicium,12.0,7
+113,Uut,Ununtrium,13.0,7
+114,Fl,Flerovium,14.0,7
+115,Uup,Ununpentium,15.0,7
+116,Lv,Livermorium,16.0,7
+117,Uus,Ununseptium,17.0,7
+118,Uuo,Ununoctium,18.0,7

--- a/carsus/data/basic_atomic_data.csv
+++ b/carsus/data/basic_atomic_data.csv
@@ -1,119 +1,119 @@
-atomic_number,symbol,name,group,period
-1,H,Hydrogen,1.0,1
-2,He,Helium,18.0,1
-3,Li,Lithium,1.0,2
-4,Be,Beryllium,2.0,2
-5,B,Boron,13.0,2
-6,C,Carbon,14.0,2
-7,N,Nitrogen,15.0,2
-8,O,Oxygen,16.0,2
-9,F,Fluorine,17.0,2
-10,Ne,Neon,18.0,2
-11,Na,Sodium,1.0,3
-12,Mg,Magnesium,2.0,3
-13,Al,Aluminium,13.0,3
-14,Si,Silicon,14.0,3
-15,P,Phosphorus,15.0,3
-16,S,Sulfur,16.0,3
-17,Cl,Chlorine,17.0,3
-18,Ar,Argon,18.0,3
-19,K,Potassium,1.0,4
-20,Ca,Calcium,2.0,4
-21,Sc,Scandium,3.0,4
-22,Ti,Titanium,4.0,4
-23,V,Vanadium,5.0,4
-24,Cr,Chromium,6.0,4
-25,Mn,Manganese,7.0,4
-26,Fe,Iron,8.0,4
-27,Co,Cobalt,9.0,4
-28,Ni,Nickel,10.0,4
-29,Cu,Copper,11.0,4
-30,Zn,Zinc,12.0,4
-31,Ga,Gallium,13.0,4
-32,Ge,Germanium,14.0,4
-33,As,Arsenic,15.0,4
-34,Se,Selenium,16.0,4
-35,Br,Bromine,17.0,4
-36,Kr,Krypton,18.0,4
-37,Rb,Rubidium,1.0,5
-38,Sr,Strontium,2.0,5
-39,Y,Yttrium,3.0,5
-40,Zr,Zirconium,4.0,5
-41,Nb,Niobium,5.0,5
-42,Mo,Molybdenum,6.0,5
-43,Tc,Technetium,7.0,5
-44,Ru,Ruthenium,8.0,5
-45,Rh,Rhodium,9.0,5
-46,Pd,Palladium,10.0,5
-47,Ag,Silver,11.0,5
-48,Cd,Cadmium,12.0,5
-49,In,Indium,13.0,5
-50,Sn,Tin,14.0,5
-51,Sb,Antimony,15.0,5
-52,Te,Tellurium,16.0,5
-53,I,Iodine,17.0,5
-54,Xe,Xenon,18.0,5
-55,Cs,Caesium,1.0,6
-56,Ba,Barium,2.0,6
-57,La,Lanthanum,-1.0,6
-58,Ce,Cerium,-1.0,6
-59,Pr,Praseodymium,-1.0,6
-60,Nd,Neodymium,-1.0,6
-61,Pm,Promethium,-1.0,6
-62,Sm,Samarium,-1.0,6
-63,Eu,Europium,-1.0,6
-64,Gd,Gadolinium,-1.0,6
-65,Tb,Terbium,-1.0,6
-66,Dy,Dysprosium,-1.0,6
-67,Ho,Holmium,-1.0,6
-68,Er,Erbium,-1.0,6
-69,Tm,Thulium,-1.0,6
-70,Yb,Ytterbium,-1.0,6
-71,Lu,Lutetium,3.0,6
-72,Hf,Hafnium,4.0,6
-73,Ta,Tantalum,5.0,6
-74,W,Tungsten,6.0,6
-75,Re,Rhenium,7.0,6
-76,Os,Osmium,8.0,6
-77,Ir,Iridium,9.0,6
-78,Pt,Platinum,10.0,6
-79,Au,Gold,11.0,6
-80,Hg,Mercury,12.0,6
-81,Tl,Thallium,13.0,6
-82,Pb,Lead,14.0,6
-83,Bi,Bismuth,15.0,6
-84,Po,Polonium,16.0,6
-85,At,Astatine,17.0,6
-86,Rn,Radon,18.0,6
-87,Fr,Francium,1.0,7
-88,Ra,Radium,2.0,7
-89,Ac,Actinium,-1.0,7
-90,Th,Thorium,-1.0,7
-91,Pa,Protactinium,-1.0,7
-92,U,Uranium,-1.0,7
-93,Np,Neptunium,-1.0,7
-94,Pu,Plutonium,-1.0,7
-95,Am,Americium,-1.0,7
-96,Cm,Curium,-1.0,7
-97,Bk,Berkelium,-1.0,7
-98,Cf,Californium,-1.0,7
-99,Es,Einsteinium,-1.0,7
-100,Fm,Fermium,-1.0,7
-101,Md,Mendelevium,-1.0,7
-102,No,Nobelium,-1.0,7
-103,Lr,Lawrencium,3.0,7
-104,Rf,Rutherfordium,4.0,7
-105,Db,Dubnium,5.0,7
-106,Sg,Seaborgium,6.0,7
-107,Bh,Bohrium,7.0,7
-108,Hs,Hassium,8.0,7
-109,Mt,Meitnerium,9.0,7
-110,Ds,Darmstadtium,10.0,7
-111,Rg,Roentgenium,11.0,7
-112,Cn,Copernicium,12.0,7
-113,Uut,Ununtrium,13.0,7
-114,Fl,Flerovium,14.0,7
-115,Uup,Ununpentium,15.0,7
-116,Lv,Livermorium,16.0,7
-117,Uus,Ununseptium,17.0,7
-118,Uuo,Ununoctium,18.0,7
+atomic_number ,symbol ,name          ,group ,period
+            1 ,H      ,Hydrogen      ,1.0   ,     1
+            2 ,He     ,Helium        ,18.0  ,     1
+            3 ,Li     ,Lithium       ,1.0   ,     2
+            4 ,Be     ,Beryllium     ,2.0   ,     2
+            5 ,B      ,Boron         ,13.0  ,     2
+            6 ,C      ,Carbon        ,14.0  ,     2
+            7 ,N      ,Nitrogen      ,15.0  ,     2
+            8 ,O      ,Oxygen        ,16.0  ,     2
+            9 ,F      ,Fluorine      ,17.0  ,     2
+           10 ,Ne     ,Neon          ,18.0  ,     2
+           11 ,Na     ,Sodium        ,1.0   ,     3
+           12 ,Mg     ,Magnesium     ,2.0   ,     3
+           13 ,Al     ,Aluminium     ,13.0  ,     3
+           14 ,Si     ,Silicon       ,14.0  ,     3
+           15 ,P      ,Phosphorus    ,15.0  ,     3
+           16 ,S      ,Sulfur        ,16.0  ,     3
+           17 ,Cl     ,Chlorine      ,17.0  ,     3
+           18 ,Ar     ,Argon         ,18.0  ,     3
+           19 ,K      ,Potassium     ,1.0   ,     4
+           20 ,Ca     ,Calcium       ,2.0   ,     4
+           21 ,Sc     ,Scandium      ,3.0   ,     4
+           22 ,Ti     ,Titanium      ,4.0   ,     4
+           23 ,V      ,Vanadium      ,5.0   ,     4
+           24 ,Cr     ,Chromium      ,6.0   ,     4
+           25 ,Mn     ,Manganese     ,7.0   ,     4
+           26 ,Fe     ,Iron          ,8.0   ,     4
+           27 ,Co     ,Cobalt        ,9.0   ,     4
+           28 ,Ni     ,Nickel        ,10.0  ,     4
+           29 ,Cu     ,Copper        ,11.0  ,     4
+           30 ,Zn     ,Zinc          ,12.0  ,     4
+           31 ,Ga     ,Gallium       ,13.0  ,     4
+           32 ,Ge     ,Germanium     ,14.0  ,     4
+           33 ,As     ,Arsenic       ,15.0  ,     4
+           34 ,Se     ,Selenium      ,16.0  ,     4
+           35 ,Br     ,Bromine       ,17.0  ,     4
+           36 ,Kr     ,Krypton       ,18.0  ,     4
+           37 ,Rb     ,Rubidium      ,1.0   ,     5
+           38 ,Sr     ,Strontium     ,2.0   ,     5
+           39 ,Y      ,Yttrium       ,3.0   ,     5
+           40 ,Zr     ,Zirconium     ,4.0   ,     5
+           41 ,Nb     ,Niobium       ,5.0   ,     5
+           42 ,Mo     ,Molybdenum    ,6.0   ,     5
+           43 ,Tc     ,Technetium    ,7.0   ,     5
+           44 ,Ru     ,Ruthenium     ,8.0   ,     5
+           45 ,Rh     ,Rhodium       ,9.0   ,     5
+           46 ,Pd     ,Palladium     ,10.0  ,     5
+           47 ,Ag     ,Silver        ,11.0  ,     5
+           48 ,Cd     ,Cadmium       ,12.0  ,     5
+           49 ,In     ,Indium        ,13.0  ,     5
+           50 ,Sn     ,Tin           ,14.0  ,     5
+           51 ,Sb     ,Antimony      ,15.0  ,     5
+           52 ,Te     ,Tellurium     ,16.0  ,     5
+           53 ,I      ,Iodine        ,17.0  ,     5
+           54 ,Xe     ,Xenon         ,18.0  ,     5
+           55 ,Cs     ,Caesium       ,1.0   ,     6
+           56 ,Ba     ,Barium        ,2.0   ,     6
+           57 ,La     ,Lanthanum     ,-1.0  ,     6
+           58 ,Ce     ,Cerium        ,-1.0  ,     6
+           59 ,Pr     ,Praseodymium  ,-1.0  ,     6
+           60 ,Nd     ,Neodymium     ,-1.0  ,     6
+           61 ,Pm     ,Promethium    ,-1.0  ,     6
+           62 ,Sm     ,Samarium      ,-1.0  ,     6
+           63 ,Eu     ,Europium      ,-1.0  ,     6
+           64 ,Gd     ,Gadolinium    ,-1.0  ,     6
+           65 ,Tb     ,Terbium       ,-1.0  ,     6
+           66 ,Dy     ,Dysprosium    ,-1.0  ,     6
+           67 ,Ho     ,Holmium       ,-1.0  ,     6
+           68 ,Er     ,Erbium        ,-1.0  ,     6
+           69 ,Tm     ,Thulium       ,-1.0  ,     6
+           70 ,Yb     ,Ytterbium     ,-1.0  ,     6
+           71 ,Lu     ,Lutetium      ,3.0   ,     6
+           72 ,Hf     ,Hafnium       ,4.0   ,     6
+           73 ,Ta     ,Tantalum      ,5.0   ,     6
+           74 ,W      ,Tungsten      ,6.0   ,     6
+           75 ,Re     ,Rhenium       ,7.0   ,     6
+           76 ,Os     ,Osmium        ,8.0   ,     6
+           77 ,Ir     ,Iridium       ,9.0   ,     6
+           78 ,Pt     ,Platinum      ,10.0  ,     6
+           79 ,Au     ,Gold          ,11.0  ,     6
+           80 ,Hg     ,Mercury       ,12.0  ,     6
+           81 ,Tl     ,Thallium      ,13.0  ,     6
+           82 ,Pb     ,Lead          ,14.0  ,     6
+           83 ,Bi     ,Bismuth       ,15.0  ,     6
+           84 ,Po     ,Polonium      ,16.0  ,     6
+           85 ,At     ,Astatine      ,17.0  ,     6
+           86 ,Rn     ,Radon         ,18.0  ,     6
+           87 ,Fr     ,Francium      ,1.0   ,     7
+           88 ,Ra     ,Radium        ,2.0   ,     7
+           89 ,Ac     ,Actinium      ,-1.0  ,     7
+           90 ,Th     ,Thorium       ,-1.0  ,     7
+           91 ,Pa     ,Protactinium  ,-1.0  ,     7
+           92 ,U      ,Uranium       ,-1.0  ,     7
+           93 ,Np     ,Neptunium     ,-1.0  ,     7
+           94 ,Pu     ,Plutonium     ,-1.0  ,     7
+           95 ,Am     ,Americium     ,-1.0  ,     7
+           96 ,Cm     ,Curium        ,-1.0  ,     7
+           97 ,Bk     ,Berkelium     ,-1.0  ,     7
+           98 ,Cf     ,Californium   ,-1.0  ,     7
+           99 ,Es     ,Einsteinium   ,-1.0  ,     7
+          100 ,Fm     ,Fermium       ,-1.0  ,     7
+          101 ,Md     ,Mendelevium   ,-1.0  ,     7
+          102 ,No     ,Nobelium      ,-1.0  ,     7
+          103 ,Lr     ,Lawrencium    ,3.0   ,     7
+          104 ,Rf     ,Rutherfordium ,4.0   ,     7
+          105 ,Db     ,Dubnium       ,5.0   ,     7
+          106 ,Sg     ,Seaborgium    ,6.0   ,     7
+          107 ,Bh     ,Bohrium       ,7.0   ,     7
+          108 ,Hs     ,Hassium       ,8.0   ,     7
+          109 ,Mt     ,Meitnerium    ,9.0   ,     7
+          110 ,Ds     ,Darmstadtium  ,10.0  ,     7
+          111 ,Rg     ,Roentgenium   ,11.0  ,     7
+          112 ,Cn     ,Copernicium   ,12.0  ,     7
+          113 ,Uut    ,Ununtrium     ,13.0  ,     7
+          114 ,Fl     ,Flerovium     ,14.0  ,     7
+          115 ,Uup    ,Ununpentium   ,15.0  ,     7
+          116 ,Lv     ,Livermorium   ,16.0  ,     7
+          117 ,Uus    ,Ununseptium   ,17.0  ,     7
+          118 ,Uuo    ,Ununoctium    ,18.0  ,     7

--- a/carsus/io/atom_data_compare.py
+++ b/carsus/io/atom_data_compare.py
@@ -5,7 +5,6 @@ import logging
 from carsus.util import parse_selected_species, convert_atomic_number2symbol
 from collections import defaultdict
 
-from collections import defaultdict
 import matplotlib.pyplot as plt
 
 logger = logging.getLogger(__name__)
@@ -112,7 +111,7 @@ class AtomDataCompare(object):
         try:
             df1 = getattr(self, f"{key_name}1")
             df2 = getattr(self, f"{key_name}2")
-        except AttributeError as exc:
+        except AttributeError:
             raise Exception(
                 f"Either key_name: {key_name} is invalid or keys are not set. "
                 "Please use the set_keys_as_attributes method to set keys as attributes for comparison."
@@ -169,7 +168,7 @@ class AtomDataCompare(object):
         try:
             df1 = getattr(self, f"{key_name}1")
             df2 = getattr(self, f"{key_name}2")
-        except AttributeError as exc:
+        except AttributeError:
             raise Exception(
                 f"Either key_name: {key_name} is invalid or keys are not set."
                 "Please use the set_keys_as_attributes method to set keys as attributes for comparison."

--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import re
 import pickle
 import logging
@@ -22,7 +23,7 @@ except ImportError:
         Read the version number of the CHIANTI database
         """
         xuvtop = os.environ['XUVTOP']
-        vFileName = os.path.join(xuvtop, 'VERSION')
+        vFileName = Path(xuvtop) / 'VERSION'
         vFile = open(vFileName)
         versionStr = vFile.readline()
         vFile.close()
@@ -31,8 +32,8 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-masterlist_ions_path = os.path.join(
-    os.getenv('XUVTOP'), "masterlist", "masterlist_ions.pkl"
+masterlist_ions_path = Path(
+    (os.getenv('XUVTOP')) / "masterlist" / "masterlist_ions.pkl"
 )
 
 masterlist_ions_file = open(masterlist_ions_path, 'rb')

--- a/carsus/io/chianti_/chianti_.py
+++ b/carsus/io/chianti_/chianti_.py
@@ -32,9 +32,7 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-masterlist_ions_path = Path(
-    (os.getenv('XUVTOP')) / "masterlist" / "masterlist_ions.pkl"
-)
+masterlist_ions_path = Path(os.getenv('XUVTOP', "")) / "masterlist" / "masterlist_ions.pkl"
 
 masterlist_ions_file = open(masterlist_ions_path, 'rb')
 masterlist_ions = pickle.load(masterlist_ions_file).keys()

--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -30,6 +30,7 @@ class CMFGENEnergyLevelsParser(BaseParser):
     """
 
     def load(self, fname):
+        fname=str(fname)
         header = parse_header(fname)
         skiprows, _ = find_row(fname, "Number of transitions")
         nrows = int(header["Number of energy levels"])
@@ -102,6 +103,7 @@ class CMFGENOscillatorStrengthsParser(BaseParser):
     """
 
     def load(self, fname):
+        fname = str(fname)
         header = parse_header(fname)
         skiprows, _ = find_row(fname, "Transition", "Lam")
         skiprows += 1
@@ -175,6 +177,7 @@ class CMFGENCollisionalStrengthsParser(BaseParser):
     """
 
     def load(self, fname):
+        fname = str(fname)
         header = parse_header(fname)
         skiprows, _ = find_row(fname, r"ransition\T")
         config = {
@@ -296,6 +299,7 @@ class CMFGENPhoCrossSectionsParser(BaseParser):
     def load(self, fname):
 
         data = []
+        fname = str(fname)
         header = parse_header(fname)
         with open_cmfgen_file(fname) as f:
             while True:
@@ -350,6 +354,7 @@ class CMFGENHydLParser(BaseParser):
     nu_ratio_key = "L_DEL_U"
 
     def load(self, fname):
+        fname = str(fname)
         header = parse_header(fname)
         self.header = header
         self.max_l = self.get_max_l()
@@ -452,6 +457,7 @@ class CMFGENHydGauntBfParser(CMFGENHydLParser):
         return n, l, num_entries
 
     def load(self, fname):
+        fname = str(fname)
         super().load(fname)
         self.base.index = self.base.index.droplevel("l")
 

--- a/carsus/io/cmfgen/base.py
+++ b/carsus/io/cmfgen/base.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import roman
 import yaml
-from scipy import interpolate
 
 from carsus import __path__ as CARSUS_PATH
 from carsus.io.base import BaseParser
@@ -813,7 +812,7 @@ class CMFGENReader:
 
                     except NotImplementedError:
                         logger.warning(
-                            f"Leibowitz's cross-section type 4 not implemented yet."
+                            "Leibowitz's cross-section type 4 not implemented yet."
                         )
                         phixs_table = get_null_phixs_table(threshold_energy_ryd)
 

--- a/carsus/io/cmfgen/hdfgen.py
+++ b/carsus/io/cmfgen/hdfgen.py
@@ -55,5 +55,5 @@ def hdf_dump(cmfgen_dir, patterns, parser, chunk_size=10, ignore_patterns=[]):
         for obj in _:
             obj.to_hdf()
 
-    logger.info(f'Finished.')
+    logger.info('Finished.')
 

--- a/carsus/io/nist/ionization.py
+++ b/carsus/io/nist/ionization.py
@@ -4,7 +4,6 @@ http://physics.nist.gov/PhysRefData/ASD/ionEnergy.html
 """
 
 import logging
-import os
 from pathlib import Path
 from io import StringIO
 

--- a/carsus/io/nist/ionization.py
+++ b/carsus/io/nist/ionization.py
@@ -5,6 +5,7 @@ http://physics.nist.gov/PhysRefData/ASD/ionEnergy.html
 
 import logging
 import os
+from pathlib import Path
 from io import StringIO
 
 import numpy as np
@@ -89,9 +90,7 @@ def download_ionization_energies(
             response = requests.get(CARSUS_DATA_NIST_IONIZATION_URL, verify=False)
             return response.text
         else:
-            basic_atomic_data_fname = os.path.join(
-                carsus.__path__[0], "data", "basic_atomic_data.csv"
-            )
+            basic_atomic_data_fname = Path(carsus.__path__[0]) / "data" / "basic_atomic_data.csv"
             basic_atomic_data = pd.read_csv(basic_atomic_data_fname)
             atomic_number_mapping = dict(
                 zip(basic_atomic_data["symbol"], basic_atomic_data["atomic_number"])

--- a/carsus/io/nndc/base.py
+++ b/carsus/io/nndc/base.py
@@ -1,5 +1,6 @@
 import urllib.request, urllib.error, urllib.parse
 import os
+from pathlib import Path
 import re
 import logging
 from astropy import units as u
@@ -30,7 +31,7 @@ NNDC_ARTIFICIAL_DATASET_TAG = "NNDC_DATASET_SPLITTER"
 
 def _get_nuclear_database_path():
     if not TARDISNUCLEAR_DATA_DIR.exists():
-        os.mkdir(TARDISNUCLEAR_DATA_DIR)
+        TARDISNUCLEAR_DATA_DIR.mkdir(parents=True)
     return TARDISNUCLEAR_DATA_DIR / "decay_radiation.h5"
 
 

--- a/carsus/io/nndc/base.py
+++ b/carsus/io/nndc/base.py
@@ -1,6 +1,6 @@
-import urllib.request, urllib.error, urllib.parse
-import os
-from pathlib import Path
+import urllib.request
+import urllib.error
+import urllib.parse
 import re
 import logging
 from astropy import units as u
@@ -20,7 +20,6 @@ from nuclear.io.nndc.parsers import decay_radiation_parsers, uncertainty_parser
 TARDISNUCLEAR_DATA_DIR = pathlib.Path(get_data_dir())
 import datetime
 from pyne import nucname
-from uncertainties import ufloat_fromstr
 
 NNDC_DECAY_RADIATION_BASE_URL = (
     "http://www.nndc.bnl.gov/nudat3/" "decaysearchdirect.jsp?nuc={nucname}&unc=nds"

--- a/carsus/io/nndc/parsers.py
+++ b/carsus/io/nndc/parsers.py
@@ -1,7 +1,6 @@
 from abc import ABCMeta
 
 import pandas as pd
-from astropy import units as u
 from uncertainties import ufloat_fromstr
 import numpy as np
 

--- a/carsus/io/nuclear/nndc.py
+++ b/carsus/io/nuclear/nndc.py
@@ -41,7 +41,7 @@ class NNDCReader:
                     subprocess.run(['git', 'clone', NNDC_SOURCE_URL, DECAY_DATA_SOURCE_DIR], check=True)
                     logger.info(f"Downloading NNDC decay data from {NNDC_SOURCE_URL}")
                 except subprocess.CalledProcessError:
-                    logger.warning(f"Failed to clone the repository.\n"
+                    logger.warning("Failed to clone the repository.\n"
                                    "Check if the repository already exists at {DECAY_DATA_SOURCE_DIR}")
             self.dirname = DECAY_DATA_SOURCE_DIR / "csv"
         else:

--- a/carsus/io/output/base.py
+++ b/carsus/io/output/base.py
@@ -264,7 +264,7 @@ class TARDISAtomData:
 
             uuid1 = uuid.uuid1().hex
 
-            logger.info(f"Signing TARDISAtomData.")
+            logger.info("Signing TARDISAtomData.")
             logger.info(f"Format Version: {FORMAT_VERSION}")
             logger.info(f"MD5: {total_checksum.hexdigest()}")
             logger.info(f"UUID1: {uuid1}")

--- a/carsus/io/tests/test_barklem.py
+++ b/carsus/io/tests/test_barklem.py
@@ -1,6 +1,6 @@
 import pytest
 
-from numpy.testing import assert_almost_equal, assert_allclose
+from numpy.testing import assert_allclose
 from carsus.io.molecules.molecules import BarklemCollet2016Reader
 
 

--- a/carsus/io/tests/test_cmfgen.py
+++ b/carsus/io/tests/test_cmfgen.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import pytest
 import numpy as np
 import pandas as pd
@@ -14,7 +15,7 @@ from carsus.io.cmfgen import (
 
 from carsus.io.cmfgen.util import *
 
-data_dir = os.path.join(os.path.dirname(__file__), "data")
+data_dir = Path(__file__).parent / "data"
 
 
 @pytest.fixture()
@@ -33,7 +34,7 @@ def si1_reader():
 @pytest.fixture()
 def cmfgen_refdata_fname(refdata_path, path):
     subdirectory, fname = path
-    return os.path.join(refdata_path, "cmfgen", subdirectory, fname)
+    return Path(refdata_path) / "cmfgen" / subdirectory / fname
 
 
 @pytest.mark.with_refdata

--- a/carsus/io/tests/test_cmfgen.py
+++ b/carsus/io/tests/test_cmfgen.py
@@ -46,6 +46,7 @@ def cmfgen_refdata_fname(refdata_path, path):
     ],
 )
 def test_CMFGENEnergyLevelsParser(cmfgen_refdata_fname):
+    cmfgen_refdata_fname = str(cmfgen_refdata_fname)
     parser = CMFGENEnergyLevelsParser(cmfgen_refdata_fname)
     n = int(parser.header["Number of energy levels"])
     assert parser.base.shape[0] == n
@@ -63,6 +64,7 @@ def test_CMFGENEnergyLevelsParser(cmfgen_refdata_fname):
     ],
 )
 def test_CMFGENOscillatorStrengthsParser(cmfgen_refdata_fname):
+    cmfgen_refdata_fname = str(cmfgen_refdata_fname)
     parser = CMFGENOscillatorStrengthsParser(cmfgen_refdata_fname)
     n = int(parser.header["Number of transitions"])
     assert parser.base.shape[0] == n
@@ -79,6 +81,7 @@ def test_CMFGENOscillatorStrengthsParser(cmfgen_refdata_fname):
     ],
 )
 def test_CMFGENCollisionalStrengthsParser(cmfgen_refdata_fname):
+    cmfgen_refdata_fname = str(cmfgen_refdata_fname)
     parser = CMFGENCollisionalStrengthsParser(cmfgen_refdata_fname)
     return parser.base
 
@@ -93,6 +96,7 @@ def test_CMFGENCollisionalStrengthsParser(cmfgen_refdata_fname):
 )
 @pytest.mark.array_compare(file_format="pd_hdf")
 def test_CMFGENPhoCrossSectionsParser(cmfgen_refdata_fname):
+    cmfgen_refdata_fname = str(cmfgen_refdata_fname)
     parser = CMFGENPhoCrossSectionsParser(cmfgen_refdata_fname)
     n = int(parser.header["Number of energy levels"])
     assert len(parser.base) == n
@@ -108,6 +112,7 @@ def test_CMFGENPhoCrossSectionsParser(cmfgen_refdata_fname):
     ],
 )
 def test_CMFGENHydLParser(cmfgen_refdata_fname):
+    cmfgen_refdata_fname = str(cmfgen_refdata_fname)
     parser = CMFGENHydLParser(cmfgen_refdata_fname)
     assert parser.header["Maximum principal quantum number"] == "30"
     return parser.base
@@ -122,6 +127,7 @@ def test_CMFGENHydLParser(cmfgen_refdata_fname):
     ],
 )
 def test_CMFGENHydGauntBfParser(cmfgen_refdata_fname):
+    cmfgen_refdata_fname = str(cmfgen_refdata_fname)
     parser = CMFGENHydGauntBfParser(cmfgen_refdata_fname)
     assert parser.header["Maximum principal quantum number"] == "30"
     return parser.base

--- a/carsus/io/tests/test_cmfgen.py
+++ b/carsus/io/tests/test_cmfgen.py
@@ -1,4 +1,4 @@
-import os
+
 from pathlib import Path
 import pytest
 import numpy as np

--- a/carsus/io/util.py
+++ b/carsus/io/util.py
@@ -5,7 +5,6 @@ import pandas as pd
 import numpy as np
 from pyparsing import ParseResults
 from carsus.util import convert_atomic_number2symbol
-import requests
 from requests.adapters import HTTPAdapter, Retry
 
 def to_flat_dict(tokens, parent_key='', sep='_'):

--- a/carsus/io/vald/vald.py
+++ b/carsus/io/vald/vald.py
@@ -1,9 +1,9 @@
 import re
 import logging
 import pandas as pd
-import numpy as np
 from io import StringIO
 from carsus.io.util import read_from_buffer
+
 from carsus.util.helpers import (
     convert_wavelength_air2vacuum,
     ATOMIC_SYMBOLS_DATA,

--- a/carsus/util/helpers.py
+++ b/carsus/util/helpers.py
@@ -1,4 +1,4 @@
-import os
+
 from pathlib import Path
 import re
 import carsus

--- a/carsus/util/helpers.py
+++ b/carsus/util/helpers.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import re
 import carsus
 import numpy as np
@@ -7,9 +8,7 @@ from collections import OrderedDict
 
 
 def get_data_path(fname):
-    return os.path.join(
-        os.path.dirname(carsus.__file__), 'data', fname
-    )
+    return Path(carsus.__file__).parent / 'data' / fname
 
 ATOMIC_SYMBOLS_DATA = np.genfromtxt(get_data_path('basic_atomic_data.csv'), skip_header=1,
                                     delimiter=',', usecols=(0, 1), names=['atomic_number', 'symbol'], encoding='utf-8', dtype=None)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@
 # be accessible, and the documentation will not build correctly.
 
 import os
+from pathlib import Path
 import sys
 import datetime
 from importlib import import_module
@@ -40,7 +41,7 @@ except ImportError:
 from configparser import ConfigParser
 conf = ConfigParser()
 
-conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
+conf.read([str(Path(__file__).resolve().parent.parent / "setup.cfg")])
 setup_cfg = dict(conf.items('metadata'))
 
 # -- General configuration ----------------------------------------------------

--- a/docs/development/compare_atomic_files.ipynb
+++ b/docs/development/compare_atomic_files.ipynb
@@ -22,7 +22,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "import logging\n",
     "from carsus.io import AtomDataCompare"
    ]
   },

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 # NOTE: The configuration for the package, including the name, version, and
 # other information are set in the setup.cfg file.
 
-import os
+from pathlib import Path
 import sys
 
 from setuptools import setup
@@ -74,7 +74,7 @@ except Exception:
     version = '{version}'
 """.lstrip()
 
-setup(use_scm_version={'write_to': os.path.join('carsus', 'version.py'),
+setup(use_scm_version={'write_to': Path('carsus') / 'version.py',
                        'write_to_template': VERSION_TEMPLATE,
                        #'version_scheme': 'calver-by-date',
                     })


### PR DESCRIPTION
### :pencil: Description

**Type:** :| :rocket: `feature` | :biohazard: `breaking change` | :roller_coaster: `infrastructure`

This PR helps aims to migrate to pathlib instead of using os.path
like tardis.


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
