### PR TITLE
[GSoC] Seaton 1992 continuum opacity reader for Carsus

### DIFF
--- a/carsus/io/seaton/__init__.py
+++ b/carsus/io/seaton/__init__.py
@@ -1,0 +1,1 @@
+from carsus.io.seaton.seaton import Seaton1992Reader

--- a/carsus/io/seaton/__init__.py
+++ b/carsus/io/seaton/__init__.py
@@ -1,1 +1,2 @@
 from carsus.io.seaton.seaton import Seaton1992Reader
+__all__ = ["Seaton1992Reader"]

--- a/carsus/io/seaton/seaton.py
+++ b/carsus/io/seaton/seaton.py
@@ -61,8 +61,9 @@ class Seaton1992Reader(object):
         except Exception as e:
             logger.error(
                 f"Failed to read data from {self.fpath}: {e}\n"
-                f"Try passing a local file path explicitly: "
-                f"Seaton1992Reader(fpath='path/to/s92.201.gz')"
+                f"Try passing a local file path explicitly:\n"
+                f"Seaton1992Reader("
+                f"fpath='path/to/s92.201.gz')"
             )
             raise
 
@@ -76,7 +77,8 @@ class Seaton1992Reader(object):
             abundances_df["abundance"], errors="coerce"
         )
         abundances_df = abundances_df.dropna()
-        abundances_df["atomic_number"] = abundances_df["atomic_number"].astype(int)
+        col = abundances_df["atomic_number"]
+        abundances_df["atomic_number"] = col.astype(int)
         abundances_df = abundances_df.reset_index(drop=True)
 
         # --- Section 2: Opacity grid (rows 20 onwards) ---

--- a/carsus/io/seaton/seaton.py
+++ b/carsus/io/seaton/seaton.py
@@ -1,0 +1,125 @@
+import pandas as pd
+import logging
+
+logger = logging.getLogger(__name__)
+
+SEATON_1992_URL = "https://cdsarc.cds.unistra.fr/ftp/VI/80/s92.201.gz"
+
+
+class Seaton1992Reader(object):
+    """
+    Reader for the Seaton 1992 continuum opacity data (Opacity Project).
+
+    Reads the s92.201.gz file from the CDS archive and parses it
+    into two pandas DataFrames:
+    - abundances: element abundances used in opacity calculations
+    - opacities: frequency-temperature opacity grid
+
+    Parameters
+    ----------
+    fpath : str, optional
+        Path or URL to the s92.201.gz file.
+        Defaults to the CDS archive URL.
+
+    Attributes
+    ----------
+    abundances : DataFrame
+        DataFrame with columns: atomic_number, abundance.
+    opacities : DataFrame
+        DataFrame with columns: log_frequency, log_temperature, opacity.
+
+    Notes
+    -----
+    If the CDS archive is unavailable, you can pass a local file path:
+        reader = Seaton1992Reader(fpath="path/to/s92.201.gz")
+    """
+
+    def __init__(self, fpath=None):
+        self.fpath = SEATON_1992_URL if fpath is None else fpath
+        self._abundances = None
+        self._opacities = None
+
+    def read_raw(self):
+        """
+        Downloads and reads the raw Seaton 1992 data file.
+
+        Returns
+        -------
+        tuple
+            (abundances_df, opacities_df)
+        """
+        logger.info(f"Reading Seaton 1992 opacity data from: {self.fpath}")
+
+        try:
+            df = pd.read_csv(
+                self.fpath,
+                compression="gzip",
+                sep=r"\s+",
+                header=None,
+                on_bad_lines="skip",
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to read data from {self.fpath}: {e}\n"
+                f"Try passing a local file path explicitly: "
+                f"Seaton1992Reader(fpath='path/to/s92.201.gz')"
+            )
+            raise
+
+        # --- Section 1: Abundances (rows 2 to 18) ---
+        abundances_df = df.iloc[2:19][[0, 1]].copy()
+        abundances_df.columns = ["atomic_number", "abundance"]
+        abundances_df["atomic_number"] = pd.to_numeric(
+            abundances_df["atomic_number"], errors="coerce"
+        )
+        abundances_df["abundance"] = pd.to_numeric(
+            abundances_df["abundance"], errors="coerce"
+        )
+        abundances_df = abundances_df.dropna()
+        abundances_df["atomic_number"] = abundances_df["atomic_number"].astype(int)
+        abundances_df = abundances_df.reset_index(drop=True)
+
+        # --- Section 2: Opacity grid (rows 20 onwards) ---
+        opacity_rows = []
+        for _, row in df.iloc[20:].iterrows():
+            col0 = pd.to_numeric(row[0], errors="coerce")
+            col1 = pd.to_numeric(row[1], errors="coerce")
+            col2 = pd.to_numeric(row[2], errors="coerce")
+
+            if pd.isna(col0) or pd.isna(col1) or pd.isna(col2):
+                continue
+
+            # Skip block header rows (large integers like 140, 142)
+            if col0 > 100 and col2 > 50:
+                continue
+
+            opacity_rows.append({
+                "log_frequency": col0,
+                "log_temperature": col1,
+                "opacity": col2
+            })
+
+        opacities_df = pd.DataFrame(opacity_rows)
+        opacities_df = opacities_df.reset_index(drop=True)
+
+        return abundances_df, opacities_df
+
+    @property
+    def abundances(self):
+        """
+        Returns the element abundances DataFrame.
+        Loads data on first access.
+        """
+        if self._abundances is None:
+            self._abundances, self._opacities = self.read_raw()
+        return self._abundances
+
+    @property
+    def opacities(self):
+        """
+        Returns the opacity grid DataFrame.
+        Loads data on first access.
+        """
+        if self._opacities is None:
+            self._abundances, self._opacities = self.read_raw()
+        return self._opacities

--- a/carsus/io/seaton/tests/test_seaton.py
+++ b/carsus/io/seaton/tests/test_seaton.py
@@ -1,0 +1,44 @@
+import pytest
+from carsus.io.seaton.seaton import Seaton1992Reader
+
+LOCAL_FILE = r"D:\Study\Hackhathons\GSOC\s92.201.gz"
+
+
+@pytest.fixture(scope="module")
+def reader():
+    return Seaton1992Reader(fpath=LOCAL_FILE)
+
+
+def test_abundances_shape(reader):
+    assert reader.abundances.shape == (17, 2)
+
+
+def test_abundances_columns(reader):
+    assert list(reader.abundances.columns) == ["atomic_number", "abundance"]
+
+
+def test_abundances_dtypes(reader):
+    assert reader.abundances["atomic_number"].dtype == int
+    assert reader.abundances["abundance"].dtype == float
+
+
+def test_opacities_shape(reader):
+    assert reader.opacities.shape == (1748, 3)
+
+
+def test_opacities_columns(reader):
+    assert list(reader.opacities.columns) == [
+        "log_frequency", "log_temperature", "opacity"
+    ]
+
+
+def test_caching(reader):
+    first = reader.abundances
+    second = reader.abundances
+    assert first is second
+
+
+def test_invalid_path():
+    reader = Seaton1992Reader(fpath="invalid/path.gz")
+    with pytest.raises(Exception):
+        _ = reader.abundances


### PR DESCRIPTION
### :pencil: Description
**Type:** 🚀 `feature`

Adds a `Seaton1992Reader` class to Carsus for GSoC 2026 Project #3 — Continuum Opacity Source Reader.

The Seaton 1992 dataset (VI/80) contains continuum opacity data calculated by Michael Seaton. Previously there was no programmatic way to access this data in Carsus. This PR adds a reader that downloads the data directly from the CDS archive and returns it as clean pandas DataFrames — making it immediately usable in TARDIS simulations.

**What the reader returns:**
- `abundances` — 17 elements with atomic number and abundance values
- `opacities` — 1748 rows of log frequency, log temperature, and opacity values

**Design decisions:**
- Lazy loading with caching — file is downloaded only on first access, cached for subsequent calls
- Default URL built in — user needs zero configuration to get started
- Custom file path supported — works with any similar Seaton format file
- Clear error message if download fails — guides user to pass a local file path

**Files added:**
- `carsus/io/seaton/seaton.py`
- `carsus/io/seaton/__init__.py`
- `carsus/io/seaton/tests/test_seaton.py`

### :pushpin: Resources
- CDS Archive VI/80: https://cdsarc.cds.unistra.fr/ftp/VI/80/

### :vertical_traffic_light: Testing
- [ ] Testing pipeline
- [x] Other method — 7 pytest tests passed, 0 warnings. Covers shape, columns, dtypes, caching, and invalid path handling.
- [ ] My changes can't be tested

### :ballot_box_with_check: Checklist
- [x] I requested two reviewers for this pull request (@AndreasFlörs @AndrewFullard @jvshields)
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** Requesting a contributor to add the `build_docs` label as I don't have permission.

**AI Disclosure:**
Tool used: Claude AI
How used: Assisted in understanding the Seaton 1992 file format, designing the class structure, implementing error handling, and improving docstrings.
Confirmation: I confirm that I have read the PR Checklist and the AI and LLM Usage Policy. I fully understand all AI-assisted changes and can explain every modification in this PR.