### PR TITLE
fix lanlads energies

### DIFF
--- a/carsus/io/lanlads/base.py
+++ b/carsus/io/lanlads/base.py
@@ -1,41 +1,47 @@
 import pandas as pd
-import logging 
+import logging
 import numpy as np
 
-from carsus.io.lanlads.parsers import read_atomic_levels, read_atomic_lines, read_lanl_available_ions
+from carsus.io.lanlads.parsers import (
+    read_atomic_levels,
+    read_atomic_lines,
+    read_lanl_available_ions,
+)
 from carsus.util import parse_selected_atoms, parse_selected_species
 from carsus.util.helpers import SYMBOL2ATOMIC_NUMBER, ATOMIC_NUMBER2SYMBOL
 
 logger = logging.getLogger(__name__)
 
-class LANLADSReader:
 
+class LANLADSReader:
     lines_loggf_threshold = -3
     levels_metastable_loggf_threshold = -3
-            
-
 
     def __init__(self, lanl_data_dir, ions_symbols, priority=10):
         self.lanl_data_dir = lanl_data_dir
         self.requested_ions_tuple = set(parse_selected_species(ions_symbols))
         self.available_ions = read_lanl_available_ions(lanl_data_dir)
-        
+
         if not self.requested_ions_tuple.issubset(self.available_ions.keys()):
             missing_ions = self.requested_ions_tuple - self.available_ions_tuple
-            raise ValueError(f"Some requested ions are not available in the LANL data directory: {missing_ions}")
+            raise ValueError(
+                f"Some requested ions are not available in the LANL data directory: {missing_ions}"
+            )
 
         self.priority = priority
-        
+
         self.read_levels_lines()
-        
+
     def read_levels_lines(self):
-        logger.info(f"Reading levels and lines LANL data for ions: {self.requested_ions_tuple}")
-        
+        logger.info(
+            f"Reading levels and lines LANL data for ions: {self.requested_ions_tuple}"
+        )
+
         levels_list = []
         lines_list = []
         for ion in self.requested_ions_tuple:
             levels_fname, lines_fname = self.available_ions[ion]
-            
+
             levels_df = read_atomic_levels(levels_fname, ion[0], ion[1])
             lines_df = read_atomic_lines(lines_fname, ion[0], ion[1])
             lines_df = lines_df[np.log10(lines_df["gf"]) > self.lines_loggf_threshold]
@@ -46,4 +52,3 @@ class LANLADSReader:
         levels["priority"] = self.priority
         self.levels = levels
         self.lines = pd.concat(lines_list, sort=True)
-     

--- a/carsus/io/lanlads/parsers.py
+++ b/carsus/io/lanlads/parsers.py
@@ -9,16 +9,31 @@ import re
 
 logger = logging.getLogger(__name__)
 
+
 def read_atomic_levels(fname, atomic_number, ion_charge):
-    levels_df = pd.read_csv(fname, sep=r"\s+", skiprows=[0,1], usecols=[0, 4, 5], names=['level_index', 'j', 'energy'])    
+    levels_df = pd.read_csv(
+        fname,
+        sep=r"\s+",
+        skiprows=[0, 1],
+        usecols=[0, 4, 5],
+        names=["level_index", "j", "energy"],
+    )
     # Add atomic_number, ion_charge as new columns
-    levels_df['atomic_number'] = atomic_number
-    levels_df['ion_charge'] = ion_charge
-    # levels_df['energy'] = (levels_df['energy'].values * u.eV).to(u.erg).value  
-    levels_df['level_index'] = levels_df['level_index'] - 1
+    levels_df["atomic_number"] = atomic_number
+    levels_df["ion_charge"] = ion_charge
+    # Due to carsus/io/output/levels_lines.py line 166, assuming energies are in 1/cm, the short term fix is to convert to 1/cm
+    levels_df["energy"] = (
+        (levels_df["energy"].values * u.eV)
+        .to(1 / u.cm, equivalencies=u.spectral())
+        .value
+    )
+    levels_df["level_index"] = levels_df["level_index"] - 1
     # Set a multi-index using atomic_number, ion_charge, and level_index
-    levels_df = levels_df.set_index(['atomic_number', 'ion_charge', 'level_index'], append=False)
+    levels_df = levels_df.set_index(
+        ["atomic_number", "ion_charge", "level_index"], append=False
+    )
     return levels_df
+
 
 def read_atomic_lines(fname, atomic_number, ion_charge):
     """
@@ -27,14 +42,22 @@ def read_atomic_lines(fname, atomic_number, ion_charge):
     and returns a DataFrame with only the columns:
     wavelengths, gf
     """
-    lines_df = pd.read_csv(fname, sep=r"\s+", 
-                skiprows=[0,1], usecols=[0, 2, 9, 10], names=['wavelength', 'gf', 'level_index_lower', 'level_index_upper'])
-    lines_df['atomic_number'] = atomic_number
-    lines_df['ion_charge'] = ion_charge
+    lines_df = pd.read_csv(
+        fname,
+        sep=r"\s+",
+        skiprows=[0, 1],
+        usecols=[0, 2, 9, 10],
+        names=["wavelength", "gf", "level_index_lower", "level_index_upper"],
+    )
+    lines_df["atomic_number"] = atomic_number
+    lines_df["ion_charge"] = ion_charge
     # Set a multi-index using atomic_number, ion_charge, level_index_lower, and level_index_upper
-    lines_df['level_index_lower'] = lines_df['level_index_lower'] - 1
-    lines_df['level_index_upper'] = lines_df['level_index_upper'] - 1
-    return lines_df.set_index(['atomic_number', 'ion_charge', 'level_index_lower', 'level_index_upper'])
+    lines_df["level_index_lower"] = lines_df["level_index_lower"] - 1
+    lines_df["level_index_upper"] = lines_df["level_index_upper"] - 1
+    return lines_df.set_index(
+        ["atomic_number", "ion_charge", "level_index_lower", "level_index_upper"]
+    )
+
 
 def read_lanl_available_ions(lanl_data_dir):
     """
@@ -63,18 +86,26 @@ def read_lanl_available_ions(lanl_data_dir):
         atomic_name = element_dir.name
         atomic_number = SYMBOL2ATOMIC_NUMBER.get(atomic_name.capitalize(), None)
         if atomic_number is None:
-            warnings.warn(f"Element directory is not an element symbol {element_dir.name.capitalize()} - skipping")
+            warnings.warn(
+                f"Element directory is not an element symbol {element_dir.name.capitalize()} - skipping"
+            )
             continue
-        
-        for ion_levels_fname in list(element_dir.glob('levels_*')):
-            levels_fname_match = re.match(r'levels_\w+(\d+)_n\d+', ion_levels_fname.name)
+
+        for ion_levels_fname in list(element_dir.glob("levels_*")):
+            levels_fname_match = re.match(
+                r"levels_\w+(\d+)_n\d+", ion_levels_fname.name
+            )
             if levels_fname_match:
                 ion_charge = int(levels_fname_match.group(1)) - 1
             else:
-                warnings.warn(f"Levels file {ion_levels_fname} does not match the expected pattern - skipping")
+                warnings.warn(
+                    f"Levels file {ion_levels_fname} does not match the expected pattern - skipping"
+                )
                 continue
-            
-            ion_lines_fname = element_dir / ion_levels_fname.name.replace('levels', 'plotgfl')
+
+            ion_lines_fname = element_dir / ion_levels_fname.name.replace(
+                "levels", "plotgfl"
+            )
             if not ion_lines_fname.exists():
                 warnings.warn(f"Lines file {ion_lines_fname} does not exist - skipping")
                 continue


### PR DESCRIPTION
Carsus assumes energies are in cm^-1. This creates a short term fix to the lanlads reader by converting to eVs to that. 

Also might apply some black codestyle fixes since wolfgang didn't have those. 