### PR TITLE
fixes NISTWeightsComp initialization error

### DIFF
--- a/carsus/io/nist/weightscomp.py
+++ b/carsus/io/nist/weightscomp.py
@@ -125,8 +125,8 @@ class NISTWeightsCompPyparser(BasePyparser):
 
     def _prepare_atomic_weights(self, atomic):
         grouped = atomic.groupby([AW_TYPE_COL])
-        interval_gr = grouped.get_group((INTERVAL,)).copy()
-        stable_mass_num_gr = grouped.get_group((STABLE_MASS_NUM,)).copy()
+        interval_gr = grouped.get_group(INTERVAL).copy()
+        stable_mass_num_gr = grouped.get_group(STABLE_MASS_NUM).copy()
 
         def atomic_weight_interval_to_nom_val_and_std(row):
             nom_val, std_dev = to_nom_val_and_std_dev(


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Whenever I try to create an object from NISTWeightsComp, I was getting the following error:

<img width="1055" alt="Screenshot 2025-03-13 at 7 35 26 PM" src="https://github.com/user-attachments/assets/8f043177-6e1e-43d7-9aca-f2b2cfbb4441" />

I fixed the error by passing a single argument in the get_group function instead of passing a tuple. 



> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
