### PR TITLE
Fix CMFGEN URL Issue

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -13,7 +13,6 @@ env:
   CHIANTI_DL_URL: https://download.chiantidatabase.org
   CHIANTI_DB_VER: CHIANTI_v9.0.1_database.tar.gz
   NBCONVERT_FLAGS: --execute --ExecutePreprocessor.timeout=600 --to html
-  CMFGEN_DL_URL: http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files
   CMFGEN_DB_VER: atomic_data_15nov16.tar.gz
   # original reference data
   REF1_PATH: ${{ github.workspace }}/tardis-refdata/unit_test_data_org.h5

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -54,11 +54,15 @@ jobs:
           key: ${{ env.CMFGEN_DB_VER }}
         id: cmfgen-cache
 
-      - name: Download CMFGEN database
-        run: |
-            wget -q -U "Mozilla/4.0" ${{ env.CMFGEN_DL_URL }}/${{ env.CMFGEN_DB_VER }} -O /tmp/atomic.tar.gz
-            tar -zxf /tmp/atomic.tar.gz -C /tmp
+      - name: Checkout CMFGEN data repository
+        uses: actions/checkout@v5
+        with:
+          repository: tardis-sn/carsus-data-cmfgen
+          path: cmfgen-data
         if: steps.cmfgen-cache.outputs.cache-hit != 'true'
+
+      - name: Extract CMFGEN database
+        run: tar -zxf cmfgen-data/${{ env.CMFGEN_DB_VER }} -C /tmp
 
       - uses: mamba-org/setup-micromamba@v2
         with:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -30,7 +30,6 @@ env:
   XUVTOP: /tmp/chianti
   CHIANTI_DL_URL: https://download.chiantidatabase.org
   CHIANTI_DB_VER: CHIANTI_10.0_database.tar.gz
-  CMFGEN_DL_URL: http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files
   CMFGEN_DB_VER: atomic_data_15nov16.tar.gz
   DEPLOY_BRANCH: gh-pages               # deployed docs branch
 

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -113,10 +113,15 @@ jobs:
           key: ${{ env.CMFGEN_DB_VER }}
         id: cmfgen-cache
 
-      - name: Download CMFGEN database
-        run: |
-            wget -q -U "Mozilla/4.0" ${{ env.CMFGEN_DL_URL }}/${{ env.CMFGEN_DB_VER }} -O /tmp/atomic.tar.gz
-            tar -zxf /tmp/atomic.tar.gz -C /tmp
+      - name: Checkout CMFGEN data repository
+        uses: actions/checkout@v5
+        with:
+          repository: tardis-sn/carsus-data-cmfgen
+          path: cmfgen-data
+        if: steps.cmfgen-cache.outputs.cache-hit != 'true'
+
+      - name: Extract CMFGEN database
+        run: tar -zxf cmfgen-data/${{ env.CMFGEN_DB_VER }} -C /tmp
         if: steps.cmfgen-cache.outputs.cache-hit != 'true'
 
       - uses: mamba-org/setup-micromamba@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,11 +84,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: tardis-sn/carsus-data-cmfgen
-          path: /tmp/cmfgen-data
+          path: cmfgen-data
         if: steps.cmfgen-cache.outputs.cache-hit != 'true'
 
       - name: Copy CMFGEN atomic data
-        run: cp -r /tmp/cmfgen-data/atomic /tmp/atomic
+        run: cp -r cmfgen-data/atomic /tmp/atomic
         if: steps.cmfgen-cache.outputs.cache-hit != 'true'
       
       - name: Download Lock File

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,6 @@ env:
   PYTEST_FLAGS: --cov=carsus --cov-report=xml --cov-report=html  --carsus-regression-data=${{ github.workspace }}/carsus-regression-data
   NBCONVERT_CMD: jupyter nbconvert --execute --ExecutePreprocessor.timeout=600 --to html
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  CMFGEN_DL_URL: http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files
   CMFGEN_DB_VER: atomic_data_15nov16.tar.gz
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,65 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Free Disk Space (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # other packages
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+      
+      - name: Free up disk space on macOS
+        if: matrix.os == 'macos-latest'
+        continue-on-error: True
+        run: |
+          echo "Initial disk usage:"
+          df -h
+          
+          # Remove unnecessary Xcode versions (if any)
+          if ls /Applications/Xcode_*.app 1> /dev/null 2>&1; then
+            echo "Removing old Xcode versions..."
+            sudo rm -rf /Applications/Xcode_*.app
+          else
+            echo "No additional Xcode versions found"
+          fi
+          
+          # Clean Homebrew cache
+          echo "Cleaning Homebrew cache..."
+          brew cleanup --prune=all || true
+          
+          # Remove iOS simulators (only if simctl is available)
+          if command -v xcrun simctl &> /dev/null; then
+            echo "Cleaning iOS simulators..."
+            xcrun simctl delete unavailable || true
+          else
+            echo "simctl not available, skipping iOS simulator cleanup"
+          fi
+          
+          # Clear system caches (be more selective)
+          echo "Clearing system caches..."
+          rm -rf ~/Library/Caches/* 2>/dev/null || true
+          
+          # Remove other large files
+          sudo rm -rf /usr/local/lib/android 2>/dev/null || true
+          sudo rm -rf /usr/local/share/dotnet 2>/dev/null || true
+          sudo rm -rf /usr/share/dotnet 2>/dev/null || true
+          sudo rm -rf /opt/ghc 2>/dev/null || true
+          sudo rm -rf "/usr/local/share/boost" 2>/dev/null || true
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY" 2>/dev/null || true
+          echo "Final disk usage:"
+          df -h
+        
+   
+
+
       - name: Setup LFS
         uses: ./.github/actions/setup_lfs
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,11 +79,16 @@ jobs:
           path: /tmp/atomic
           key: ${{ env.CMFGEN_DB_VER }}
         id: cmfgen-cache
-        
-      - name: Download CMFGEN database
-        run: |
-            wget -q -U "Mozilla/4.0" ${{ env.CMFGEN_DL_URL }}/${{ env.CMFGEN_DB_VER }} -O /tmp/atomic.tar.gz
-            tar -zxf /tmp/atomic.tar.gz -C /tmp
+
+      - name: Checkout CMFGEN data repository
+        uses: actions/checkout@v4
+        with:
+          repository: tardis-sn/carsus-data-cmfgen
+          path: /tmp/cmfgen-data
+        if: steps.cmfgen-cache.outputs.cache-hit != 'true'
+
+      - name: Copy CMFGEN atomic data
+        run: cp -r /tmp/cmfgen-data/atomic /tmp/atomic
         if: steps.cmfgen-cache.outputs.cache-hit != 'true'
       
       - name: Download Lock File

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,16 +34,16 @@ env:
   CMFGEN_DB_VER: atomic_data_15nov16.tar.gz
 
 jobs:
-  test-cache:
-    uses: ./.github/workflows/lfs-cache.yml
-    with:
-      atom-data-sparse: false
-      regression-data-repo: tardis-sn/carsus-regression-data
-      allow_lfs_pull: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'git-lfs-pull') }}
+  # test-cache:
+  #   uses: ./.github/workflows/lfs-cache.yml
+  #   with:
+  #     atom-data-sparse: false
+  #     regression-data-repo: tardis-sn/carsus-regression-data
+  #     allow_lfs_pull: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'git-lfs-pull') }}
 
   build:
     if: github.repository_owner == 'tardis-sn'
-    needs: [test-cache]
+    # needs: [test-cache]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.label }}
     strategy:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,7 +13,7 @@ Prerequisites
 
         export XUVTOP=/path/to/chianti/root
 
-#. *(optional)*. Download and extract the `CMFGEN Atomic Data <http://kookaburra.phyast.pitt.edu/hillier/web/CMFGEN.htm>`_.  
+#. *(optional)*. Download and extract the `CMFGEN Atomic Data <https://sites.pitt.edu/~hillier/web/CMFGEN.htm>`_.  
 
 ====================
 Clone the Repository

--- a/docs/io/cmfgen.ipynb
+++ b/docs/io/cmfgen.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "**Note:**\n",
     "    \n",
-    "In this example, the data was downloaded from the [CMFGEN website](http://kookaburra.phyast.pitt.edu/hillier/web/CMFGEN.htm) and extracted to the `/tmp/atomic` folder.\n",
+    "In this example, the data was downloaded from the [CMFGEN website](https://sites.pitt.edu/~hillier/web/CMFGEN.htm) and extracted to the `/tmp/atomic` folder.\n",
     "    \n",
     "</div>\n",
     "\n"

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -130,7 +130,7 @@
    "source": [
     "### CMFGEN\n",
     "\n",
-    "The atomic database of [CMFGEN](http://kookaburra.phyast.pitt.edu/hillier/web/CMFGEN.htm) is a source of levels, lines and (optionally) **ionization energies**, **photoionization cross-sections** and **collisions**.\n",
+    "The atomic database of [CMFGEN](https://sites.pitt.edu/~hillier/web/CMFGEN.htm) is a source of levels, lines and (optionally) **ionization energies**, **photoionization cross-sections** and **collisions**.\n",
     "\n",
     "<div class=\"alert alert-info\">\n",
     "    \n",


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

CMFGEN Url http://kookaburra.phyast.pitt.edu/hillier/cmfgen_files doesn't work anymore. This PR replaces that with the new one. https://sites.pitt.edu/~hillier/web/CMFGEN.htm 

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [X] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
