### PR TITLE
replace refdata with regression data

### DIFF
--- a/.github/workflows/carsus-data-repos-config.yml
+++ b/.github/workflows/carsus-data-repos-config.yml
@@ -18,6 +18,12 @@ jobs:
         with:
           path: carsus/
 
+      - name: Setup regression data via LFS
+        uses: ./.github/actions/setup_lfs
+        with:
+            regression-data-repo: tardis-sn/carsus-regression-data
+            atom-data-sparse: false
+
       - name: Restore cache
         uses: actions/cache@v4
         with:
@@ -65,7 +71,7 @@ jobs:
         run: |
           jupyter nbconvert ${{ env.NBCONVERT_FLAGS }} carsus/docs/tardis_atomdata_ref.ipynb
         env:
-          CARSUS_REFDATA: ${{ github.workspace }}/carsus-refdata
+          CARSUS_REGRESSION_DATA: ${{ github.workspace }}/carsus-regression-data
         
       - name: Upload Atom Data
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ env:
   XUVTOP: /tmp/chianti
   CHIANTI_DL_URL: https://download.chiantidatabase.org
   CHIANTI_DB_VER: CHIANTI_10.0_database.tar.gz
-  PYTEST_FLAGS: --refdata=carsus-refdata --cov=carsus --cov-report=xml --cov-report=html  --carsus-regression-data=${{ github.workspace }}/carsus-regression-data
+  PYTEST_FLAGS: --cov=carsus --cov-report=xml --cov-report=html  --carsus-regression-data=${{ github.workspace }}/carsus-regression-data
   NBCONVERT_CMD: jupyter nbconvert --execute --ExecutePreprocessor.timeout=600 --to html
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   CMFGEN_DL_URL: http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files
@@ -60,13 +60,6 @@ jobs:
 
       - name: Setup LFS
         uses: ./.github/actions/setup_lfs
-
-      - name: Clone tardis-sn/carsus-refdata
-        uses: actions/checkout@v4
-        with:
-          repository: tardis-sn/carsus-refdata
-          path: carsus-refdata
-          lfs: true
 
       - uses: actions/cache@v4
         with:

--- a/carsus/conftest.py
+++ b/carsus/conftest.py
@@ -80,9 +80,6 @@ def pytest_addoption(parser):
         help="filename for the testing database",
     )
     parser.addoption(
-        "--refdata", dest="refdata", default=None, help="carsus-refdata folder location"
-    )
-    parser.addoption(
         "--carsus-regression-data",
         default=None,
         help="Path to the Carsus regression data directory",
@@ -96,12 +93,12 @@ def pytest_addoption(parser):
 
 
 def pytest_collection_modifyitems(config, items):
-    skip_not_with_refdata = pytest.mark.skip(
-        reason="carsus-refdata folder location not specified"
+    skip_no_regdata = pytest.mark.skip(
+        reason="--carsus-regression-data was not specified"
     )
     for item in items:
-        if "with_refdata" in item.keywords and not config.getoption("--refdata"):
-            item.add_marker(skip_not_with_refdata)
+        if "with_regression_data" in item.keywords and not config.getoption("--carsus-regression-data"):
+            item.add_marker(skip_no_regdata)
 
 
 @pytest.fixture(scope="session")
@@ -129,15 +126,6 @@ def vald_short_form_stellar_fname():
 @pytest.fixture(scope="session")
 def nndc_dirname():
     return str(DATA_DIR_PATH / "nndc")  # Mn-52, Ni-56
-
-
-@pytest.fixture(scope="session")
-def refdata_path(request):
-    refdata_path = request.config.getoption("--refdata")
-    if refdata_path is None:
-        pytest.skip("--refdata folder path was not specified")
-    else:
-        return str(Path(refdata_path).expanduser().resolve())
 
 @pytest.fixture(scope="session")
 def carsus_regression_path(request):

--- a/carsus/io/tests/test_cmfgen.py
+++ b/carsus/io/tests/test_cmfgen.py
@@ -31,21 +31,21 @@ def si1_reader():
 
 
 @pytest.fixture()
-def cmfgen_refdata_fname(refdata_path, path):
+def cmfgen_regression_data_fname(carsus_regression_path, path):
     subdirectory, fname = path
-    return Path(refdata_path) / "cmfgen" / subdirectory / fname
+    return Path(carsus_regression_path) / "cmfgen" / subdirectory / fname
 
 
-@pytest.mark.with_refdata
+@pytest.mark.with_regression_data
 @pytest.mark.parametrize(
     "path",
     [
         ["energy_levels", "si2_osc_kurucz"],
     ],
 )
-def test_CMFGENEnergyLevelsParser(cmfgen_refdata_fname, regression_data):
-    cmfgen_refdata_fname = str(cmfgen_refdata_fname)
-    parser = CMFGENEnergyLevelsParser(cmfgen_refdata_fname)
+def test_CMFGENEnergyLevelsParser(cmfgen_regression_data_fname, regression_data):
+    cmfgen_regression_data_fname = str(cmfgen_regression_data_fname)
+    parser = CMFGENEnergyLevelsParser(cmfgen_regression_data_fname)
     n = int(parser.header["Number of energy levels"])
     assert parser.base.shape[0] == n
     
@@ -53,7 +53,7 @@ def test_CMFGENEnergyLevelsParser(cmfgen_refdata_fname, regression_data):
     pd.testing.assert_frame_equal(parser.base, expected)
 
 
-@pytest.mark.with_refdata
+@pytest.mark.with_regression_data
 @pytest.mark.parametrize(
     "path",
     [
@@ -62,9 +62,9 @@ def test_CMFGENEnergyLevelsParser(cmfgen_refdata_fname, regression_data):
         ["oscillator_strengths", "vi_osc"],
     ],
 )
-def test_CMFGENOscillatorStrengthsParser(cmfgen_refdata_fname, regression_data):
-    cmfgen_refdata_fname = str(cmfgen_refdata_fname)
-    parser = CMFGENOscillatorStrengthsParser(cmfgen_refdata_fname)
+def test_CMFGENOscillatorStrengthsParser(cmfgen_regression_data_fname, regression_data):
+    cmfgen_regression_data_fname = str(cmfgen_regression_data_fname)
+    parser = CMFGENOscillatorStrengthsParser(cmfgen_regression_data_fname)
     n = int(parser.header["Number of transitions"])
     assert parser.base.shape[0] == n
     
@@ -72,7 +72,7 @@ def test_CMFGENOscillatorStrengthsParser(cmfgen_refdata_fname, regression_data):
     pd.testing.assert_frame_equal(parser.base, expected)
 
 
-@pytest.mark.with_refdata
+@pytest.mark.with_regression_data
 @pytest.mark.parametrize(
     "path",
     [
@@ -80,15 +80,15 @@ def test_CMFGENOscillatorStrengthsParser(cmfgen_refdata_fname, regression_data):
         ["collisional_strengths", "col_ariii"],
     ],
 )
-def test_CMFGENCollisionalStrengthsParser(cmfgen_refdata_fname, regression_data):
-    cmfgen_refdata_fname = str(cmfgen_refdata_fname)
-    parser = CMFGENCollisionalStrengthsParser(cmfgen_refdata_fname)
+def test_CMFGENCollisionalStrengthsParser(cmfgen_regression_data_fname, regression_data):
+    cmfgen_regression_data_fname = str(cmfgen_regression_data_fname)
+    parser = CMFGENCollisionalStrengthsParser(cmfgen_regression_data_fname)
     
     expected = regression_data.sync_dataframe(parser.base)
     pd.testing.assert_frame_equal(parser.base, expected)
 
 
-@pytest.mark.with_refdata
+@pytest.mark.with_regression_data
 @pytest.mark.parametrize(
     "path",
     [
@@ -96,9 +96,9 @@ def test_CMFGENCollisionalStrengthsParser(cmfgen_refdata_fname, regression_data)
         ["photoionization_cross_sections", "phot_data_gs"],
     ],
 )
-def test_CMFGENPhoCrossSectionsParser(cmfgen_refdata_fname, regression_data):
-    cmfgen_refdata_fname = str(cmfgen_refdata_fname)
-    parser = CMFGENPhoCrossSectionsParser(cmfgen_refdata_fname)
+def test_CMFGENPhoCrossSectionsParser(cmfgen_regression_data_fname, regression_data):
+    cmfgen_regression_data_fname = str(cmfgen_regression_data_fname)
+    parser = CMFGENPhoCrossSectionsParser(cmfgen_regression_data_fname)
     n = int(parser.header["Number of energy levels"])
     assert len(parser.base) == n
     
@@ -108,67 +108,67 @@ def test_CMFGENPhoCrossSectionsParser(cmfgen_refdata_fname, regression_data):
     pd.testing.assert_frame_equal(first_item, expected)
 
 
-@pytest.mark.with_refdata
+@pytest.mark.with_regression_data
 @pytest.mark.parametrize(
     "path",
     [
         ["photoionization_cross_sections", "hyd_l_data.dat"],
     ],
 )
-def test_CMFGENHydLParser(cmfgen_refdata_fname, regression_data):
-    cmfgen_refdata_fname = str(cmfgen_refdata_fname)
-    parser = CMFGENHydLParser(cmfgen_refdata_fname)
+def test_CMFGENHydLParser(cmfgen_regression_data_fname, regression_data):
+    cmfgen_regression_data_fname = str(cmfgen_regression_data_fname)
+    parser = CMFGENHydLParser(cmfgen_regression_data_fname)
     assert parser.header["Maximum principal quantum number"] == "30"
     
     expected = regression_data.sync_dataframe(parser.base)
     pd.testing.assert_frame_equal(parser.base, expected)
 
 
-@pytest.mark.with_refdata
+@pytest.mark.with_regression_data
 @pytest.mark.parametrize(
     "path",
     [
         ["photoionization_cross_sections", "gbf_n_data.dat"],
     ],
 )
-def test_CMFGENHydGauntBfParser(cmfgen_refdata_fname, regression_data):
-    cmfgen_refdata_fname = str(cmfgen_refdata_fname)
-    parser = CMFGENHydGauntBfParser(cmfgen_refdata_fname)
+def test_CMFGENHydGauntBfParser(cmfgen_regression_data_fname, regression_data):
+    cmfgen_regression_data_fname = str(cmfgen_regression_data_fname)
+    parser = CMFGENHydGauntBfParser(cmfgen_regression_data_fname)
     assert parser.header["Maximum principal quantum number"] == "30"
     
     expected = regression_data.sync_dataframe(parser.base)
     pd.testing.assert_frame_equal(parser.base, expected)
 
 
-@pytest.mark.with_refdata
+@pytest.mark.with_regression_data
 def test_reader_lines(si1_reader, regression_data):
     lines = si1_reader.lines
     expected = regression_data.sync_dataframe(lines)
     pd.testing.assert_frame_equal(lines, expected)
 
 
-@pytest.mark.with_refdata
+@pytest.mark.with_regression_data
 def test_reader_levels(si1_reader, regression_data):
     levels = si1_reader.levels
     expected = regression_data.sync_dataframe(levels)
     pd.testing.assert_frame_equal(levels, expected)
 
 
-@pytest.mark.with_refdata
+@pytest.mark.with_regression_data
 def test_reader_collisions(si1_reader, regression_data):
     collisions = si1_reader.collisions
     expected = regression_data.sync_dataframe(collisions)
     pd.testing.assert_frame_equal(collisions, expected)
 
 
-@pytest.mark.with_refdata
+@pytest.mark.with_regression_data
 def test_reader_cross_sections_squeeze(si1_reader, regression_data):
     cross_sections = si1_reader.cross_sections
     expected = regression_data.sync_dataframe(cross_sections)
     pd.testing.assert_frame_equal(cross_sections, expected)
 
 
-@pytest.mark.with_refdata
+@pytest.mark.with_regression_data
 def test_reader_ionization_energies(si1_reader, regression_data):
     ionization_energies = si1_reader.ionization_energies.to_frame()
     expected = regression_data.sync_dataframe(ionization_energies)

--- a/docs/development/testing.rst
+++ b/docs/development/testing.rst
@@ -17,10 +17,10 @@ Optional Flags
 
 A set of flags can be appended to the above command to run different kinds of tests:
 
-- `--refdata=/path/to/carsus-refdata`
-    Run tests marked with the ``@with_refdata`` decorator. Requires the
-    `tardis-sn/carsus-refdata <https://github.com/tardis-sn/carsus-refdata>`_ repository.
-  
+- `--carsus-regression-data=/path/to/carsus-regression-data`
+  Run tests marked with the ``@with_regression_data`` decorator.  
+  Requires the `tardis-sn/carsus-regression-data <https://github.com/tardis-sn/carsus-regression-data>`_ repository.
+
 - `--cov=carsus --cov-report=xml --cov-report=html`
     Get code coverage results using the `pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`_ plugin.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 markers =
-    with_refdata: mark tests as needing refdata path to run
+    with_regression_data: mark tests as needing regression data path to run


### PR DESCRIPTION
### :pencil: Description

**Type:** :vertical_traffic_light: `testing`

This PR aims at replacing ref data with regression data
https://github.com/tardis-sn/carsus-regression-data/pull/4

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
